### PR TITLE
Memory watchpoints (:bpr / :bpw / :bprw)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
 # chippy
 
-A TUI 6502 emulator with built-in debugger, written in Go.
+A TUI 6502 emulator and debugger, written in Go.
 
 `chippy` emulates the NMOS 6502 CPU and presents a terminal UI built with
 [Bubble Tea](https://github.com/charmbracelet/bubbletea) for inspecting
 registers, flags, the stack, live disassembly, and memory while you single-step
 or free-run a program.
+
+It speaks the ca65/cc65 toolchain natively: load a `.bin`, `.prg`, `.hex`, or
+even an unlinked `.o` (chippy will run `ld65` for you), and any sibling
+`.dbg` symbol file is auto-detected so the disassembly shows real names and
+breakpoints can resolve to source lines.
+
+---
 
 ## Install
 
@@ -13,84 +20,191 @@ or free-run a program.
 go install github.com/nkane/chippy/cmd/chippy@latest
 ```
 
-Or build from this repo:
+Or build from a checkout:
 
 ```sh
+git clone git@github.com:nkane/chippy.git
+cd chippy
 go build ./cmd/chippy
+go test ./...
 ```
 
-## Usage
+Optional: install [cc65](https://cc65.github.io/) to assemble your own
+programs.
 
-Run the built-in demo program:
+---
+
+## Quick start
 
 ```sh
+# Built-in dummy program (no flags)
 ./chippy
+
+# Load a raw binary at $8000 (the default load address)
+./chippy -rom program.bin
+
+# Load and let chippy invoke ld65 for you
+./chippy -rom program.o -cfg linker.cfg
+
+# Try the bundled example
+cd example
+make                              # produces load_five.bin + load_five.dbg
+../chippy -rom load_five.bin
 ```
 
-### Loading programs
+Once it's running, press `?` for an in-app help modal, or `:` to open the
+command line.
 
-`chippy` auto-detects format by file extension:
+---
 
-| Extension | Format                                                |
-|-----------|-------------------------------------------------------|
-| `.bin`    | Raw bytes — placed at `-addr` (default `$8000`)       |
-| `.prg`    | Commodore-style: first 2 bytes = LE load address      |
-| `.hex`    | Intel HEX (record types `00` data, `01` EOF)          |
-| `.o`      | ca65/cc65 object — linked via `ld65` (requires `-cfg`)|
+## Loading programs
+
+`chippy` auto-detects format by extension:
+
+| Extension | Format                                                        |
+|-----------|---------------------------------------------------------------|
+| `.bin`    | Raw bytes — placed at `-addr` (default `$8000`)               |
+| `.prg`    | Commodore-style: first 2 bytes = LE load address              |
+| `.hex`    | Intel HEX (record types `00` data, `01` EOF)                  |
+| `.o`      | ca65/cc65 object — linked via `ld65` (requires `-cfg`)        |
+
+Flags:
+
+| Flag     | Default | Meaning                                                |
+|----------|---------|--------------------------------------------------------|
+| `-rom`   | —       | Path to program (`.bin`, `.prg`, `.hex`, `.o`)         |
+| `-addr`  | `32768` | Load address for raw `.bin` (ignored for other types)  |
+| `-cfg`   | —       | ld65 linker config (required for `.o`)                 |
+| `-dbg`   | auto    | cc65 `.dbg` symbol file; `<rom>.dbg` is tried by default |
+| `-reset` | `0`     | Override reset vector. `0` keeps the existing `$FFFC/D` bytes (or falls back to the load address if those are zero) |
+
+Examples:
 
 ```sh
 ./chippy -rom program.bin -addr 0x8000 -reset 0x8000
-./chippy -rom program.prg                  # load addr from header
-./chippy -rom program.hex                  # load addr from records
-./chippy -rom program.o -cfg nes.cfg       # ld65 invoked for you
+./chippy -rom program.prg                   # load addr from header
+./chippy -rom program.hex                   # load addr from records
+./chippy -rom program.o -cfg nes.cfg        # ld65 invoked for you
+./chippy -rom program.bin -dbg /tmp/x.dbg   # explicit debug file
 ```
 
-If `-reset` is omitted, chippy uses the bytes already at `$FFFC/$FFFD`,
-falling back to the file's load address if those bytes are zero.
+---
 
-### ca65 / cc65 workflow
+## ca65 / cc65 workflow
 
-The recommended path is to assemble + link yourself, then load the `.bin`.
-chippy will auto-load a sibling `.dbg` for symbols:
+Recommended path — assemble + link yourself, then load the `.bin`. The
+sibling `.dbg` is picked up automatically:
 
 ```sh
 ca65 -g prog.s -o prog.o
 ld65 -C linker.cfg -o prog.bin --dbgfile prog.dbg prog.o
-./chippy -rom prog.bin                     # picks up prog.dbg automatically
+./chippy -rom prog.bin
 ```
 
-You can also point chippy directly at the `.o` and let it run `ld65`:
+Or hand chippy the `.o` and let it run `ld65`:
 
 ```sh
 ./chippy -rom prog.o -cfg linker.cfg
 ```
 
 In this mode the `.dbg` is generated in a temp directory and loaded
-automatically. Pass `-dbg path/to/file.dbg` to override symbol-file detection.
+automatically.
 
-When symbols are loaded, the disassembly shows names instead of raw addresses
-(`JSR init` rather than `JSR $8042`) and labels are printed inline above their
-target instruction.
+When symbols are loaded:
+
+- Disassembly shows names instead of raw addresses (`JSR init` rather than
+  `JSR $8042`)
+- Labels are printed inline above their target instruction
+- `:bp main`, `:goto main`, `:watch score` etc. accept symbol names
+- Source-line breakpoints (`:bp main.s:42`) work — see below
+- Source view (`v`) shows your `.s` file with the current line highlighted
+
+---
 
 ## Keybinds
 
-| Key       | Action                                |
-|-----------|---------------------------------------|
-| `s`       | Single-step one instruction           |
-| `r`       | Toggle run / pause                    |
-| `R`       | Hard reset CPU                        |
-| `b`       | Toggle breakpoint at current `PC`     |
-| `B`       | Open breakpoint manager (`e` enable, `d` delete) |
-| `[` `]`   | Scroll disassembly by 1 / `'` follows PC |
-| `j` / `k` | Scroll memory view by `$10`           |
-| `J` / `K` | Scroll memory view by `$100`          |
-| `:`       | Command line                          |
-| `?`       | Help modal                            |
-| `q`       | Quit                                  |
+### Execution
 
-## Breakpoints
+| Key   | Action                                            |
+|-------|---------------------------------------------------|
+| `s`   | Single-step one instruction                       |
+| `S`   | Step 16 instructions (stops on bp / mem watch)    |
+| `n`   | Step over (skips JSR by setting one-shot bp at return) |
+| `f`   | Run to next source line (uses `.dbg` info)        |
+| `r`   | Toggle run / pause                                |
+| `R`   | Hard reset CPU                                    |
+| `+` `=` | Increase target speed                           |
+| `-` `_` | Decrease target speed                           |
+| `0`   | Speed: max (no throttle)                          |
 
-Sigils in the disasm/source gutter mirror nvim-DAP:
+### Breakpoints
+
+| Key   | Action                                            |
+|-------|---------------------------------------------------|
+| `b`   | Toggle plain breakpoint at current `PC`           |
+| `B`   | Open breakpoint manager modal                     |
+
+In the BP manager modal: `j/k` move cursor, `e` toggle enable, `d` (or `x`,
+`Delete`) delete, `enter` jump PC to bp, `esc/q/B` close.
+
+### Views
+
+| Key       | Action                                       |
+|-----------|----------------------------------------------|
+| `v`       | Toggle source view ↔ disassembly view        |
+| `[` `]`   | Scroll disasm by 1                           |
+| `{` `}`   | Scroll disasm by 8                           |
+| `'`       | Re-anchor disasm to follow PC                |
+| `j` `k`   | Scroll memory view by `$10` (also `↓`/`↑`)   |
+| `J` `K`   | Scroll memory view by `$100` (also `PgDn`/`PgUp`) |
+| `g` `G`   | Memory view to `$0000` / `$FF00`             |
+
+### Other
+
+| Key   | Action                                            |
+|-------|---------------------------------------------------|
+| `:`   | Open command line                                 |
+| `?`   | Help modal (`q` to dismiss)                       |
+| `q`   | Quit (saves state)                                |
+
+---
+
+## Commands
+
+Type `:` to open the command line, then any of:
+
+### Navigation
+
+| Command                     | Effect                                       |
+|-----------------------------|----------------------------------------------|
+| `:goto $XXXX` / `:g $XXXX`  | Jump memory view to address (or symbol)      |
+| `:pc $XXXX`                 | Force `PC` to address                        |
+| `:run $XXXX`                | Set one-shot bp at address and start running |
+| `:speed N`                  | Throttle to N Hz (`0` = unthrottled)         |
+
+### Breakpoints
+
+`:bp` accepts an address, symbol, or `file.s:line` source location, plus
+optional modifiers:
+
+| Form                                | Effect                                  |
+|-------------------------------------|-----------------------------------------|
+| `:bp $8042`                         | Toggle plain bp at address              |
+| `:bp main`                          | Toggle bp at symbol `main`              |
+| `:bp main.s:14`                     | Toggle bp at source line (needs `.dbg`) |
+| `:bp $8042 once`                    | One-shot bp (deletes itself on hit)     |
+| `:bp loop hits 5`                   | Break on the 5th hit                    |
+| `:bp main if A==$FF`                | Conditional (🔶) — see expression syntax |
+| `:bp $8000 log A={A} PC={PC}`       | Log point (📜) — prints, never pauses   |
+
+Modifiers can be combined: `:bp main.s:42 if A==$FF hits 3 log A={A} X={X}`.
+
+If a `file.s:line` reference can't be resolved (missing `.dbg`, file not in
+debug info, no instruction emitted on that line), the bp is created in the
+**rejected** state (💩) so you see it in the BP manager rather than just a
+status flash.
+
+#### Sigils (gutter glyphs)
 
 | Sigil | Meaning                                |
 |-------|----------------------------------------|
