### PR TITLE
feat(example): add four new demo ROMs (count_to_ten, fibonacci, stack_demo, bcd_add)

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,11 @@ programs.
 # Load and let chippy invoke ld65 for you
 ./chippy -rom program.o -cfg linker.cfg
 
-# Try the bundled example
+# Try the bundled examples (see example/README.md for descriptions)
 cd example
-make                              # produces load_five.bin + load_five.dbg
+make                              # builds every demo .bin + .dbg
 ../chippy -rom load_five.bin
+../chippy -rom fibonacci.bin      # or count_to_ten / stack_demo / bcd_add
 ```
 
 Once it's running, press `?` for an in-app help modal, or `:` to open the
@@ -403,7 +404,7 @@ internal/cpu/       6502 core: CPU, RAM, opcodes, disassembler
 internal/loader/    .bin/.prg/.hex/.o loaders
 internal/symbols/   cc65 .dbg parser, symbol + source-line tables
 internal/tui/       Bubble Tea model, panels, modals, commands
-example/            Bundled load_five demo (ca65 source + Makefile)
+example/            Bundled ca65 demo programs (source + shared linker cfg + Makefile)
 ```
 
 ---

--- a/example/Makefile
+++ b/example/Makefile
@@ -1,30 +1,39 @@
-# Build the example program with cc65.
+# Build the example programs with cc65.
+#
+# All programs share load_five.cfg (ROM $8000-$FFFF, reset vector at $FFFC).
 #
 # Targets:
-#   make            -> build load_five.bin (+ .dbg symbol file)
-#   make run        -> build then launch chippy on the binary
+#   make            -> build every .bin (+ .dbg symbol file)
+#   make run        -> build then launch chippy on load_five.bin
+#   make run-<name> -> build then launch chippy on <name>.bin
+#                       e.g. make run-fibonacci
 #   make clean      -> remove build artifacts
 
-SRC := load_five.s
 CFG := load_five.cfg
-OBJ := $(SRC:.s=.o)
-BIN := $(SRC:.s=.bin)
-DBG := $(SRC:.s=.dbg)
+
+PROGRAMS := load_five count_to_ten fibonacci stack_demo bcd_add
+
+OBJS := $(PROGRAMS:=.o)
+BINS := $(PROGRAMS:=.bin)
+DBGS := $(PROGRAMS:=.dbg)
 
 CHIPPY := go run ../cmd/chippy
 
-.PHONY: all run clean
+.PHONY: all run clean $(addprefix run-,$(PROGRAMS))
 
-all: $(BIN)
+all: $(BINS)
 
-$(OBJ): $(SRC)
+%.o: %.s
 	ca65 -g $< -o $@
 
-$(BIN): $(OBJ) $(CFG)
-	ld65 -C $(CFG) -o $(BIN) --dbgfile $(DBG) $(OBJ)
+%.bin: %.o $(CFG)
+	ld65 -C $(CFG) -o $@ --dbgfile $*.dbg $<
 
-run: $(BIN)
-	$(CHIPPY) -rom $(BIN)
+run: load_five.bin
+	$(CHIPPY) -rom load_five.bin
+
+run-%: %.bin
+	$(CHIPPY) -rom $<
 
 clean:
