### PR TITLE
feat(cpu): implement stable NMOS illegal opcodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,9 +352,13 @@ Implements all official NMOS 6502 opcodes, including packed-BCD `ADC`/`SBC`
 when the `D` flag is set (NMOS semantics — the binary path drives N/V/Z and
 the decimal path drives C and A).
 
-Known gaps tracked as GitHub issues:
-
-- [#2](https://github.com/nkane/chippy/issues/2) — Unofficial / illegal opcodes (currently 1-byte NOPs)
+Stable undocumented ("illegal") opcodes are also implemented:
+`LAX`, `SAX`, `DCP`, `ISC`, `SLO`, `RLA`, `SRE`, `RRA`, `ANC`, `ALR`, `ARR`,
+`SBX`, the `SBC` alias at `$EB`, and the family of multi-byte/multi-cycle
+NOPs that real silicon decodes at undocumented slots. `RRA` and `ISC` honor
+decimal mode. The unstable opcodes (AHX/SHA, SHY, SHX, TAS, LAS, XAA, KIL/JAM)
+remain decoded as 1-byte NOPs since their behavior depends on bus capacitance
+or halts the CPU.
 
 ---
 

--- a/internal/cpu/illegal_test.go
+++ b/internal/cpu/illegal_test.go
@@ -1,0 +1,318 @@
+package cpu
+
+import "testing"
+
+// Helper: load a program at $8000 and pre-seed A/X/Y/P/some RAM.
+func setupIllegal(prog []byte, setup func(*CPU, *RAM)) (*CPU, *RAM) {
+	c, r := newTestCPU(prog)
+	if setup != nil {
+		setup(c, r)
+	}
+	return c, r
+}
+
+// --- LAX ---
+
+func TestLAX_ZP(t *testing.T) {
+	// LAX $40
+	c, _ := setupIllegal([]byte{0xA7, 0x40}, func(c *CPU, r *RAM) {
+		r.Write(0x0040, 0x7F)
+	})
+	c.Step()
+	if c.A != 0x7F || c.X != 0x7F {
+		t.Fatalf("A=%02X X=%02X want 7F/7F", c.A, c.X)
+	}
+	if c.hasFlag(FlagZ) || c.hasFlag(FlagN) {
+		t.Fatalf("flags wrong: %08b", c.P)
+	}
+}
+
+func TestLAX_SetsNegative(t *testing.T) {
+	c, _ := setupIllegal([]byte{0xA7, 0x40}, func(c *CPU, r *RAM) {
+		r.Write(0x0040, 0x80)
+	})
+	c.Step()
+	if c.A != 0x80 || c.X != 0x80 {
+		t.Fatalf("A=%02X X=%02X want 80/80", c.A, c.X)
+	}
+	if !c.hasFlag(FlagN) {
+		t.Fatalf("N not set")
+	}
+}
+
+// --- SAX ---
+
+func TestSAX_ZP(t *testing.T) {
+	// LDA #$F0 ; LDX #$0F ; SAX $50  -> $50 := $F0 & $0F = $00
+	prog := []byte{0xA9, 0xF0, 0xA2, 0x0F, 0x87, 0x50}
+	c, r := newTestCPU(prog)
+	c.Step()
+	c.Step()
+	pBefore := c.P
+	c.Step()
+	if r.Read(0x0050) != 0x00 {
+		t.Fatalf("$50=%02X want 00", r.Read(0x0050))
+	}
+	if c.P != pBefore {
+		t.Fatalf("SAX modified flags: before=%08b after=%08b", pBefore, c.P)
+	}
+}
+
+// --- DCP ---
+
+func TestDCP_DecAndCompareEqual(t *testing.T) {
+	// LDA #$05 ; DCP $40  ; $40 was $06 -> becomes $05, CMP A($05) vs $05 -> Z=1, C=1
+	prog := []byte{0xA9, 0x05, 0xC7, 0x40}
+	c, r := setupIllegal(prog, func(c *CPU, r *RAM) {
+		r.Write(0x0040, 0x06)
+	})
+	c.Step()
+	c.Step()
+	if r.Read(0x0040) != 0x05 {
+		t.Fatalf("mem=%02X want 05", r.Read(0x0040))
+	}
+	if !c.hasFlag(FlagZ) || !c.hasFlag(FlagC) {
+		t.Fatalf("flags %08b want Z+C", c.P)
+	}
+}
+
+// --- ISC ---
+
+func TestISC_IncAndSubtract(t *testing.T) {
+	// LDA #$10 ; SEC ; ISC $40  ; $40 was $04 -> becomes $05, A := $10 - $05 = $0B
+	prog := []byte{0xA9, 0x10, 0x38, 0xE7, 0x40}
+	c, r := setupIllegal(prog, func(c *CPU, r *RAM) {
+		r.Write(0x0040, 0x04)
+	})
+	c.Step()
+	c.Step()
+	c.Step()
+	if r.Read(0x0040) != 0x05 {
+		t.Fatalf("mem=%02X want 05", r.Read(0x0040))
+	}
+	if c.A != 0x0B {
+		t.Fatalf("A=%02X want 0B", c.A)
+	}
+	if !c.hasFlag(FlagC) {
+		t.Fatalf("C should be set (no borrow)")
+	}
+}
+
+// --- SLO ---
+
+func TestSLO_ShiftAndOR(t *testing.T) {
+	// LDA #$01 ; SLO $40  ; $40=$81 -> shifted=$02, C=1; A := $01 | $02 = $03
+	prog := []byte{0xA9, 0x01, 0x07, 0x40}
+	c, r := setupIllegal(prog, func(c *CPU, r *RAM) {
+		r.Write(0x0040, 0x81)
+	})
+	c.Step()
+	c.Step()
+	if r.Read(0x0040) != 0x02 {
+		t.Fatalf("mem=%02X want 02", r.Read(0x0040))
+	}
+	if c.A != 0x03 {
+		t.Fatalf("A=%02X want 03", c.A)
+	}
+	if !c.hasFlag(FlagC) {
+		t.Fatalf("C should be set from old bit 7")
+	}
+}
+
+// --- RLA ---
+
+func TestRLA_RotateAndAND(t *testing.T) {
+	// CLC ; LDA #$0F ; RLA $40  ; $40=$81 -> rotated=$02 (carry-in 0), A := $0F & $02 = $02
+	prog := []byte{0x18, 0xA9, 0x0F, 0x27, 0x40}
+	c, r := setupIllegal(prog, func(c *CPU, r *RAM) {
+		r.Write(0x0040, 0x81)
+	})
+	c.Step()
+	c.Step()
+	c.Step()
+	if r.Read(0x0040) != 0x02 {
+		t.Fatalf("mem=%02X want 02", r.Read(0x0040))
+	}
+	if c.A != 0x02 {
+		t.Fatalf("A=%02X want 02", c.A)
+	}
+	if !c.hasFlag(FlagC) {
+		t.Fatalf("C should be set from old bit 7")
+	}
+}
+
+// --- SRE ---
+
+func TestSRE_ShiftRightAndEOR(t *testing.T) {
+	// LDA #$F0 ; SRE $40  ; $40=$03 -> shifted=$01, C=1; A := $F0 ^ $01 = $F1
+	prog := []byte{0xA9, 0xF0, 0x47, 0x40}
+	c, r := setupIllegal(prog, func(c *CPU, r *RAM) {
+		r.Write(0x0040, 0x03)
+	})
+	c.Step()
+	c.Step()
+	if r.Read(0x0040) != 0x01 {
+		t.Fatalf("mem=%02X want 01", r.Read(0x0040))
+	}
+	if c.A != 0xF1 {
+		t.Fatalf("A=%02X want F1", c.A)
+	}
+	if !c.hasFlag(FlagC) {
+		t.Fatalf("C should be set from old bit 0")
+	}
+}
+
+// --- RRA ---
+
+func TestRRA_RotateRightAndADC(t *testing.T) {
+	// CLC ; LDA #$10 ; RRA $40  ; $40=$02 -> rotated right=$01, C=0
+	// Then ADC: A := $10 + $01 + 0 = $11
+	prog := []byte{0x18, 0xA9, 0x10, 0x67, 0x40}
+	c, r := setupIllegal(prog, func(c *CPU, r *RAM) {
+		r.Write(0x0040, 0x02)
+	})
+	c.Step()
+	c.Step()
+	c.Step()
+	if r.Read(0x0040) != 0x01 {
+		t.Fatalf("mem=%02X want 01", r.Read(0x0040))
+	}
+	if c.A != 0x11 {
+		t.Fatalf("A=%02X want 11", c.A)
+	}
+}
+
+// --- ANC ---
+
+func TestANC_CopiesNegToCarry(t *testing.T) {
+	// LDA #$FF ; ANC #$80  -> A := $80, N=1, C=1
+	prog := []byte{0xA9, 0xFF, 0x0B, 0x80}
+	c, _ := newTestCPU(prog)
+	c.Step()
+	c.Step()
+	if c.A != 0x80 {
+		t.Fatalf("A=%02X want 80", c.A)
+	}
+	if !c.hasFlag(FlagN) || !c.hasFlag(FlagC) {
+		t.Fatalf("flags %08b want N+C", c.P)
+	}
+}
+
+func TestANC_ZeroResult(t *testing.T) {
+	// LDA #$0F ; ANC #$F0  -> A := 0, Z=1, C=0
+	prog := []byte{0xA9, 0x0F, 0x0B, 0xF0}
+	c, _ := newTestCPU(prog)
+	c.Step()
+	c.Step()
+	if c.A != 0x00 {
+		t.Fatalf("A=%02X want 00", c.A)
+	}
+	if !c.hasFlag(FlagZ) || c.hasFlag(FlagC) {
+		t.Fatalf("flags %08b want Z, no C", c.P)
+	}
+}
+
+// --- ALR ---
+
+func TestALR_AndThenShiftRight(t *testing.T) {
+	// LDA #$FF ; ALR #$03  -> A & $03 = $03, then >>1 = $01, C=1 (old bit 0)
+	prog := []byte{0xA9, 0xFF, 0x4B, 0x03}
+	c, _ := newTestCPU(prog)
+	c.Step()
+	c.Step()
+	if c.A != 0x01 {
+		t.Fatalf("A=%02X want 01", c.A)
+	}
+	if !c.hasFlag(FlagC) {
+		t.Fatalf("C should be set")
+	}
+}
+
+// --- SBX ---
+
+func TestSBX_NoBorrow(t *testing.T) {
+	// LDA #$FF ; LDX #$0F ; SBX #$01  -> ($FF & $0F)=$0F; $0F - $01 = $0E, C=1
+	prog := []byte{0xA9, 0xFF, 0xA2, 0x0F, 0xCB, 0x01}
+	c, _ := newTestCPU(prog)
+	c.Step()
+	c.Step()
+	c.Step()
+	if c.X != 0x0E {
+		t.Fatalf("X=%02X want 0E", c.X)
+	}
+	if !c.hasFlag(FlagC) {
+		t.Fatalf("C should be set (no borrow)")
+	}
+	if c.A != 0xFF {
+		t.Fatalf("SBX modified A: %02X", c.A)
+	}
+}
+
+func TestSBX_WithBorrow(t *testing.T) {
+	// LDA #$01 ; LDX #$01 ; SBX #$05  -> X := ($01 & $01) - $05 = $FC, C=0
+	prog := []byte{0xA9, 0x01, 0xA2, 0x01, 0xCB, 0x05}
+	c, _ := newTestCPU(prog)
+	c.Step()
+	c.Step()
+	c.Step()
+	if c.X != 0xFC {
+		t.Fatalf("X=%02X want FC", c.X)
+	}
+	if c.hasFlag(FlagC) {
+		t.Fatalf("C should be clear (borrow occurred)")
+	}
+	if !c.hasFlag(FlagN) {
+		t.Fatalf("N should be set")
+	}
+}
+
+// --- SBC alias at $EB ---
+
+func TestSBC_AliasEB(t *testing.T) {
+	// SEC ; LDA #$10 ; SBC #$01 (via $EB)  -> A := $0F, C=1
+	prog := []byte{0x38, 0xA9, 0x10, 0xEB, 0x01}
+	c, _ := newTestCPU(prog)
+	c.Step()
+	c.Step()
+	c.Step()
+	if c.A != 0x0F {
+		t.Fatalf("A=%02X want 0F", c.A)
+	}
+	if !c.hasFlag(FlagC) {
+		t.Fatalf("C should be set")
+	}
+}
+
+// --- multi-byte NOPs advance PC correctly ---
+
+func TestNOP_Multibyte_AdvancesPC(t *testing.T) {
+	cases := []struct {
+		name   string
+		prog   []byte
+		wantPC uint16
+	}{
+		{"1-byte $1A", []byte{0x1A}, 0x8001},
+		{"2-byte IMM $80", []byte{0x80, 0xFF}, 0x8002},
+		{"2-byte ZP $04", []byte{0x04, 0x40}, 0x8002},
+		{"2-byte ZPX $14", []byte{0x14, 0x40}, 0x8002},
+		{"3-byte ABS $0C", []byte{0x0C, 0x34, 0x12}, 0x8003},
+		{"3-byte ABX $1C", []byte{0x1C, 0x34, 0x12}, 0x8003},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, _ := newTestCPU(tc.prog)
+			pBefore := c.P
+			aBefore, xBefore, yBefore := c.A, c.X, c.Y
+			c.Step()
+			if c.PC != tc.wantPC {
+				t.Fatalf("PC=%04X want %04X", c.PC, tc.wantPC)
+			}
+			if c.P != pBefore {
+				t.Fatalf("NOP modified flags")
+			}
+			if c.A != aBefore || c.X != xBefore || c.Y != yBefore {
+				t.Fatalf("NOP modified registers")
+			}
+		})
+	}
+}

