### PR TITLE
ci: build + test workflow with 3-OS matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+          cache: true
+
+      - name: go mod download
+        run: go mod download
+
+      - name: go build
+        run: go build ./...
+
+      - name: go test
+        run: go test -race -count=1 ./...

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # chippy
 
+[![ci](https://github.com/nkane/chippy/actions/workflows/ci.yml/badge.svg)](https://github.com/nkane/chippy/actions/workflows/ci.yml)
+[![release](https://img.shields.io/github/v/release/nkane/chippy?sort=semver)](https://github.com/nkane/chippy/releases)
+[![license](https://img.shields.io/github/license/nkane/chippy)](LICENSE)
+
 A TUI 6502 emulator and debugger, written in Go.
 
 `chippy` emulates the NMOS 6502 CPU and presents a terminal UI built with


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` running on push to main and on every PR.
- Matrix: ubuntu-latest, macos-latest, windows-latest × Go stable.
- Steps: `go build ./...` and `go test -race -count=1 ./...`.
- README gets ci/release/license badges.

## Verified locally
`go build ./... && go test -race -count=1 ./...` is green on darwin/arm64.

Closes #11