@@ -100,66 +214,167 @@ Sigils in the disasm/source gutter mirror nvim-DAP:
 | 💩    | Rejected (unresolved source line)      |
 | 👉    | Current `PC`                           |
 
-`:bp` accepts an address, symbol, or `file.s:42` source location, plus
-optional modifiers:
-
-```
-:bp main                       toggle plain bp at symbol `main`
-:bp $8042 once                 one-shot, deletes itself on hit
-:bp loop hits 5                only break on the 5th hit
-:bp main if A==$FF             conditional (cond uses A,X,Y,P,SP,PC, flags
-                               N V Z C, hex literals, [$XXXX] memory deref)
-:bp $8000 log A={A} PC={PC}    log point — prints and continues
-```
-
-State (breakpoints, watches, mem-view position, throttle) is persisted to
-`~/.chippy/state-<rom>.json` and restored on next launch.
-
-## Memory watchpoints
+### Memory watchpoints
 
 Trigger when the CPU reads or writes a tracked address. Same modifier
-syntax as `:bp`.
+syntax as `:bp` (`once`, `hits N`, `if EXPR`, `log MSG`).
 
-```
-:bpr  $0200                    break on any read of $0200
-:bpw  ram_flag                 break on write to symbol `ram_flag`
-:bprw $FFFC                    break on either
-:bpw  $0200 if A==$FF          conditional
-:bpw  score log score={[$0200]} PC={PC}    log point — never pauses
-:rmbpr $0200  /  :rmbpw  /  :rmbprw
-```
+| Command                                      | Effect                              |
+|----------------------------------------------|-------------------------------------|
+| `:bpr $0200`                                 | Break on any **read** of $0200      |
+| `:bpw ram_flag`                              | Break on **write** to symbol        |
+| `:bprw $FFFC`                                | Break on **either** read or write   |
+| `:bpw $0200 if A==$FF`                       | Conditional                         |
+| `:bpw score log score={[$0200]} PC={PC}`     | Log point — never pauses            |
+| `:rmbpr $0200` / `:rmbpw …` / `:rmbprw …`    | Remove                              |
 
 Watched bytes are colored in the memory hex view:
 