--- a/internal/cpu/opcodes_illegal.go
+++ b/internal/cpu/opcodes_illegal.go
@@ -1,0 +1,316 @@
+// Package cpu — undocumented ("illegal") NMOS 6502 opcodes.
+//
+// Implements the stable subset that real silicon executes deterministically.
+// Behavior references:
+//
+//   - http://www.oxyron.de/html/opcodes02.html
+//   - https://www.masswerk.at/6502/6502_instruction_set.html
+//
+// Implemented:
+//   LAX  — LDA + LDX (no flag-set surprises beyond setZN)
+//   SAX  — store (A & X), no flag changes
+//   DCP  — DEC then CMP
+//   ISC  — INC then SBC (also called ISB)
+//   SLO  — ASL then ORA
+//   RLA  — ROL then AND
+//   SRE  — LSR then EOR
+//   RRA  — ROR then ADC (decimal-aware via opADC's D-mode branch)
+//   ANC  — AND #imm; C := N (i.e. C := bit7 of result)
+//   ALR  — AND #imm then LSR A
+//   ARR  — AND #imm then ROR A; sets V and C from the result's bits 5/6
+//   SBX  — X := (A & X) - imm  (carry set if no borrow; flags from result)
+//   NOPs — multi-byte / multi-cycle no-ops at undocumented opcode slots
+//
+// Unstable opcodes (silicon-dependent on bus capacitance / hi-byte+1 ANDs)
+// remain decoded as plain NOPs:
+//   AHX/SHA, SHY, SHX, TAS/SHS, LAS/LAR, XAA/ANE, KIL/JAM
+//
+// These cannot be reliably emulated and no widely-used software depends on
+// them. They occupy 1 byte by default and consume 2 cycles, which matches
+// the placeholder fill in opcodes.go's init().
+package cpu
+
+// --- combined R-M-W illegals ---
+
+// opDCP: M := M-1; CMP A vs new M.
+func opDCP(c *CPU, addr uint16, _ AddrMode) {
+	v := c.Bus.Read(addr) - 1
+	c.Bus.Write(addr, v)
+	cmp(c, c.A, v)
+}
+
+// opISC: M := M+1; SBC A, new M. Honors decimal mode via opSBC path.
+func opISC(c *CPU, addr uint16, m AddrMode) {
+	v := c.Bus.Read(addr) + 1
+	c.Bus.Write(addr, v)
+	// Inline SBC against v: re-use the same arithmetic as opSBC. We can't
+	// call opSBC directly (it would re-read), so duplicate the dispatch.
+	carry := uint16(0)
+	if c.hasFlag(FlagC) {
+		carry = 1
+	}
+	if c.hasFlag(FlagD) {
+		sbcDecimal(c, v, carry)
+		return
+	}
+	w := uint16(v) ^ 0xFF
+	sum := uint16(c.A) + w + carry
+	c.setFlag(FlagC, sum > 0xFF)
+	c.setFlag(FlagV, (^(uint16(c.A)^w)&(uint16(c.A)^sum))&0x80 != 0)
+	c.A = byte(sum)
+	c.setZN(c.A)
+}
+
+// opSLO: M := M<<1; A := A | M. C := old bit 7.
+func opSLO(c *CPU, addr uint16, _ AddrMode) {
+	v := c.Bus.Read(addr)
+	c.setFlag(FlagC, v&0x80 != 0)
+	v <<= 1
+	c.Bus.Write(addr, v)
+	c.A |= v
+	c.setZN(c.A)
+}
+
+// opRLA: M := ROL M; A := A & M.
+func opRLA(c *CPU, addr uint16, _ AddrMode) {
+	v := c.Bus.Read(addr)
+	carryIn := byte(0)
+	if c.hasFlag(FlagC) {
+		carryIn = 1
+	}
+	c.setFlag(FlagC, v&0x80 != 0)
+	v = (v << 1) | carryIn
+	c.Bus.Write(addr, v)
+	c.A &= v
+	c.setZN(c.A)
+}
+
+// opSRE: M := M>>1; A := A ^ M. C := old bit 0.
+func opSRE(c *CPU, addr uint16, _ AddrMode) {
+	v := c.Bus.Read(addr)
+	c.setFlag(FlagC, v&1 != 0)
+	v >>= 1
+	c.Bus.Write(addr, v)
+	c.A ^= v
+	c.setZN(c.A)
+}
+
+// opRRA: M := ROR M; ADC A, new M. Honors decimal mode via opADC path.
+func opRRA(c *CPU, addr uint16, m AddrMode) {
+	v := c.Bus.Read(addr)
+	carryIn := byte(0)
+	if c.hasFlag(FlagC) {
+		carryIn = 0x80
+	}
+	c.setFlag(FlagC, v&1 != 0)
+	v = (v >> 1) | carryIn
+	c.Bus.Write(addr, v)
+	// ADC with v
+	carry := uint16(0)
+	if c.hasFlag(FlagC) {
+		carry = 1
+	}
+	if c.hasFlag(FlagD) {
+		adcDecimal(c, v, carry)
+		return
+	}
+	sum := uint16(c.A) + uint16(v) + carry
+	c.setFlag(FlagC, sum > 0xFF)
+	c.setFlag(FlagV, (^(uint16(c.A)^uint16(v))&(uint16(c.A)^sum))&0x80 != 0)
+	c.A = byte(sum)
+	c.setZN(c.A)
+}
+
+// --- load/store illegals ---
+
+// opLAX: A,X := M.
+func opLAX(c *CPU, addr uint16, _ AddrMode) {
+	v := c.Bus.Read(addr)
+	c.A = v
+	c.X = v
+	c.setZN(v)
+}
+
+// opSAX: M := A & X. Does not affect any flags.
+func opSAX(c *CPU, addr uint16, _ AddrMode) {
+	c.Bus.Write(addr, c.A&c.X)
+}
+
+// --- immediate-only illegals ---
+
+// opANC: A := A & imm; then C := bit7 of A (i.e. C copies N).
+func opANC(c *CPU, addr uint16, _ AddrMode) {
+	c.A &= c.Bus.Read(addr)
+	c.setZN(c.A)
+	c.setFlag(FlagC, c.A&0x80 != 0)
+}
+
+// opALR (also ASR): A := (A & imm) >> 1. C := old bit 0 of (A & imm).
+func opALR(c *CPU, addr uint16, _ AddrMode) {
+	c.A &= c.Bus.Read(addr)
+	c.setFlag(FlagC, c.A&1 != 0)
+	c.A >>= 1
+	c.setZN(c.A)
+}
+
+// opARR: A := ROR(A & imm). Then a C/V quirk:
+//   C := bit 6 of result
+//   V := bit 6 XOR bit 5 of result
+// (Decimal-mode ARR has even weirder behaviour; we implement the binary
+// case here. Real software almost never uses ARR in decimal mode.)
+func opARR(c *CPU, addr uint16, _ AddrMode) {
+	c.A &= c.Bus.Read(addr)
+	carryIn := byte(0)
+	if c.hasFlag(FlagC) {
+		carryIn = 0x80
+	}
+	c.A = (c.A >> 1) | carryIn
+	c.setZN(c.A)
+	c.setFlag(FlagC, c.A&0x40 != 0)
+	c.setFlag(FlagV, ((c.A>>6)^(c.A>>5))&1 != 0)
+}
+
+// opSBX (also called AXS): X := (A & X) - imm. Carry set if no borrow.
+// A is unchanged. Flags are set from the result.
+func opSBX(c *CPU, addr uint16, _ AddrMode) {
+	v := c.Bus.Read(addr)
+	tmp := uint16(c.A&c.X) + uint16(v^0xFF) + 1 // i.e. (A&X) - v
+	c.setFlag(FlagC, tmp > 0xFF)
+	c.X = byte(tmp)
+	c.setZN(c.X)
+}
+
+// opNOP2 / opNOP3 — multi-byte NOPs that still need to consume the operand
+// byte (which the addressing-mode resolver already reads via `addr` param).
+// We don't need a body; the side effect of having a non-IMP mode in the
+// opcode table is the PC advancing past the operand. opNOP() works fine
+// here because the PC bump happens in resolve(), not in Exec.
+//
+// We expose this alias purely for readability in the table.
+func opNOP2(c *CPU, _ uint16, _ AddrMode) {}
+func opNOP3(c *CPU, _ uint16, _ AddrMode) {}
+
+// --- table installation ---
+
+func init() {
+	set := func(op byte, name string, mode AddrMode, bytes, cycles int, pageAdd bool, fn func(*CPU, uint16, AddrMode)) {
+		Opcodes[op] = Instr{name, mode, bytes, cycles, pageAdd, fn}
+	}
+
+	// LAX — load A and X from memory
+	set(0xA7, "LAX", ZP, 2, 3, false, opLAX)
+	set(0xB7, "LAX", ZPY, 2, 4, false, opLAX)
+	set(0xAF, "LAX", ABS, 3, 4, false, opLAX)
+	set(0xBF, "LAX", ABY, 3, 4, true, opLAX)
+	set(0xA3, "LAX", IZX, 2, 6, false, opLAX)
+	set(0xB3, "LAX", IZY, 2, 5, true, opLAX)
+	// $AB is "LAX #imm" (XAA-ish, unstable). Leave as NOP.
+
+	// SAX — store A AND X
+	set(0x87, "SAX", ZP, 2, 3, false, opSAX)
+	set(0x97, "SAX", ZPY, 2, 4, false, opSAX)
+	set(0x8F, "SAX", ABS, 3, 4, false, opSAX)
+	set(0x83, "SAX", IZX, 2, 6, false, opSAX)
+
+	// DCP — DEC then CMP
+	set(0xC7, "DCP", ZP, 2, 5, false, opDCP)
+	set(0xD7, "DCP", ZPX, 2, 6, false, opDCP)
+	set(0xCF, "DCP", ABS, 3, 6, false, opDCP)
+	set(0xDF, "DCP", ABX, 3, 7, false, opDCP)
+	set(0xDB, "DCP", ABY, 3, 7, false, opDCP)
+	set(0xC3, "DCP", IZX, 2, 8, false, opDCP)
+	set(0xD3, "DCP", IZY, 2, 8, false, opDCP)
+
+	// ISC — INC then SBC
+	set(0xE7, "ISC", ZP, 2, 5, false, opISC)
+	set(0xF7, "ISC", ZPX, 2, 6, false, opISC)
+	set(0xEF, "ISC", ABS, 3, 6, false, opISC)
+	set(0xFF, "ISC", ABX, 3, 7, false, opISC)
+	set(0xFB, "ISC", ABY, 3, 7, false, opISC)
+	set(0xE3, "ISC", IZX, 2, 8, false, opISC)
+	set(0xF3, "ISC", IZY, 2, 8, false, opISC)
+
+	// SLO — ASL then ORA
+	set(0x07, "SLO", ZP, 2, 5, false, opSLO)
+	set(0x17, "SLO", ZPX, 2, 6, false, opSLO)
+	set(0x0F, "SLO", ABS, 3, 6, false, opSLO)
+	set(0x1F, "SLO", ABX, 3, 7, false, opSLO)
+	set(0x1B, "SLO", ABY, 3, 7, false, opSLO)
+	set(0x03, "SLO", IZX, 2, 8, false, opSLO)
+	set(0x13, "SLO", IZY, 2, 8, false, opSLO)
+
+	// RLA — ROL then AND
+	set(0x27, "RLA", ZP, 2, 5, false, opRLA)
+	set(0x37, "RLA", ZPX, 2, 6, false, opRLA)
+	set(0x2F, "RLA", ABS, 3, 6, false, opRLA)
+	set(0x3F, "RLA", ABX, 3, 7, false, opRLA)
+	set(0x3B, "RLA", ABY, 3, 7, false, opRLA)
+	set(0x23, "RLA", IZX, 2, 8, false, opRLA)
+	set(0x33, "RLA", IZY, 2, 8, false, opRLA)
+
+	// SRE — LSR then EOR
+	set(0x47, "SRE", ZP, 2, 5, false, opSRE)
+	set(0x57, "SRE", ZPX, 2, 6, false, opSRE)
+	set(0x4F, "SRE", ABS, 3, 6, false, opSRE)
+	set(0x5F, "SRE", ABX, 3, 7, false, opSRE)
+	set(0x5B, "SRE", ABY, 3, 7, false, opSRE)
+	set(0x43, "SRE", IZX, 2, 8, false, opSRE)
+	set(0x53, "SRE", IZY, 2, 8, false, opSRE)
+
+	// RRA — ROR then ADC
+	set(0x67, "RRA", ZP, 2, 5, false, opRRA)
+	set(0x77, "RRA", ZPX, 2, 6, false, opRRA)
+	set(0x6F, "RRA", ABS, 3, 6, false, opRRA)
+	set(0x7F, "RRA", ABX, 3, 7, false, opRRA)
+	set(0x7B, "RRA", ABY, 3, 7, false, opRRA)
+	set(0x63, "RRA", IZX, 2, 8, false, opRRA)
+	set(0x73, "RRA", IZY, 2, 8, false, opRRA)
+
+	// Single-byte / single-operand specials
+	set(0x0B, "ANC", IMM, 2, 2, false, opANC)
+	set(0x2B, "ANC", IMM, 2, 2, false, opANC) // alias
+	set(0x4B, "ALR", IMM, 2, 2, false, opALR)
+	set(0x6B, "ARR", IMM, 2, 2, false, opARR)
+	set(0xCB, "SBX", IMM, 2, 2, false, opSBX)
+
+	// Duplicate SBC opcode at $EB (same behavior as $E9, ca65 emits this
+	// for some macros). Map to opSBC with IMM mode.
+	set(0xEB, "SBC", IMM, 2, 2, false, opSBC)
+
+	// Multi-byte NOPs. These are hit by some test ROMs and (rarely) real
+	// software relying on cycle padding. Cycle counts per oxyron table.
+	// Single-byte 2-cycle NOPs at undocumented slots: $1A, $3A, $5A, $7A, $DA, $FA
+	for _, op := range []byte{0x1A, 0x3A, 0x5A, 0x7A, 0xDA, 0xFA} {
+		set(op, "NOP", IMP, 1, 2, false, opNOP)
+	}
+	// 2-byte NOPs: $80, $82, $89, $C2, $E2 are NOP #imm (2 cycles).
+	for _, op := range []byte{0x80, 0x82, 0x89, 0xC2, 0xE2} {
+		set(op, "NOP", IMM, 2, 2, false, opNOP2)
+	}
+	// 2-byte ZP NOPs: $04, $44, $64 (3 cycles).
+	for _, op := range []byte{0x04, 0x44, 0x64} {
+		set(op, "NOP", ZP, 2, 3, false, opNOP2)
+	}
+	// 2-byte ZPX NOPs: $14, $34, $54, $74, $D4, $F4 (4 cycles).
+	for _, op := range []byte{0x14, 0x34, 0x54, 0x74, 0xD4, 0xF4} {
+		set(op, "NOP", ZPX, 2, 4, false, opNOP2)
+	}
+	// 3-byte ABS NOP: $0C (4 cycles).
+	set(0x0C, "NOP", ABS, 3, 4, false, opNOP3)
+	// 3-byte ABX NOPs: $1C, $3C, $5C, $7C, $DC, $FC (4 cycles +1 page cross).
+	for _, op := range []byte{0x1C, 0x3C, 0x5C, 0x7C, 0xDC, 0xFC} {
+		set(op, "NOP", ABX, 3, 4, true, opNOP3)
+	}
+
+	// Unstable opcodes — explicitly left as 1-byte NOPs (the default fill).
+	// Listing them here documents the decision:
+	//   $93 AHX (zp),Y     $9F AHX abs,Y
+	//   $9C SHY abs,X
+	//   $9E SHX abs,Y
+	//   $9B TAS abs,Y
+	//   $BB LAS abs,Y
+	//   $8B XAA #imm       $AB LAX #imm  (XAA-family)
+	//   $02 $12 $22 $32 $42 $52 $62 $72 $92 $B2 $D2 $F2  KIL/JAM
+	// These either depend on bus capacitance or halt the CPU; the default
+	// 2-cycle NOP fill is the safest stub.
+}


### PR DESCRIPTION
## Summary
- Implements stable undocumented NMOS opcodes: DCP, ISC, SLO, RLA, SRE, RRA, LAX, SAX, ANC, ALR, ARR, SBX, SBC alias $EB, plus multi-byte NOPs at undocumented slots.
- RRA and ISC honor decimal mode via the existing BCD-aware ADC/SBC helpers.
- Unstable opcodes (AHX, SHY, SHX, TAS, LAS, XAA, KIL/JAM) remain decoded as 1-byte NOPs and are documented as such in code.

## Notes
- New file is named `opcodes_illegal.go` so its `init()` runs after `opcodes.go`'s default-fill init (Go runs inits per file in lexical filename order). Otherwise the fill loop overwrites the new entries.
- Adds 25+ unit tests covering the arithmetic, flag side effects, and PC advancement for multi-byte NOPs.

Closes #2