-	rm -f $(OBJ) $(BIN) $(DBG)
+	rm -f $(OBJS) $(BINS) $(DBGS)

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,62 @@
+# chippy example programs
+
+Five small ca65/cc65 programs, all linked against the shared
+`load_five.cfg` (ROM at `$8000-$FFFF`, reset vector at `$FFFC`). Each one is
+self-contained — assemble, then load the resulting `.bin` in chippy.
+
+## Build
+
+Requires [cc65](https://cc65.github.io/) on `$PATH`.
+
+```sh
+make            # builds every .bin + .dbg
+make run        # builds + runs load_five.bin in chippy
+make run-fibonacci   # or run-count_to_ten / run-stack_demo / run-bcd_add
+make clean
+```
+
+## Programs
+
+| Program        | Demonstrates                                   | Final state                              |
+|----------------|------------------------------------------------|------------------------------------------|
+| `load_five`    | Immediate loads into A / X / Y                 | A=X=Y=`$05`                              |
+| `count_to_ten` | INX loop with `CPX` / `BNE`                    | X=`$0A`, Z=1                             |
+| `fibonacci`    | Zero-page state, ADC carry-out, indexed store  | 13 bytes at `$0200..$020C`, X=`$0D`      |
+| `stack_demo`   | `PHA` / `PLA` order, register transfers        | A=`$11`, X=`$33`, Y=`$22`, SP=`$FF`      |
+| `bcd_add`      | `SED` + `ADC` decimal-mode arithmetic          | A=`$07`, X=`$01` (BCD: 49 + 58 = 107)    |
+
+All programs spin on a `JMP halt` so the TUI keeps showing the final state.
+
+## Suggested chippy session
+
+Try fibonacci with watchpoints on the result table:
+
+```
+:bpw $0200 log fib[0]={[$0200]}
+:watch $0200 byte fib0
+:watch $0201 byte fib1
+:watch $0202 byte fib2
+r
+```
+
+Or watch BCD math step by step:
+
+```
+chippy -rom bcd_add.bin
+:bp start
+r
+s s s s s s s s s s s s
+```
+
+## Layout
+
+All programs share `load_five.cfg`:
+
+```
+MEMORY  ROM: $8000 size $8000 fill $00
+SEGMENT CODE   @ $8000
+SEGMENT VECTORS @ $FFFA  (NMI / RESET / IRQ words)
+```
+
+Add a new demo by dropping `myprog.s` next to the others and adding
+`myprog` to the `PROGRAMS` list in the `Makefile`.

--- a/example/bcd_add.s
+++ b/example/bcd_add.s
@@ -1,0 +1,43 @@
+; bcd_add.s — add two BCD-encoded values with the decimal flag set.
+;
+; Demonstrates: SED/CLD, ADC in decimal mode, multi-byte BCD addition with
+; carry propagation. Verifies chippy's BCD implementation (issue #1).
+;
+; Computes 49 + 58 = 107 (BCD), stored as low byte $07 in A and high byte
+; $01 in X (carry-in for the next column).
+;
+; Operand bytes live in zero page so the math is easy to follow in the TUI:
+;   $10 = $49   (operand A, low BCD pair)
+;   $11 = $58   (operand B, low BCD pair)
+;
+; Final state: A = $07, X = $01, D flag = 1, C = 0 (after the high-byte add).
+;
+; Build with cc65:
+;   ca65 bcd_add.s -o bcd_add.o
+;   ld65 -C load_five.cfg -o bcd_add.bin --dbgfile bcd_add.dbg bcd_add.o
+
+.segment "CODE"
+
+.proc start
+        sed                     ; enable decimal mode
+        lda     #$49
+        sta     $10
+        lda     #$58
+        sta     $11
+
+        clc
+        lda     $10
+        adc     $11             ; A = $07, C = 1 (BCD: 49 + 58 = 107)
+
+        ldx     #$00
+        bcc     nocarry
+        inx                     ; X = $01 carry into next BCD column
+nocarry:
+        cld                     ; back to binary mode for cleanliness
+halt:   jmp     halt
+.endproc
+
+.segment "VECTORS"
+        .word   start           ; NMI   ($FFFA)
+        .word   start           ; RESET ($FFFC)
+        .word   start           ; IRQ   ($FFFE)

--- a/example/count_to_ten.s
+++ b/example/count_to_ten.s
@@ -1,0 +1,27 @@
+; count_to_ten.s — increment X from 0 to 10 using a loop, then halt.
+;
+; Demonstrates: register init, INX, CMP-immediate, conditional branch (BNE).
+;
+; Build with cc65:
+;   ca65 count_to_ten.s -o count_to_ten.o
+;   ld65 -C load_five.cfg -o count_to_ten.bin --dbgfile count_to_ten.dbg count_to_ten.o
+;
+; Run in chippy:
+;   chippy -rom example/count_to_ten.bin
+;
+; Expected final state: X = $0A, Z = 1 (CMP matched).
+
+.segment "CODE"
+
+.proc start
+        ldx     #$00            ; X = 0
+loop:   inx                     ; X++
+        cpx     #$0A            ; reached 10?
+        bne     loop            ; no -> keep counting
+halt:   jmp     halt            ; spin so the TUI keeps showing final state
+.endproc
+
+.segment "VECTORS"
+        .word   start           ; NMI   ($FFFA)
+        .word   start           ; RESET ($FFFC)
+        .word   start           ; IRQ   ($FFFE)

--- a/example/fibonacci.s
+++ b/example/fibonacci.s
@@ -1,0 +1,59 @@
+; fibonacci.s — compute Fibonacci numbers in zero page until overflow, then halt.
+;
+; Demonstrates: zero-page storage, ADC with carry tracking, BCC branch on
+; carry-out, indexed store into a result table.
+;
+; Layout:
+;   $00     prev   (F[n-1])
+;   $01     curr   (F[n])
+;   $02     idx    (next slot in $0200..)
+;   $0200+  result table of 8-bit Fibonacci values, terminated when overflow hits.
+;
+; Sequence stored at $0200: 01 01 02 03 05 08 0D 15 22 37 59 90 E9 (next would
+; overflow 8 bits so we stop). Total 13 entries.
+;
+; Build with cc65:
+;   ca65 fibonacci.s -o fibonacci.o
+;   ld65 -C load_five.cfg -o fibonacci.bin --dbgfile fibonacci.dbg fibonacci.o
+
+.segment "CODE"
+
+prev = $00
+curr = $01
+idx  = $02
+
+.proc start
+        lda     #$01
+        sta     prev            ; F[0] = 1
+        sta     curr            ; F[1] = 1
+        ldx     #$00
+        stx     idx
+
+        ; Store the two seed values at $0200, $0201.
+        sta     $0200
+        sta     $0201
+        lda     #$02
+        sta     idx
+
+next:   clc
+        lda     prev
+        adc     curr            ; A = prev + curr
+        bcs     done            ; overflow -> stop
+        ldx     idx
+        sta     $0200,x         ; result[idx] = A
+        inx
+        stx     idx
+        ; Shift window: prev <- curr, curr <- A.
+        ldy     curr
+        sty     prev
+        sta     curr
+        jmp     next
+
+done:   ; idx holds the count of stored entries.
+halt:   jmp     halt
+.endproc
+
+.segment "VECTORS"
+        .word   start           ; NMI   ($FFFA)
+        .word   start           ; RESET ($FFFC)
+        .word   start           ; IRQ   ($FFFE)

--- a/example/stack_demo.s
+++ b/example/stack_demo.s
@@ -1,0 +1,42 @@
+; stack_demo.s — push three bytes, pull them back into different registers.
+;
+; Demonstrates: stack pointer behavior, PHA, PLA, and TAX/TAY for moving
+; the pulled value into X / Y.
+;
+; Push order: $11, $22, $33  (SP decrements each push)
+; Pull order: pulls in reverse so:
+;   A <- $33 (then TAX -> X = $33)
+;   A <- $22 (then TAY -> Y = $22)
+;   A <- $11 (left in A)
+;
+; Final state: A=$11, X=$33, Y=$22, SP back to $FF.
+;
+; Build with cc65:
+;   ca65 stack_demo.s -o stack_demo.o
+;   ld65 -C load_five.cfg -o stack_demo.bin --dbgfile stack_demo.dbg stack_demo.o
+
+.segment "CODE"
+
+.proc start
+        ldx     #$FF            ; reset stack pointer to top of page 1
+        txs
+
+        lda     #$11
+        pha                     ; push $11
+        lda     #$22
+        pha                     ; push $22
+        lda     #$33
+        pha                     ; push $33
+
+        pla                     ; A = $33
+        tax                     ; X = $33
+        pla                     ; A = $22
+        tay                     ; Y = $22
+        pla                     ; A = $11
+halt:   jmp     halt
+.endproc
+
+.segment "VECTORS"
+        .word   start           ; NMI   ($FFFA)
+        .word   start           ; RESET ($FFFC)
+        .word   start           ; IRQ   ($FFFE)


### PR DESCRIPTION
## Summary

- Adds four new ca65 demo programs alongside `load_five`, each exercising a distinct slice of the CPU.
- Refactors `example/Makefile` to pattern rules; all programs share the existing `load_five.cfg`.
- Adds `example/README.md` describing every demo, expected final state, and a sample chippy session.

## Programs

| Program        | Demonstrates                                  | Final state                          |
|----------------|-----------------------------------------------|--------------------------------------|
| load_five      | Immediate loads into A / X / Y                | A=X=Y=$05                           |
| count_to_ten   | INX loop + CPX/BNE                            | X=$0A, Z=1                          |
| fibonacci      | Zero-page state, ADC carry-out, indexed store | 13 bytes at $0200..$020C, X=$0D   |
| stack_demo     | PHA/PLA order + register transfers            | A=$11, X=$33, Y=$22, SP=$FF      |
| bcd_add        | SED + ADC decimal-mode arithmetic             | A=$07, X=$01 (BCD: 49+58=107)      |

## Verification

- `make -C example` builds all five `.bin`s + `.dbg`s with `cc65`.
- Wrote a temporary harness that runs each ROM until the `JMP halt` spin and confirmed the expected final register state (harness removed before commit).
- `go build ./... && go test -race -count=1 ./...` green.