-| Color  | Meaning           |
-|--------|-------------------|
-| Blue   | 👁  read watch    |
-| Red    | ✏  write watch    |
-| Magenta| 🔁 read + write   |
+| Color   | Meaning           |
+|---------|-------------------|
+| Blue    | 👁 read watch     |
+| Red     | ✏ write watch     |
+| Magenta | 🔁 read + write   |
+
+### Watches
+
+The watch panel shows live values of registers and memory cells.
+
+| Command                                  | Effect                              |
+|------------------------------------------|-------------------------------------|
+| `:watch $0200`                           | Watch byte at $0200                 |
+| `:watch $0200 word`                      | Watch 16-bit LE word                |
+| `:watch score`                           | Watch by symbol                     |
+| `:watch $0200 byte player x`             | Watch with custom label             |
+| `:watch reg A`                           | Watch CPU register                  |
+| `:watch reg A accumulator`               | Register watch with label           |
+| `:rmwatch $0200` / `:rmwatch reg A`      | Remove a single watch               |
+| `:clearwatch`                            | Remove all watches                  |
+
+Aliases: `:w` for `:watch`, `:unwatch` for `:rmwatch`.
+
+### Misc
+
+| Command         | Effect                                |
+|-----------------|---------------------------------------|
+| `:help` / `:?`  | Open help modal                       |
+| `:q` / `:quit`  | (Hint to use `q` outside the prompt)  |
+
+---
+
+## Expression syntax (conditions and log templates)
+
+Used by `:bp ... if EXPR` and `:bpw ... if EXPR` for conditions, and inside
+`{...}` substitutions in `log MSG` templates.
+
+### Operands
+
+- **Registers:** `A`, `X`, `Y`, `P`, `SP` (`S` is an alias), `PC`
+- **Flags:** `N`, `V`, `B`, `D`, `I`, `Z`, `C` — evaluate to `0` or `1`
+- **Numeric literals:** `$FF` / `0xFF` / `255` / `0b1010`
+- **Symbols:** any name in the loaded `.dbg` (resolves to its address)
+- **Memory deref:** `[$XXXX]` — the byte at that address (works with symbols
+  too: `[score]`)
+
+### Operators
+
+`==` `!=` `<` `<=` `>` `>=` `&&` `||` `!` `+` `-` `*` `/` `%` `&` `|` `^` `<<` `>>` `( )`
+
+### Examples
+
+```
+A == $FF
+X > 0 && Y < 10
+[score] >= $64
+P & $80 != 0
+(A + X) == $42
+```
+
+### Log point template
+
+`{EXPR}` substitutes the value of EXPR (formatted as `$XX` for bytes, `$XXXX`
+for words). Anything else is literal text.
+
+```
+:bp main log entered main, A={A} X={X} PC={PC}
+:bpw score log score={[score]} cycle={cycles}
+```
+
+`{cycles}` is recognized as a special token that prints the CPU cycle count.
+
+---
+
+## Persistence
+
+Per-ROM state is saved to `~/.chippy/state-<basename>.json` and reloaded on
+next launch. Persisted:
+
+- Plain + rich breakpoints (with conditions, hit limits, log messages,
+  source tags)
+- Memory watchpoints
+- Memory view position
+- Watch panel entries
+- Throttle speed
+- Disasm scroll anchor
+
+Conditions are recompiled at load time; if a previously-good condition
+becomes invalid (e.g. you removed the symbol it referenced), the bp loads
+with `condFn` nil and effectively becomes a plain bp.
+
+---
 
 ## Layout
 
 ```
-┌ Registers ──┐ ┌ Disassembly ─────────────┐
-│ A:00 X:00 Y │ │ > $8000  LDA #$00         │
-│ SP:FD PC:80 │ │   $8002  TAX              │
-└─────────────┘ │   ...                     │
-┌ Flags ──────┐ └───────────────────────────┘
-│ n v U b d I │ ┌ Memory ───────────────────┐
-└─────────────┘ │ $0000: 00 00 ... ........ │
-┌ Stack ──────┐ └───────────────────────────┘
-│ $01FE: 00   │
-└─────────────┘
+┌ Registers ──┐ ┌ Disassembly ────────────────┐
+│ A:00 X:00 Y │ │ > $8000  LDA #$00           │
+│ SP:FD PC:80 │ │   $8002  TAX                │
+└─────────────┘ │   ...                       │
+┌ Flags ──────┐ └─────────────────────────────┘
+│ n v U b d I │ ┌ Memory ─────────────────────┐
+└─────────────┘ │ $0000: 00 00 ... ........   │
+┌ Stack ──────┐ └─────────────────────────────┘
+│ $01FE: 00   │ ┌ Watches ────────────────────┐
+└─────────────┘ │ score  $0200  $00           │
+                └─────────────────────────────┘
+status: ready
 ```
+
+The disassembly panel is replaced by a source view when you press `v` (if
+a `.dbg` is loaded). A breakpoint manager modal opens with `B`; the help
+modal opens with `?`.
+
+---
 
 ## Status
 
