### PR TITLE
ci: add Codecov coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,15 @@ jobs:
         run: go build ./...
 
       - name: go test
-        run: go test -race -count=1 ./...
+        run: go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./...
+
+      - name: Upload coverage to Codecov
+        if: matrix.os == 'ubuntu-latest'
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage.out
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   lint:
     name: lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         run: go build ./...
 
       - name: go test
+        shell: bash
         run: go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./...
 
       - name: Upload coverage to Codecov

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # chippy
 
 [![ci](https://github.com/nkane/chippy/actions/workflows/ci.yml/badge.svg)](https://github.com/nkane/chippy/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/nkane/chippy/branch/main/graph/badge.svg)](https://codecov.io/gh/nkane/chippy)
 [![release](https://img.shields.io/github/v/release/nkane/chippy?sort=semver)](https://github.com/nkane/chippy/releases)
 [![license](https://img.shields.io/github/license/nkane/chippy)](LICENSE)
 


### PR DESCRIPTION
Uploads coverage from the ubuntu test job, adds badge to README. Closes #13