### PR TITLE
ci: add golangci-lint v2 + fix 20 lint findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,6 @@ jobs:
           cache: true
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.12.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,3 +33,20 @@ jobs:
 
       - name: go test
         run: go test -race -count=1 ./...
+
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+          cache: true
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v2.12.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,41 @@
+version: "2"
+
+run:
+  timeout: 5m
+  tests: true
+
+linters:
+  default: none
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+    - misspell
+  settings:
+    errcheck:
+      # Don't require checking errors on Fprintf/Println-style writes to
+      # bytes.Buffer / stdout — they cannot fail in practice and the noise
+      # isn't worth the readability hit.
+      exclude-functions:
+        - (*bytes.Buffer).WriteString
+        - (*bytes.Buffer).WriteByte
+        - (*bytes.Buffer).Write
+        - (*strings.Builder).WriteString
+        - (*strings.Builder).WriteByte
+        - (*strings.Builder).Write
+        - fmt.Fprintf
+        - fmt.Fprintln
+        - fmt.Fprint
+        # Fire-and-forget Close on read-only files is idiomatic Go.
+        - (*os.File).Close
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/internal/cpu/bcd_test.go
+++ b/internal/cpu/bcd_test.go
@@ -15,11 +15,11 @@ func runBCD(op byte, a, imm byte, carryIn bool) (out byte, cOut, vOut, nOut, zOu
 
 func TestBCD_ADC_AcceptanceVectors(t *testing.T) {
 	cases := []struct {
-		name             string
-		a, imm           byte
-		carryIn          bool
-		wantA            byte
-		wantC            bool
+		name    string
+		a, imm  byte
+		carryIn bool
+		wantA   byte
+		wantC   bool
 	}{
 		// From issue acceptance criteria.
 		{"15+27=42 no carry", 0x15, 0x27, false, 0x42, false},
@@ -47,11 +47,11 @@ func TestBCD_ADC_AcceptanceVectors(t *testing.T) {
 func TestBCD_SBC_AcceptanceVectors(t *testing.T) {
 	// Note: SBC carry-in semantics — C=1 means "no borrow", C=0 means borrow.
 	cases := []struct {
-		name             string
-		a, imm           byte
-		carryIn          bool
-		wantA            byte
-		wantC            bool
+		name    string
+		a, imm  byte
+		carryIn bool
+		wantA   byte
+		wantC   bool
 	}{
 		// From issue acceptance criteria.
 		{"50-25=25 no borrow", 0x50, 0x25, true, 0x25, true},

--- a/internal/cpu/cpu_test.go
+++ b/internal/cpu/cpu_test.go
@@ -38,20 +38,14 @@ func TestADC_BasicAndOverflow(t *testing.T) {
 }
 
 func TestJSR_RTS(t *testing.T) {
-	// $8000: JSR $8005 ; LDA #$01 ; BRK
-	// $8005: LDA #$AA ; RTS
+	// $8000: JSR $8006 ; LDA #$01 ; BRK
+	// $8006: LDA #$AA ; RTS
 	prog := []byte{
-		0x20, 0x05, 0x80, // JSR $8005
-		0xA9, 0x01,       // LDA #$01
-		0xA9, 0xAA, 0x60, // pad+ LDA #$AA ; RTS at $8005,$8006,$8007 -- adjust
-	}
-	// Actually rebuild precisely:
-	prog = []byte{
 		0x20, 0x06, 0x80, // 8000: JSR $8006
-		0xA9, 0x01,       // 8003: LDA #$01
-		0x00,             // 8005: BRK
-		0xA9, 0xAA,       // 8006: LDA #$AA
-		0x60,             // 8008: RTS
+		0xA9, 0x01, // 8003: LDA #$01
+		0x00,       // 8005: BRK
+		0xA9, 0xAA, // 8006: LDA #$AA
+		0x60, // 8008: RTS
 	}
 	c, _ := newTestCPU(prog)
 	c.Step() // JSR

--- a/internal/cpu/exec.go
+++ b/internal/cpu/exec.go
@@ -177,12 +177,20 @@ func opCMP(c *CPU, addr uint16, m AddrMode) { cmp(c, c.A, c.Bus.Read(addr)) }
 func opCPX(c *CPU, addr uint16, m AddrMode) { cmp(c, c.X, c.Bus.Read(addr)) }
 func opCPY(c *CPU, addr uint16, m AddrMode) { cmp(c, c.Y, c.Bus.Read(addr)) }
 
-func opINC(c *CPU, addr uint16, m AddrMode) { v := c.Bus.Read(addr) + 1; c.Bus.Write(addr, v); c.setZN(v) }
-func opDEC(c *CPU, addr uint16, m AddrMode) { v := c.Bus.Read(addr) - 1; c.Bus.Write(addr, v); c.setZN(v) }
-func opINX(c *CPU, _ uint16, _ AddrMode)    { c.X++; c.setZN(c.X) }
-func opINY(c *CPU, _ uint16, _ AddrMode)    { c.Y++; c.setZN(c.Y) }
-func opDEX(c *CPU, _ uint16, _ AddrMode)    { c.X--; c.setZN(c.X) }
-func opDEY(c *CPU, _ uint16, _ AddrMode)    { c.Y--; c.setZN(c.Y) }
+func opINC(c *CPU, addr uint16, m AddrMode) {
+	v := c.Bus.Read(addr) + 1
+	c.Bus.Write(addr, v)
+	c.setZN(v)
+}
+func opDEC(c *CPU, addr uint16, m AddrMode) {
+	v := c.Bus.Read(addr) - 1
+	c.Bus.Write(addr, v)
+	c.setZN(v)
+}
+func opINX(c *CPU, _ uint16, _ AddrMode) { c.X++; c.setZN(c.X) }
+func opINY(c *CPU, _ uint16, _ AddrMode) { c.Y++; c.setZN(c.Y) }
+func opDEX(c *CPU, _ uint16, _ AddrMode) { c.X--; c.setZN(c.X) }
+func opDEY(c *CPU, _ uint16, _ AddrMode) { c.Y--; c.setZN(c.Y) }
 
 func opASL(c *CPU, addr uint16, m AddrMode) {
 	v := c.load(addr, m)

--- a/internal/cpu/memory.go
+++ b/internal/cpu/memory.go
@@ -13,8 +13,8 @@ type RAM struct {
 
 func NewRAM() *RAM { return &RAM{} }
 
-func (r *RAM) Read(addr uint16) byte       { return r.Data[addr] }
-func (r *RAM) Write(addr uint16, v byte)   { r.Data[addr] = v }
+func (r *RAM) Read(addr uint16) byte     { return r.Data[addr] }
+func (r *RAM) Write(addr uint16, v byte) { r.Data[addr] = v }
 
 // Load copies bytes into RAM at addr.
 func (r *RAM) Load(addr uint16, data []byte) {

--- a/internal/cpu/opcodes_illegal.go
+++ b/internal/cpu/opcodes_illegal.go
@@ -7,23 +7,25 @@
 //   - https://www.masswerk.at/6502/6502_instruction_set.html
 //
 // Implemented:
-//   LAX  — LDA + LDX (no flag-set surprises beyond setZN)
-//   SAX  — store (A & X), no flag changes
-//   DCP  — DEC then CMP
-//   ISC  — INC then SBC (also called ISB)
-//   SLO  — ASL then ORA
-//   RLA  — ROL then AND
-//   SRE  — LSR then EOR
-//   RRA  — ROR then ADC (decimal-aware via opADC's D-mode branch)
-//   ANC  — AND #imm; C := N (i.e. C := bit7 of result)
-//   ALR  — AND #imm then LSR A
-//   ARR  — AND #imm then ROR A; sets V and C from the result's bits 5/6
-//   SBX  — X := (A & X) - imm  (carry set if no borrow; flags from result)
-//   NOPs — multi-byte / multi-cycle no-ops at undocumented opcode slots
+//
+//	LAX  — LDA + LDX (no flag-set surprises beyond setZN)
+//	SAX  — store (A & X), no flag changes
+//	DCP  — DEC then CMP
+//	ISC  — INC then SBC (also called ISB)
+//	SLO  — ASL then ORA
+//	RLA  — ROL then AND
+//	SRE  — LSR then EOR
+//	RRA  — ROR then ADC (decimal-aware via opADC's D-mode branch)
+//	ANC  — AND #imm; C := N (i.e. C := bit7 of result)
+//	ALR  — AND #imm then LSR A
+//	ARR  — AND #imm then ROR A; sets V and C from the result's bits 5/6
+//	SBX  — X := (A & X) - imm  (carry set if no borrow; flags from result)
+//	NOPs — multi-byte / multi-cycle no-ops at undocumented opcode slots
 //
 // Unstable opcodes (silicon-dependent on bus capacitance / hi-byte+1 ANDs)
 // remain decoded as plain NOPs:
-//   AHX/SHA, SHY, SHX, TAS/SHS, LAS/LAR, XAA/ANE, KIL/JAM
+//
+//	AHX/SHA, SHY, SHX, TAS/SHS, LAS/LAR, XAA/ANE, KIL/JAM
 //
 // These cannot be reliably emulated and no widely-used software depends on
 // them. They occupy 1 byte by default and consume 2 cycles, which matches
@@ -154,8 +156,10 @@ func opALR(c *CPU, addr uint16, _ AddrMode) {
 }
 
 // opARR: A := ROR(A & imm). Then a C/V quirk:
-//   C := bit 6 of result
-//   V := bit 6 XOR bit 5 of result
+//
+//	C := bit 6 of result
+//	V := bit 6 XOR bit 5 of result
+//
 // (Decimal-mode ARR has even weirder behaviour; we implement the binary
 // case here. Real software almost never uses ARR in decimal mode.)
 func opARR(c *CPU, addr uint16, _ AddrMode) {

--- a/internal/tui/cond.go
+++ b/internal/tui/cond.go
@@ -270,11 +270,6 @@ func (p *condParser) accept(k tokKind) bool {
 	}
 	return false
 }
-func (p *condParser) eat() tok {
-	t := p.toks[p.pos]
-	p.pos++
-	return t
-}
 
 // or := and ('||' and)*
 func (p *condParser) parseOr() (evalFn, error) {

--- a/internal/tui/membp_test.go
+++ b/internal/tui/membp_test.go
@@ -39,9 +39,10 @@ func progStaThenLda(ram *cpu.RAM) {
 }
 
 // progLoopWrites writes #$05 to $0210 four times in a row, then BRK.
-//   LDA #$05
-//   STA $0210 ; x4
-//   BRK
+//
+//	LDA #$05
+//	STA $0210 ; x4
+//	BRK
 func progLoopWrites(ram *cpu.RAM) {
 	p := uint16(0x0200)
 	ram.Write(p, 0xA9)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -21,7 +21,6 @@ var (
 	flagOn     = lipgloss.NewStyle().Foreground(lipgloss.Color("46")).Bold(true)
 	flagOff    = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
 	curLine    = lipgloss.NewStyle().Background(lipgloss.Color("236")).Foreground(lipgloss.Color("226")).Bold(true)
-	bpLine     = lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true)
 	help       = lipgloss.NewStyle().Foreground(lipgloss.Color("245")).Italic(true)
 	statusBar  = lipgloss.NewStyle().Background(lipgloss.Color("57")).Foreground(lipgloss.Color("231")).Padding(0, 1)
 	labelStyle = lipgloss.NewStyle().Foreground(lipgloss.Color("207")).Bold(true)
@@ -66,10 +65,10 @@ type Model struct {
 	BPCursor int // selected row in BP manager
 
 	// Source view
-	ShowSource  bool                       // toggle source panel vs disassembly
-	SourceFiles map[string][]string        // filename -> lines (1-indexed via [i-1])
-	PCToSrc     map[uint16]symbols.SrcLoc  // PC -> (file, line)
-	DataRanges  []symbols.Range            // [start,end) regions to render as .byte
+	ShowSource  bool                      // toggle source panel vs disassembly
+	SourceFiles map[string][]string       // filename -> lines (1-indexed via [i-1])
+	PCToSrc     map[uint16]symbols.SrcLoc // PC -> (file, line)
+	DataRanges  []symbols.Range           // [start,end) regions to render as .byte
 
 	// Watch list
 	Watches []Watch
@@ -101,12 +100,10 @@ type disasmCacheEntry struct {
 	addrs        []uint16
 }
 
-type srcLoc = symbols.SrcLoc
-
 func New(c *cpu.CPU, r *cpu.RAM) Model {
 	return Model{
-		CPU:         c,
-		RAM:         r,
+		CPU:          c,
+		RAM:          r,
 		Breakpoints:  map[uint16]*Breakpoint{},
 		MemBPs:       map[uint16]*MemBP{},
 		MemViewAddr:  0x0000,
@@ -916,9 +913,9 @@ func (m Model) watchView(w, h int) string {
 				name = fmt.Sprintf("$%04X", wt.Addr)
 			}
 		}
-		b.WriteString(fmt.Sprintf("%s %s\n",
+		fmt.Fprintf(&b, "%s %s\n",
 			dimAddr.Render(fmt.Sprintf("%-10s", name)),
-			lipgloss.NewStyle().Foreground(lipgloss.Color("231")).Bold(true).Render(val)))
+			lipgloss.NewStyle().Foreground(lipgloss.Color("231")).Bold(true).Render(val))
 	}
 	return fitPanel("Watch", strings.TrimRight(b.String(), "\n"), w, h)
 }
@@ -962,7 +959,7 @@ func (m Model) stackView(w, h int) string {
 		if i == 0 {
 			marker = curLine.Render(" >")
 		}
-		b.WriteString(fmt.Sprintf("%s %s  %02X\n", marker, dimAddr.Render(fmt.Sprintf("$%04X", sp)), m.RAM.Read(sp)))
+		fmt.Fprintf(&b, "%s %s  %02X\n", marker, dimAddr.Render(fmt.Sprintf("$%04X", sp)), m.RAM.Read(sp))
 	}
 	return fitPanel("Stack", strings.TrimRight(b.String(), "\n"), w, h)
 }
@@ -1020,8 +1017,8 @@ func (m Model) disasmView(w, h int) string {
 		// Wide emoji (2 cells) consumes the marker slot; we drop the leading
 		// space to keep the address column aligned with non-PC rows.
 		var marker string
-		switch {
-		case a == pc:
+		switch a {
+		case pc:
 			marker = "\U0001F449"
 		default:
 			if bp, ok := m.Breakpoints[a]; ok {
@@ -1083,7 +1080,6 @@ func walkBack(ram cpu.Bus, pc uint16, n int) []uint16 {
 		return nil
 	}
 	const maxLook = 64 // bytes of lookback
-	bestStart := pc
 	bestSeq := []uint16{}
 	for back := 1; back <= maxLook; back++ {
 		if int(pc)-back < 0 {
@@ -1111,8 +1107,6 @@ func walkBack(ram cpu.Bus, pc uint16, n int) []uint16 {
 		// Prefer sequences with more instructions (closer to a stable boundary).
 		if len(seq) > len(bestSeq) {
 			bestSeq = seq
-			bestStart = start
-			_ = bestStart
 			if len(bestSeq) >= n {
 				break
 			}
@@ -1244,8 +1238,8 @@ func (m Model) sourceView(w, h int) string {
 	for i := start; i < end; i++ {
 		lineNum := i + 1
 		var marker string
-		switch {
-		case lineNum == loc.Line:
+		switch lineNum {
+		case loc.Line:
 			marker = "\U0001F449"
 		default:
 			if bp, ok := bpLines[lineNum]; ok {

--- a/internal/tui/prompt.go
+++ b/internal/tui/prompt.go
@@ -152,7 +152,7 @@ func (m *Model) runCommand(line string) string {
 			}
 			out := m.Watches[:0]
 			for _, w := range m.Watches {
-				if !(w.Kind == "reg" && w.Reg == reg) {
+				if w.Kind != "reg" || w.Reg != reg {
 					out = append(out, w)
 				}
 			}


### PR DESCRIPTION
Adds golangci-lint v2 config, fixes all baseline findings, wires it into CI as a separate ubuntu job. Closes #12