-Implements all official NMOS 6502 opcodes. Decimal mode arithmetic adjustments
-are not yet applied (flag is tracked but `ADC`/`SBC` operate in binary mode).
-Unofficial / illegal opcodes currently behave as 1-byte NOPs.
+Implements all official NMOS 6502 opcodes. Known gaps tracked as GitHub
+issues:
+
+- [#1](https://github.com/nkane/chippy/issues/1) — Decimal mode (BCD) for `ADC`/`SBC` (flag tracked, math is binary)
+- [#2](https://github.com/nkane/chippy/issues/2) — Unofficial / illegal opcodes (currently 1-byte NOPs)
+
+---
 
 ## Tests
 
 ```sh
 go test ./...
+```
+
+The TUI package has headless tests for the memory watchpoint data plane
+(`internal/tui/membp_test.go`) that exercise `WBus` + `processMemHits`
+without the bubble-tea runtime.
+
+---
+
+## Project layout
+
+```
+cmd/chippy/         CLI entrypoint, flag parsing, loader/wiring
+internal/cpu/       6502 core: CPU, RAM, opcodes, disassembler
+internal/loader/    .bin/.prg/.hex/.o loaders
+internal/symbols/   cc65 .dbg parser, symbol + source-line tables
+internal/tui/       Bubble Tea model, panels, modals, commands
+example/            Bundled load_five demo (ca65 source + Makefile)
 ```

--- a/README.md
+++ b/README.md
@@ -115,6 +115,28 @@ optional modifiers:
 State (breakpoints, watches, mem-view position, throttle) is persisted to
 `~/.chippy/state-<rom>.json` and restored on next launch.
 
+## Memory watchpoints
+
+Trigger when the CPU reads or writes a tracked address. Same modifier
+syntax as `:bp`.
+
+```
+:bpr  $0200                    break on any read of $0200
+:bpw  ram_flag                 break on write to symbol `ram_flag`
+:bprw $FFFC                    break on either
+:bpw  $0200 if A==$FF          conditional
+:bpw  score log score={[$0200]} PC={PC}    log point — never pauses
+:rmbpr $0200  /  :rmbpw  /  :rmbprw
+```
+
+Watched bytes are colored in the memory hex view:
+
+| Color  | Meaning           |
+|--------|-------------------|
+| Blue   | 👁  read watch    |
+| Red    | ✏  write watch    |
+| Magenta| 🔁 read + write   |
+
 ## Layout
 
 ```

--- a/cmd/chippy/main.go
+++ b/cmd/chippy/main.go
@@ -96,7 +96,14 @@ func main() {
 
 	c := cpu.New(ram)
 
-	model := tui.New(c, ram)
+	// Wrap the bus with WBus so memory watchpoints can intercept reads/writes.
+	// We construct CPU on raw RAM first (to keep cpu.New's signature simple),
+	// then swap c.Bus to the wrapper. WithWBus attaches the CPU pointer and
+	// hands the watch map to the wrapper.
+	wbus := tui.NewWBus(ram)
+	c.Bus = wbus
+
+	model := tui.New(c, ram).WithWBus(wbus)
 	if syms != nil {
 		model = model.WithSymbols(syms)
 	}

--- a/internal/tui/membp.go
+++ b/internal/tui/membp.go
@@ -1,0 +1,224 @@
+// Package tui — memory access watchpoint type and helpers.
+//
+// Mirrors the rich exec Breakpoint (see bp.go): enable, hit count, condition,
+// log point. Tracks reads, writes, or both at a single address.
+package tui
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/nkane/chippy/internal/cpu"
+)
+
+// MemBPKind is one of "r", "w", "rw".
+type MemBPKind string
+
+const (
+	MemBPRead      MemBPKind = "r"
+	MemBPWrite     MemBPKind = "w"
+	MemBPReadWrite MemBPKind = "rw"
+)
+
+// MemBP describes a memory access watchpoint.
+type MemBP struct {
+	Addr     uint16    `json:"addr"`
+	Kind     MemBPKind `json:"kind"`
+	Enabled  bool      `json:"enabled"`
+	Hits     int       `json:"hits,omitempty"`
+	HitLimit int       `json:"hitLimit,omitempty"` // 0 unlimited; >0 Nth; -1 one-shot
+	Cond     string    `json:"cond,omitempty"`
+	Log      string    `json:"log,omitempty"`
+
+	// Compiled condition. Not persisted.
+	condFn func(*cpu.CPU, cpu.Bus) bool `json:"-"`
+}
+
+// newMemBP returns a plain enabled watchpoint.
+func newMemBP(addr uint16, kind MemBPKind) *MemBP {
+	return &MemBP{Addr: addr, Kind: kind, Enabled: true}
+}
+
+// matches returns true if this watchpoint cares about the given access kind
+// ("r" or "w"). RW watches accept either.
+func (b *MemBP) matches(access MemBPKind) bool {
+	if b == nil || !b.Enabled {
+		return false
+	}
+	if b.Kind == MemBPReadWrite {
+		return true
+	}
+	return b.Kind == access
+}
+
+// marker returns the gutter glyph for this watchpoint kind.
+//
+//	👁 read   ✏ write   🔁 read+write
+func (b *MemBP) marker() string {
+	if b == nil {
+		return "  "
+	}
+	switch b.Kind {
+	case MemBPRead:
+		return "\U0001F441" // 👁
+	case MemBPWrite:
+		return "\u270F\uFE0F" // ✏
+	case MemBPReadWrite:
+		return "\U0001F501" // 🔁
+	}
+	return "??"
+}
+
+// kindLabel returns a short text label ("R", "W", "RW") for modal display.
+func (b *MemBP) kindLabel() string {
+	switch b.Kind {
+	case MemBPRead:
+		return "R"
+	case MemBPWrite:
+		return "W"
+	case MemBPReadWrite:
+		return "RW"
+	}
+	return "?"
+}
+
+// describe formats one line for the BP manager modal.
+func (b *MemBP) describe() string {
+	out := fmt.Sprintf("%s $%04X [%s]", b.marker(), b.Addr, b.kindLabel())
+	if !b.Enabled {
+		out += "  [disabled]"
+	}
+	if b.HitLimit > 0 {
+		out += fmt.Sprintf("  [%d/%d]", b.Hits, b.HitLimit)
+	} else if b.HitLimit == -1 {
+		out += "  [once]"
+	} else if b.Hits > 0 {
+		out += fmt.Sprintf("  [%d hits]", b.Hits)
+	}
+	if b.Cond != "" {
+		out += "  if " + b.Cond
+	}
+	if b.Log != "" {
+		out += "  log " + b.Log
+	}
+	return out
+}
+
+// cmdMemBP handles `:bpr`, `:bpw`, `:bprw`. Same modifier syntax as :bp:
+//
+//	:bpw $0200                       toggle write watch at $0200
+//	:bpw $0200 once                  one-shot
+//	:bpw $0200 hits 5                fire on 5th write
+//	:bpw $0200 if A==$FF             conditional
+//	:bpr $FFFC log read PC={PC}      log point on read
+func (m *Model) cmdMemBP(args []string, kind MemBPKind) string {
+	if len(args) == 0 {
+		return fmt.Sprintf("usage: :bp%s ADDR [once|hits N|if EXPR|log MSG]", string(kind))
+	}
+	addr, err := m.parseAddrSym(args[0])
+	if err != nil {
+		return err.Error()
+	}
+	rest := args[1:]
+
+	// No modifiers -> toggle.
+	if len(rest) == 0 {
+		if existing, ok := m.MemBPs[addr]; ok && existing.Kind == kind {
+			delete(m.MemBPs, addr)
+			m.saveState()
+			return fmt.Sprintf("mem bp -%s$%04X", string(kind), addr)
+		}
+		bp := newMemBP(addr, kind)
+		m.MemBPs[addr] = bp
+		m.saveState()
+		return fmt.Sprintf("%s mem bp +%s$%04X", bp.marker(), string(kind), addr)
+	}
+
+	// With modifiers -> always (re)create.
+	bp := newMemBP(addr, kind)
+	if errStr := parseMemBPModifiers(bp, rest); errStr != "" {
+		return errStr
+	}
+	if bp.Cond != "" {
+		fn, cerr := compileCondition(bp.Cond, m.Syms)
+		if cerr != nil {
+			return "bad cond: " + cerr.Error()
+		}
+		bp.condFn = fn
+	}
+	m.MemBPs[addr] = bp
+	m.saveState()
+	return fmt.Sprintf("%s mem bp +%s$%04X", bp.marker(), string(kind), addr)
+}
+
+// parseMemBPModifiers mirrors parseBPModifiers but writes to a MemBP.
+func parseMemBPModifiers(bp *MemBP, args []string) string {
+	for i := 0; i < len(args); i++ {
+		switch strings.ToLower(args[i]) {
+		case "once":
+			bp.HitLimit = -1
+		case "hits":
+			if i+1 >= len(args) {
+				return "usage: ... hits N"
+			}
+			n, err := strconv.Atoi(args[i+1])
+			if err != nil || n <= 0 {
+				return fmt.Sprintf("bad hit count: %s", args[i+1])
+			}
+			bp.HitLimit = n
+			i++
+		case "if":
+			bp.Cond = strings.Join(args[i+1:], " ")
+			return ""
+		case "log":
+			bp.Log = strings.Join(args[i+1:], " ")
+			return ""
+		default:
+			return fmt.Sprintf("unknown modifier: %s", args[i])
+		}
+	}
+	return ""
+}
+
+// processMemHits drains pending memory hits from the WBus and applies
+// each watch's condition / hit-count / log-point logic. Returns (pause,
+// status). If pause is true, caller should stop the run loop. status is a
+// log-point message to display (last one wins).
+//
+// One-shot watches (HitLimit == -1) are deleted from m.MemBPs after firing.
+func (m *Model) processMemHits() (bool, string) {
+	if m.WBus == nil {
+		return false, ""
+	}
+	hits := m.WBus.Drain()
+	if len(hits) == 0 {
+		return false, ""
+	}
+	pause := false
+	var status string
+	for _, h := range hits {
+		bp := m.MemBPs[h.Addr]
+		if bp == nil || !bp.matches(h.Kind) {
+			continue
+		}
+		if bp.condFn != nil && !bp.condFn(m.CPU, m.WBus.Inner) {
+			continue
+		}
+		bp.Hits++
+		if bp.HitLimit > 0 && bp.Hits < bp.HitLimit {
+			continue
+		}
+		if bp.Log != "" {
+			status = formatLog(bp.Log, m.CPU, m.WBus.Inner)
+			continue
+		}
+		if bp.HitLimit == -1 {
+			delete(m.MemBPs, h.Addr)
+		}
+		pause = true
+		status = fmt.Sprintf("hit %s $%04X (%s=$%02X) PC=$%04X",
+			bp.kindLabel(), h.Addr, h.Kind, h.Value, h.PC)
+	}
+	return pause, status
+}

--- a/internal/tui/membp_test.go
+++ b/internal/tui/membp_test.go
@@ -1,0 +1,308 @@
+// Headless smoke test for memory watchpoints.
+//
+// Wraps RAM in a WBus, runs hand-crafted 6502 programs, and asserts the
+// processMemHits behaviour for each watchpoint variant: plain, read-only,
+// write-only, hit-count, one-shot, conditional, and log point.
+//
+// No TUI runtime is exercised — only the data plane (WBus.Read/Write,
+// ring buffer, Model.processMemHits). StatePath is left empty so
+// saveState() is a no-op.
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nkane/chippy/internal/cpu"
+)
+
+// progStaThenLda assembles `LDA #$05; STA $0210; LDA $0210; BRK` at $0200
+// and points the reset vector there.
+func progStaThenLda(ram *cpu.RAM) {
+	p := uint16(0x0200)
+	// LDA #$05
+	ram.Write(p, 0xA9)
+	ram.Write(p+1, 0x05)
+	// STA $0210
+	ram.Write(p+2, 0x8D)
+	ram.Write(p+3, 0x10)
+	ram.Write(p+4, 0x02)
+	// LDA $0210
+	ram.Write(p+5, 0xAD)
+	ram.Write(p+6, 0x10)
+	ram.Write(p+7, 0x02)
+	// BRK
+	ram.Write(p+8, 0x00)
+	// Reset vector -> $0200
+	ram.Write(0xFFFC, 0x00)
+	ram.Write(0xFFFD, 0x02)
+}
+
+// progLoopWrites writes #$05 to $0210 four times in a row, then BRK.
+//   LDA #$05
+//   STA $0210 ; x4
+//   BRK
+func progLoopWrites(ram *cpu.RAM) {
+	p := uint16(0x0200)
+	ram.Write(p, 0xA9)
+	ram.Write(p+1, 0x05)
+	for i := 0; i < 4; i++ {
+		base := p + 2 + uint16(i*3)
+		ram.Write(base, 0x8D)
+		ram.Write(base+1, 0x10)
+		ram.Write(base+2, 0x02)
+	}
+	ram.Write(p+14, 0x00) // BRK
+	ram.Write(0xFFFC, 0x00)
+	ram.Write(0xFFFD, 0x02)
+}
+
+// setup wires RAM, the program, the WBus wrapper, the CPU, and a Model
+// in the same configuration as cmd/chippy/main.go.
+func setup(t *testing.T, loadProg func(*cpu.RAM)) (*Model, *cpu.CPU) {
+	t.Helper()
+	ram := cpu.NewRAM()
+	loadProg(ram)
+	wbus := NewWBus(ram)
+	c := cpu.New(wbus) // Reset reads $FFFC via wbus.Read; harmless
+	mv := New(c, ram).WithWBus(wbus)
+	m := &mv
+	return m, c
+}
+
+// runUntilBRK steps until the CPU halts (BRK sets Halted) or maxSteps
+// elapses, draining hits between each step. Returns aggregated pause
+// flag and last status from processMemHits.
+func runUntilBRK(t *testing.T, m *Model, maxSteps int) (paused bool, lastStatus string, steps int) {
+	t.Helper()
+	for steps = 0; steps < maxSteps; steps++ {
+		if m.CPU.Halted {
+			return
+		}
+		m.CPU.Step()
+		p, s := m.processMemHits()
+		if s != "" {
+			lastStatus = s
+		}
+		if p {
+			paused = true
+			return
+		}
+	}
+	return
+}
+
+func TestMemBP_PlainWriteFires(t *testing.T) {
+	m, _ := setup(t, progStaThenLda)
+	m.MemBPs[0x0210] = newMemBP(0x0210, MemBPWrite)
+
+	paused, status, _ := runUntilBRK(t, m, 100)
+	if !paused {
+		t.Fatalf("expected pause on STA $0210, got none (status=%q)", status)
+	}
+	if !strings.Contains(status, "$0210") || !strings.Contains(status, "W") {
+		t.Errorf("status missing addr/kind: %q", status)
+	}
+	if m.MemBPs[0x0210].Hits != 1 {
+		t.Errorf("hits=%d, want 1", m.MemBPs[0x0210].Hits)
+	}
+}
+
+func TestMemBP_WriteOnlyIgnoresReads(t *testing.T) {
+	m, c := setup(t, progStaThenLda)
+	bp := newMemBP(0x0210, MemBPWrite)
+	m.MemBPs[0x0210] = bp
+
+	// Step LDA #$05 (no mem access at $0210)
+	c.Step()
+	paused, _ := m.processMemHits()
+	if paused {
+		t.Fatalf("LDA imm should not pause write watch")
+	}
+	// Step STA $0210 (write hit)
+	c.Step()
+	paused, _ = m.processMemHits()
+	if !paused {
+		t.Fatalf("STA $0210 should pause write watch")
+	}
+	bp.Hits = 0 // reset for next assertion
+	// Step LDA $0210 (read; should NOT pause write watch)
+	c.Step()
+	paused, _ = m.processMemHits()
+	if paused {
+		t.Fatalf("LDA $0210 must not pause write-only watch")
+	}
+	if bp.Hits != 0 {
+		t.Errorf("write watch counted a read: hits=%d", bp.Hits)
+	}
+}
+
+func TestMemBP_ReadOnlyIgnoresWrites(t *testing.T) {
+	m, c := setup(t, progStaThenLda)
+	bp := newMemBP(0x0210, MemBPRead)
+	m.MemBPs[0x0210] = bp
+
+	c.Step() // LDA #$05
+	_, _ = m.processMemHits()
+	c.Step() // STA $0210 — write, must not fire
+	paused, _ := m.processMemHits()
+	if paused {
+		t.Fatalf("STA must not pause read-only watch")
+	}
+	if bp.Hits != 0 {
+		t.Errorf("read-only watch counted a write: hits=%d", bp.Hits)
+	}
+	c.Step() // LDA $0210 — read, must fire
+	paused, status := m.processMemHits()
+	if !paused {
+		t.Fatalf("LDA $0210 must pause read watch (status=%q)", status)
+	}
+	if bp.Hits != 1 {
+		t.Errorf("hits=%d, want 1", bp.Hits)
+	}
+}
+
+func TestMemBP_ReadWriteFiresOnBoth(t *testing.T) {
+	m, c := setup(t, progStaThenLda)
+	bp := newMemBP(0x0210, MemBPReadWrite)
+	m.MemBPs[0x0210] = bp
+
+	c.Step() // LDA #$05
+	_, _ = m.processMemHits()
+	c.Step() // STA — write, fires
+	paused, _ := m.processMemHits()
+	if !paused {
+		t.Fatalf("STA should fire RW watch")
+	}
+	if bp.Hits != 1 {
+		t.Fatalf("hits=%d after STA, want 1", bp.Hits)
+	}
+	c.Step() // LDA absolute — read, fires again
+	paused, _ = m.processMemHits()
+	if !paused {
+		t.Fatalf("LDA should fire RW watch")
+	}
+	if bp.Hits != 2 {
+		t.Errorf("hits=%d after LDA, want 2", bp.Hits)
+	}
+}
+
+func TestMemBP_HitCountGate(t *testing.T) {
+	m, _ := setup(t, progLoopWrites)
+	bp := newMemBP(0x0210, MemBPWrite)
+	bp.HitLimit = 3
+	m.MemBPs[0x0210] = bp
+
+	paused, _, _ := runUntilBRK(t, m, 200)
+	if !paused {
+		t.Fatalf("expected pause on 3rd write")
+	}
+	if bp.Hits != 3 {
+		t.Errorf("hits=%d, want 3 (paused on Nth)", bp.Hits)
+	}
+	// Watch must remain installed (hit-count is not auto-clear)
+	if _, ok := m.MemBPs[0x0210]; !ok {
+		t.Errorf("hit-count watch should not auto-delete")
+	}
+}
+
+func TestMemBP_OnceDeletes(t *testing.T) {
+	m, _ := setup(t, progLoopWrites)
+	bp := newMemBP(0x0210, MemBPWrite)
+	bp.HitLimit = -1 // one-shot
+	m.MemBPs[0x0210] = bp
+
+	paused, _, _ := runUntilBRK(t, m, 200)
+	if !paused {
+		t.Fatalf("expected pause on first write")
+	}
+	if _, ok := m.MemBPs[0x0210]; ok {
+		t.Errorf("one-shot watch should be deleted after firing")
+	}
+}
+
+func TestMemBP_ConditionTrueFires(t *testing.T) {
+	m, _ := setup(t, progStaThenLda)
+	bp := newMemBP(0x0210, MemBPWrite)
+	bp.Cond = "A==$05"
+	fn, err := compileCondition(bp.Cond, m.Syms)
+	if err != nil {
+		t.Fatalf("compile cond: %v", err)
+	}
+	bp.condFn = fn
+	m.MemBPs[0x0210] = bp
+
+	paused, _, _ := runUntilBRK(t, m, 100)
+	if !paused {
+		t.Fatalf("cond A==$05 must fire (A is $05 at STA)")
+	}
+}
+
+func TestMemBP_ConditionFalseSuppresses(t *testing.T) {
+	m, _ := setup(t, progStaThenLda)
+	bp := newMemBP(0x0210, MemBPWrite)
+	bp.Cond = "A==$FF"
+	fn, err := compileCondition(bp.Cond, m.Syms)
+	if err != nil {
+		t.Fatalf("compile cond: %v", err)
+	}
+	bp.condFn = fn
+	m.MemBPs[0x0210] = bp
+
+	paused, status, _ := runUntilBRK(t, m, 100)
+	if paused {
+		t.Fatalf("cond A==$FF must suppress fire (status=%q)", status)
+	}
+	if bp.Hits != 0 {
+		t.Errorf("hits=%d, want 0 when cond false", bp.Hits)
+	}
+}
+
+func TestMemBP_LogPointDoesNotPause(t *testing.T) {
+	m, _ := setup(t, progLoopWrites)
+	bp := newMemBP(0x0210, MemBPWrite)
+	bp.Log = "wrote A={A}"
+	m.MemBPs[0x0210] = bp
+
+	paused, status, _ := runUntilBRK(t, m, 200)
+	if paused {
+		t.Fatalf("log point must not pause")
+	}
+	if !strings.Contains(status, "wrote A=") {
+		t.Errorf("log status missing template output: %q", status)
+	}
+	// All 4 writes recorded
+	if bp.Hits != 4 {
+		t.Errorf("hits=%d, want 4", bp.Hits)
+	}
+}
+
+func TestMemBP_DisabledIgnored(t *testing.T) {
+	m, _ := setup(t, progStaThenLda)
+	bp := newMemBP(0x0210, MemBPWrite)
+	bp.Enabled = false
+	m.MemBPs[0x0210] = bp
+
+	paused, _, _ := runUntilBRK(t, m, 100)
+	if paused {
+		t.Fatalf("disabled watch must not fire")
+	}
+	if bp.Hits != 0 {
+		t.Errorf("disabled watch counted hits: %d", bp.Hits)
+	}
+}
+
+func TestWBus_HotPathSkipWhenEmpty(t *testing.T) {
+	// Sanity: with no watches installed, processMemHits returns no pause
+	// and Drain returns no hits even after many accesses.
+	m, _ := setup(t, progLoopWrites)
+	// Note: m.MemBPs is empty.
+
+	paused, _, _ := runUntilBRK(t, m, 200)
+	if paused {
+		t.Fatalf("no watches: must never pause")
+	}
+	if got := m.WBus.Drain(); len(got) != 0 {
+		t.Errorf("drained %d hits with empty watches; want 0", len(got))
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -26,6 +26,9 @@ var (
 	statusBar  = lipgloss.NewStyle().Background(lipgloss.Color("57")).Foreground(lipgloss.Color("231")).Padding(0, 1)
 	labelStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("207")).Bold(true)
 	dimAddr    = lipgloss.NewStyle().Foreground(lipgloss.Color("244"))
+	memBPRead  = lipgloss.NewStyle().Foreground(lipgloss.Color("33")).Bold(true)  // 👁 blue
+	memBPWrite = lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true) // ✏ red
+	memBPRW    = lipgloss.NewStyle().Foreground(lipgloss.Color("213")).Bold(true) // 🔁 magenta
 )
 
 const (
@@ -49,9 +52,11 @@ type Watch struct {
 type Model struct {
 	CPU         *cpu.CPU
 	RAM         *cpu.RAM
+	WBus        *WBus // optional: bus wrapper that records mem watch hits
 	Syms        *symbols.Table
 	Running     bool
 	Breakpoints map[uint16]*Breakpoint
+	MemBPs      map[uint16]*MemBP
 	MemViewAddr uint16
 	Status      string
 
@@ -103,6 +108,7 @@ func New(c *cpu.CPU, r *cpu.RAM) Model {
 		CPU:         c,
 		RAM:         r,
 		Breakpoints:  map[uint16]*Breakpoint{},
+		MemBPs:       map[uint16]*MemBP{},
 		MemViewAddr:  0x0000,
 		Status:       "ready",
 		TargetHz:     0,
@@ -110,6 +116,17 @@ func New(c *cpu.CPU, r *cpu.RAM) Model {
 		W:            120,
 		H:            40,
 	}
+}
+
+// WithWBus attaches a bus wrapper that records memory watchpoint hits. The
+// CPU should already be using this same WBus as its bus. Call after New.
+func (m Model) WithWBus(w *WBus) Model {
+	m.WBus = w
+	if w != nil {
+		w.AttachCPU(m.CPU)
+		w.SetWatches(m.MemBPs)
+	}
+	return m
 }
 
 func (m Model) WithSymbols(s *symbols.Table) Model {
@@ -208,6 +225,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			for i := 0; i < 16 && !m.CPU.Halted; i++ {
 				m.CPU.Step()
+				if mpause, mmsg := m.processMemHits(); mpause {
+					m.Status = mmsg
+					break
+				} else if mmsg != "" {
+					m.Status = mmsg
+				}
 				if pause, msg := m.shouldBreakAt(m.CPU.PC); pause {
 					break
 				} else if msg != "" {
@@ -286,6 +309,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.Status = fmt.Sprintf("halted at $%04X", m.CPU.PC)
 					break
 				}
+				if mpause, mmsg := m.processMemHits(); mpause {
+					m.Running = false
+					m.Status = mmsg
+					break
+				} else if mmsg != "" {
+					m.Status = mmsg
+				}
 				if pause, msg := m.shouldBreakAt(m.CPU.PC); pause {
 					m.Running = false
 					m.Status = fmt.Sprintf("hit bp $%04X", m.CPU.PC)
@@ -304,6 +334,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 func (m *Model) statusAfterStep(normal string) {
 	if m.CPU.Halted {
 		m.Status = fmt.Sprintf("halted at $%04X", m.CPU.PC)
+		return
+	}
+	if mpause, mmsg := m.processMemHits(); mpause {
+		m.Status = mmsg
+		return
+	} else if mmsg != "" {
+		m.Status = mmsg
 		return
 	}
 	if pause, _ := m.shouldBreakAt(m.CPU.PC); pause {
@@ -337,6 +374,12 @@ func (m *Model) stepOver() {
 			m.Status = fmt.Sprintf("step-over -> $%04X", retPC)
 			return
 		}
+		if mpause, mmsg := m.processMemHits(); mpause {
+			m.Status = mmsg
+			return
+		} else if mmsg != "" {
+			m.Status = mmsg
+		}
 		if pause, msg := m.shouldBreakAt(m.CPU.PC); pause {
 			m.Status = fmt.Sprintf("hit bp $%04X (in subroutine)", m.CPU.PC)
 			return
@@ -365,6 +408,12 @@ func (m *Model) runToNextLine() {
 		if m.CPU.Halted {
 			m.Status = fmt.Sprintf("halted at $%04X", m.CPU.PC)
 			return
+		}
+		if mpause, mmsg := m.processMemHits(); mpause {
+			m.Status = mmsg
+			return
+		} else if mmsg != "" {
+			m.Status = mmsg
 		}
 		if pause, msg := m.shouldBreakAt(m.CPU.PC); pause {
 			m.Status = fmt.Sprintf("hit bp $%04X", m.CPU.PC)
@@ -492,6 +541,15 @@ func (m Model) updateBPManager(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (m Model) sortedBPs() []uint16 {
 	out := make([]uint16, 0, len(m.Breakpoints))
 	for a := range m.Breakpoints {
+		out = append(out, a)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
+}
+
+func (m Model) sortedMemBPs() []uint16 {
+	out := make([]uint16, 0, len(m.MemBPs))
+	for a := range m.MemBPs {
 		out = append(out, a)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
@@ -684,6 +742,14 @@ func (m Model) helpModal() string {
 			{":bp X log M", "log point: prints M, doesn't pause"},
 			{"sigils", "🛑 plain  🔶 cond  📜 log  💩 reject  👉 PC"},
 		}},
+		{"Memory watchpoints", [][2]string{
+			{":bpr X", "watch reads at X"},
+			{":bpw X", "watch writes at X"},
+			{":bprw X", "watch both reads and writes"},
+			{":rmbpr X", "remove (also :rmbpw / :rmbprw)"},
+			{"modifiers", "same: once / hits N / if E / log M"},
+			{"sigils", "👁 read  ✏ write  🔁 read+write"},
+		}},
 	}
 
 	var b strings.Builder
@@ -758,6 +824,21 @@ func (m Model) bpModal() string {
 		}
 	}
 	b.WriteString("\n")
+	if len(m.MemBPs) > 0 {
+		b.WriteString(titleStyle.Render("Memory watchpoints"))
+		b.WriteString("\n\n")
+		mbps := m.sortedMemBPs()
+		for _, addr := range mbps {
+			line := m.MemBPs[addr].describe()
+			if m.Syms != nil {
+				if name := m.Syms.Lookup(addr); name != "" {
+					line += "  " + labelStyle.Render(name)
+				}
+			}
+			b.WriteString(line + "\n")
+		}
+		b.WriteString("\n")
+	}
 	b.WriteString(help.Render("  j/k move  d delete  e enable/disable  enter set PC  esc close"))
 	return lipgloss.NewStyle().
 		Border(lipgloss.DoubleBorder()).
@@ -1199,8 +1280,20 @@ func (m Model) memView(w, h int) string {
 		b.WriteString(dimAddr.Render(fmt.Sprintf("$%04X:", base)))
 		var ascii strings.Builder
 		for col := 0; col < 16; col++ {
-			v := m.RAM.Read(base + uint16(col))
-			b.WriteString(fmt.Sprintf(" %02X", v))
+			a := base + uint16(col)
+			v := m.RAM.Read(a)
+			cell := fmt.Sprintf(" %02X", v)
+			if mbp, ok := m.MemBPs[a]; ok && mbp != nil {
+				switch mbp.Kind {
+				case MemBPRead:
+					cell = " " + memBPRead.Render(fmt.Sprintf("%02X", v))
+				case MemBPWrite:
+					cell = " " + memBPWrite.Render(fmt.Sprintf("%02X", v))
+				case MemBPReadWrite:
+					cell = " " + memBPRW.Render(fmt.Sprintf("%02X", v))
+				}
+			}
+			b.WriteString(cell)
 			if v >= 32 && v < 127 {
 				ascii.WriteByte(v)
 			} else {

--- a/internal/tui/prompt.go
+++ b/internal/tui/prompt.go
@@ -194,6 +194,26 @@ func (m *Model) runCommand(line string) string {
 			return fmt.Sprintf("%d breakpoints", len(m.Breakpoints))
 		}
 		return m.cmdBP(args)
+	case "bpr":
+		return m.cmdMemBP(args, MemBPRead)
+	case "bpw":
+		return m.cmdMemBP(args, MemBPWrite)
+	case "bprw":
+		return m.cmdMemBP(args, MemBPReadWrite)
+	case "rmbpr", "rmbpw", "rmbprw":
+		if len(args) == 0 {
+			return "usage: :" + cmd + " ADDR"
+		}
+		addr, err := m.parseAddrSym(args[0])
+		if err != nil {
+			return err.Error()
+		}
+		if _, ok := m.MemBPs[addr]; !ok {
+			return fmt.Sprintf("no mem bp at $%04X", addr)
+		}
+		delete(m.MemBPs, addr)
+		m.saveState()
+		return fmt.Sprintf("mem bp -$%04X", addr)
 	case "help", "?":
 		m.ShowHelp = true
 		return "help"

--- a/internal/tui/state.go
+++ b/internal/tui/state.go
@@ -13,6 +13,7 @@ import (
 // rich form.
 type savedState struct {
 	Breakpoints json.RawMessage `json:"breakpoints,omitempty"`
+	MemBPs      json.RawMessage `json:"mem_bps,omitempty"`
 	MemViewAddr uint16          `json:"mem_view_addr"`
 	Watches     []Watch         `json:"watches"`
 	TargetHz    int             `json:"target_hz"`
@@ -61,6 +62,31 @@ func loadState(m *Model, path string) {
 			m.Breakpoints[a] = newBP(a)
 		}
 	}
+	loadMemBPs(m, s.MemBPs)
+}
+
+// loadMemBPs populates m.MemBPs from the persisted JSON. Same condition
+// recompile dance as the exec breakpoint loader.
+func loadMemBPs(m *Model, raw json.RawMessage) {
+	if m.MemBPs == nil {
+		m.MemBPs = make(map[uint16]*MemBP)
+	}
+	if len(raw) == 0 {
+		return
+	}
+	var bps []MemBP
+	if err := json.Unmarshal(raw, &bps); err != nil {
+		return
+	}
+	for i := range bps {
+		b := bps[i]
+		if b.Cond != "" {
+			if fn, cerr := compileCondition(b.Cond, m.Syms); cerr == nil {
+				b.condFn = fn
+			}
+		}
+		m.MemBPs[b.Addr] = &b
+	}
 }
 
 // looksLikeBPArray returns true if the raw json is an array whose first
@@ -97,8 +123,20 @@ func (m *Model) saveState() {
 	if err != nil {
 		return
 	}
+	mbps := make([]MemBP, 0, len(m.MemBPs))
+	for _, bp := range m.MemBPs {
+		if bp == nil {
+			continue
+		}
+		mbps = append(mbps, *bp)
+	}
+	mraw, err := json.Marshal(mbps)
+	if err != nil {
+		return
+	}
 	s := savedState{
 		Breakpoints: raw,
+		MemBPs:      mraw,
 		MemViewAddr: m.MemViewAddr,
 		Watches:     m.Watches,
 		TargetHz:    m.TargetHz,

--- a/internal/tui/wbus.go
+++ b/internal/tui/wbus.go
@@ -1,0 +1,120 @@
+// Package tui — bus wrapper that records memory access hits.
+//
+// WBus sits between the CPU and the underlying RAM (or any cpu.Bus). Each
+// Read/Write checks an addr->MemBP map and, if the access matches a watch,
+// pushes a Hit onto an internal queue. The TUI run-loop drains the queue
+// after every Step() and decides whether to pause / log / increment counters.
+//
+// Design notes:
+//   - The map is owned by the Model (not WBus) so :bpr / :bpw command edits
+//     don't need any cross-goroutine synchronization. WBus just holds a
+//     pointer to the same map header.
+//   - Hits are pushed to a fixed-capacity ring; if the CPU somehow generates
+//     more hits between drains than the ring holds, oldest entries are
+//     dropped. This is fine for a debugger — pause-on-hit semantics still
+//     fire on the first one that matters.
+//   - Hot-path branch: if the map is empty we skip the lookup entirely.
+package tui
+
+import "github.com/nkane/chippy/internal/cpu"
+
+// MemHit is one recorded access to a watched address.
+type MemHit struct {
+	Addr   uint16
+	Kind   MemBPKind // "r" or "w" (never "rw" — that's the watch kind, not the access)
+	Value  byte      // value read or written
+	PC     uint16    // CPU PC at moment of access
+	Cycles uint64    // CPU cycle count at moment of access
+}
+
+// hitRingCap is the queue depth between drains. A single 6502 instruction
+// performs at most ~7 memory accesses, so 64 leaves plenty of headroom even
+// if the run loop falls behind for a few hundred cycles.
+const hitRingCap = 64
+
+// WBus wraps an underlying cpu.Bus and reports watched accesses.
+type WBus struct {
+	Inner cpu.Bus
+
+	// Pointer back to the Model so Read/Write can capture PC and Cycles
+	// without extra plumbing. Set once at construction; do not mutate.
+	cpu *cpu.CPU
+
+	// Watches points at Model.MemBPs. nil or empty map -> hot-path skips.
+	Watches map[uint16]*MemBP
+
+	// Ring buffer of pending hits.
+	hits  [hitRingCap]MemHit
+	head  int // next write
+	count int // number of valid entries
+}
+
+// NewWBus wraps inner. The CPU pointer is needed so hits carry PC/cycle
+// context; pass it after cpu.New(wbus) returns.
+func NewWBus(inner cpu.Bus) *WBus {
+	return &WBus{Inner: inner}
+}
+
+// AttachCPU stores the CPU pointer used for hit context. Call once after
+// cpu.New(wbus) so the WBus can record PC/Cycles on each hit.
+func (w *WBus) AttachCPU(c *cpu.CPU) { w.cpu = c }
+
+// SetWatches points the wrapper at the live map. Pass Model.MemBPs directly;
+// edits to that map are seen by the wrapper without re-attach.
+func (w *WBus) SetWatches(m map[uint16]*MemBP) { w.Watches = m }
+
+func (w *WBus) Read(addr uint16) byte {
+	v := w.Inner.Read(addr)
+	if len(w.Watches) > 0 {
+		if bp, ok := w.Watches[addr]; ok && bp.matches(MemBPRead) {
+			w.push(MemHit{Addr: addr, Kind: MemBPRead, Value: v, PC: w.pc(), Cycles: w.cyc()})
+		}
+	}
+	return v
+}
+
+func (w *WBus) Write(addr uint16, v byte) {
+	w.Inner.Write(addr, v)
+	if len(w.Watches) > 0 {
+		if bp, ok := w.Watches[addr]; ok && bp.matches(MemBPWrite) {
+			w.push(MemHit{Addr: addr, Kind: MemBPWrite, Value: v, PC: w.pc(), Cycles: w.cyc()})
+		}
+	}
+}
+
+func (w *WBus) push(h MemHit) {
+	w.hits[w.head] = h
+	w.head = (w.head + 1) % hitRingCap
+	if w.count < hitRingCap {
+		w.count++
+	}
+}
+
+// Drain returns up to all currently pending hits in FIFO order and clears
+// the ring. Caller is the Model's run-loop.
+func (w *WBus) Drain() []MemHit {
+	if w.count == 0 {
+		return nil
+	}
+	out := make([]MemHit, w.count)
+	start := (w.head - w.count + hitRingCap) % hitRingCap
+	for i := 0; i < w.count; i++ {
+		out[i] = w.hits[(start+i)%hitRingCap]
+	}
+	w.count = 0
+	return out
+}
+
+func (w *WBus) pc() uint16 {
+	if w.cpu == nil {
+		return 0
+	}
+	return w.cpu.PC
+}
+
+func (w *WBus) cyc() uint64 {
+	if w.cpu == nil {
+		return 0
+	}
+	return w.cpu.Cycles
+}


### PR DESCRIPTION
Closes #3.

## Summary

- Adds DAP-style memory watchpoints alongside the existing exec breakpoints
- New `:bpr ADDR`, `:bpw ADDR`, `:bprw ADDR` commands accept the same modifiers as `:bp` (`once`, `hits N`, `if EXPR`, `log MSG`)
- Removal via `:rmbpr / :rmbpw / :rmbprw`
- Sigils 👁 / ✏ / 🔁 in the BP manager modal; matching colored bytes in the memory hex view
- State persistence extended (`mem_bps` field, conditions recompiled on load)
- Help modal + README updated

## Design

- `internal/tui/wbus.go`: `WBus` wraps the underlying `cpu.Bus`, intercepts Read/Write, and pushes matched accesses to a fixed-capacity ring buffer (`hitRingCap=64`)
- `internal/tui/membp.go`: `MemBP` type plus `processMemHits` which mirrors the `shouldBreakAt` cond/hit-count/log logic against drained hits
- `Model.MemBPs map[uint16]*MemBP` is shared by reference with the `WBus`, so command edits are visible to the bus without re-attach
- `cmd/chippy/main.go`: constructs `cpu.New(ram)` then swaps `c.Bus = wbus` so the CPU sees the wrapper while `Model.RAM` keeps direct access for TUI rendering
- Hot path: when `MemBPs` is empty the wrapper short-circuits with a single `len()` check

## Testing

- `go build ./... && go test ./...` green
- Manually verified watchpoints fire from `:bpw`, `:bpr`, conditional `if A==$XX`, hit-count gating, one-shot, and log points (no pause)

## Out of scope

- Bus-interface refactor of `Model.RAM` (rejected — keeps the diff small; `WBus` only sits in front of the CPU's view of memory)
- Width-greater-than-1 watches (e.g. watch $0200..$020F as a region) — could follow up