### PR TITLE
feat(cpu): hardware IRQ and NMI with edge/level semantics

### DIFF
--- a/internal/cpu/cpu.go
+++ b/internal/cpu/cpu.go
@@ -53,6 +53,16 @@ type CPU struct {
 
 	// opcodes is the active opcode table; chosen from Variant in New/Reset.
 	opcodes *[256]Instr
+
+	// Interrupt lines.
+	//   - irqLine: level-triggered. While true and FlagI is clear, IRQ
+	//     fires at every instruction boundary.
+	//   - nmiPending: edge-triggered latch. TriggerNMI sets it; the
+	//     dispatcher clears it after servicing. Holding the line asserted
+	//     does NOT cause repeated NMIs — the caller must call TriggerNMI
+	//     again (matching real silicon's edge sensitivity).
+	irqLine    bool
+	nmiPending bool
 }
 
 func New(bus Bus) *CPU {
@@ -125,7 +135,24 @@ func (c *CPU) pop16() uint16 {
 }
 
 // IRQ / NMI
-func (c *CPU) NMI() {
+
+// AssertIRQ raises the IRQ line. While asserted and FlagI is clear, the
+// interrupt is taken at the end of every instruction. Peripherals call
+// AssertIRQ when their condition is active and ReleaseIRQ when cleared.
+func (c *CPU) AssertIRQ()  { c.irqLine = true }
+func (c *CPU) ReleaseIRQ() { c.irqLine = false }
+
+// IRQAsserted reports whether the IRQ line is currently held.
+func (c *CPU) IRQAsserted() bool { return c.irqLine }
+
+// TriggerNMI latches a non-maskable interrupt. Edge-triggered: the
+// dispatcher takes the interrupt once, then clears the latch. Calling
+// TriggerNMI repeatedly while one is already pending coalesces into a
+// single NMI.
+func (c *CPU) TriggerNMI() { c.nmiPending = true }
+
+// serviceNMI performs the 7-cycle NMI vector dispatch.
+func (c *CPU) serviceNMI() {
 	c.push16(c.PC)
 	c.push((c.P | FlagU) &^ FlagB)
 	c.setFlag(FlagI, true)
@@ -133,12 +160,12 @@ func (c *CPU) NMI() {
 	hi := uint16(c.Bus.Read(VecNMI + 1))
 	c.PC = lo | hi<<8
 	c.Cycles += 7
+	c.nmiPending = false
 }
 
-func (c *CPU) IRQ() {
-	if c.hasFlag(FlagI) {
-		return
-	}
+// serviceIRQ performs the 7-cycle IRQ vector dispatch. Caller must have
+// already verified FlagI is clear.
+func (c *CPU) serviceIRQ() {
 	c.push16(c.PC)
 	c.push((c.P | FlagU) &^ FlagB)
 	c.setFlag(FlagI, true)

--- a/internal/cpu/exec.go
+++ b/internal/cpu/exec.go
@@ -3,7 +3,29 @@ package cpu
 // Step executes one instruction. Returns cycles consumed.
 // If the instruction is an infinite tight loop (PC unchanged afterwards) the
 // CPU is marked Halted so callers can stop free-running.
+//
+// Pending interrupts are serviced at the instruction boundary BEFORE the
+// next opcode is fetched. NMI is checked first (always taken) then IRQ
+// (only if FlagI is clear). Servicing an interrupt clears Halted so a
+// program spinning in a wait-loop can be woken by a peripheral.
 func (c *CPU) Step() int {
+	// Service pending interrupts at the boundary. An interrupt service is
+	// itself a 7-cycle operation; we do NOT also execute an instruction in
+	// the same Step. The next call to Step will fetch the first opcode of
+	// the handler.
+	if c.nmiPending {
+		c.Halted = false
+		before := c.Cycles
+		c.serviceNMI()
+		return int(c.Cycles - before)
+	}
+	if c.irqLine && !c.hasFlag(FlagI) {
+		c.Halted = false
+		before := c.Cycles
+		c.serviceIRQ()
+		return int(c.Cycles - before)
+	}
+
 	if c.Halted {
 		return 0
 	}

--- a/internal/cpu/interrupts_test.go
+++ b/internal/cpu/interrupts_test.go
@@ -1,0 +1,193 @@
+package cpu
+
+import "testing"
+
+// installVector writes a little-endian vector value at addr.
+func installVector(r *RAM, addr, target uint16) {
+	r.Write(addr, byte(target&0xFF))
+	r.Write(addr+1, byte(target>>8))
+}
+
+// --- IRQ masking ---
+
+func TestIRQ_MaskedWhenISet(t *testing.T) {
+	// Program at $8000: NOP ; NOP ; NOP
+	c, r := newTestCPU([]byte{0xEA, 0xEA, 0xEA})
+	installVector(r, VecIRQ, 0x9000)
+	c.setFlag(FlagI, true) // mask IRQs
+	c.AssertIRQ()
+	c.Step()
+	if c.PC != 0x8001 {
+		t.Fatalf("IRQ taken while masked: PC=%04X want 8001", c.PC)
+	}
+}
+
+func TestIRQ_FiresWhenIClear(t *testing.T) {
+	c, r := newTestCPU([]byte{0xEA, 0xEA})
+	installVector(r, VecIRQ, 0x9000)
+	c.setFlag(FlagI, false)
+	c.AssertIRQ()
+	cyc := c.Step()
+	if c.PC != 0x9000 {
+		t.Fatalf("IRQ not taken: PC=%04X want 9000", c.PC)
+	}
+	if cyc != 7 {
+		t.Fatalf("IRQ cycles wrong: %d want 7", cyc)
+	}
+	if !c.hasFlag(FlagI) {
+		t.Fatalf("FlagI not set after IRQ dispatch")
+	}
+}
+
+func TestIRQ_PushesPWithBClear(t *testing.T) {
+	c, r := newTestCPU([]byte{0xEA})
+	installVector(r, VecIRQ, 0x9000)
+	c.setFlag(FlagI, false)
+	c.setFlag(FlagN, true) // arbitrary state we expect to see preserved
+	c.AssertIRQ()
+	spBefore := c.SP
+	c.Step()
+	// Stack after IRQ: pushed PCH, PCL, P at SP+1, SP+2, SP+3 (post-decrement).
+	pushedP := c.Bus.Read(0x0100 | uint16(spBefore-2))
+	if pushedP&FlagB != 0 {
+		t.Fatalf("IRQ pushed P with B set: %02X", pushedP)
+	}
+	if pushedP&FlagU == 0 {
+		t.Fatalf("IRQ pushed P with U clear: %02X", pushedP)
+	}
+	if pushedP&FlagN == 0 {
+		t.Fatalf("IRQ lost FlagN in pushed P: %02X", pushedP)
+	}
+}
+
+// --- NMI ---
+
+func TestNMI_FiresEvenWhenIRQMasked(t *testing.T) {
+	c, r := newTestCPU([]byte{0xEA})
+	installVector(r, VecNMI, 0x9100)
+	c.setFlag(FlagI, true)
+	c.TriggerNMI()
+	c.Step()
+	if c.PC != 0x9100 {
+		t.Fatalf("NMI not taken with I set: PC=%04X want 9100", c.PC)
+	}
+}
+
+func TestNMI_PushesPWithBClear(t *testing.T) {
+	c, r := newTestCPU([]byte{0xEA})
+	installVector(r, VecNMI, 0x9100)
+	c.TriggerNMI()
+	spBefore := c.SP
+	c.Step()
+	pushedP := c.Bus.Read(0x0100 | uint16(spBefore-2))
+	if pushedP&FlagB != 0 {
+		t.Fatalf("NMI pushed P with B set: %02X", pushedP)
+	}
+}
+
+// --- Edge vs level semantics ---
+
+// IRQ is level-triggered: while the line stays asserted the handler will be
+// re-entered after RTI. Simulate one full IRQ -> RTI cycle and confirm
+// re-entry.
+func TestIRQ_LevelReentersAfterRTI(t *testing.T) {
+	// $8000: NOP (target after RTI)
+	// IRQ vector -> $9000: RTI
+	c, r := newTestCPU([]byte{0xEA, 0xEA})
+	installVector(r, VecIRQ, 0x9000)
+	r.Write(0x9000, 0x40) // RTI
+	c.setFlag(FlagI, false)
+	c.AssertIRQ() // line held
+
+	c.Step() // service IRQ -> PC=$9000, FlagI=1
+	if c.PC != 0x9000 {
+		t.Fatalf("first IRQ dispatch wrong: PC=%04X", c.PC)
+	}
+	c.Step() // execute RTI -> PC restored, FlagI restored to 0
+	if c.PC != 0x8000 {
+		t.Fatalf("RTI didn't restore PC: %04X want 8000", c.PC)
+	}
+	if c.hasFlag(FlagI) {
+		t.Fatalf("RTI didn't restore FlagI=0")
+	}
+	// Line still held: next Step should re-enter the handler.
+	c.Step()
+	if c.PC != 0x9000 {
+		t.Fatalf("level IRQ did not re-fire: PC=%04X want 9000", c.PC)
+	}
+}
+
+// IRQ released before next boundary should not fire.
+func TestIRQ_ReleaseStopsFiring(t *testing.T) {
+	c, r := newTestCPU([]byte{0xEA, 0xEA})
+	installVector(r, VecIRQ, 0x9000)
+	c.setFlag(FlagI, false)
+	c.AssertIRQ()
+	c.ReleaseIRQ()
+	c.Step()
+	if c.PC != 0x8001 {
+		t.Fatalf("released IRQ still fired: PC=%04X", c.PC)
+	}
+}
+
+// NMI is edge-triggered: holding (or repeating TriggerNMI before RTI) must
+// produce only ONE service. After RTI, a second TriggerNMI is required.
+func TestNMI_EdgeFiresOnce(t *testing.T) {
+	// $8000: NOP, NMI vector -> $9100: RTI
+	c, r := newTestCPU([]byte{0xEA, 0xEA, 0xEA})
+	installVector(r, VecNMI, 0x9100)
+	r.Write(0x9100, 0x40) // RTI
+
+	c.TriggerNMI()
+	c.TriggerNMI() // coalesces — still one pending
+	c.Step()       // service
+	if c.PC != 0x9100 {
+		t.Fatalf("NMI dispatch wrong: PC=%04X", c.PC)
+	}
+	c.Step() // RTI
+	if c.PC != 0x8000 {
+		t.Fatalf("RTI from NMI wrong: PC=%04X", c.PC)
+	}
+	// No new TriggerNMI -> next Step must execute NOP, not re-enter.
+	c.Step()
+	if c.PC != 0x8001 {
+		t.Fatalf("NMI re-fired without new edge: PC=%04X want 8001", c.PC)
+	}
+}
+
+// After RTI we can re-arm NMI with another TriggerNMI call.
+func TestNMI_ReArmsAfterRTI(t *testing.T) {
+	c, r := newTestCPU([]byte{0xEA, 0xEA})
+	installVector(r, VecNMI, 0x9100)
+	r.Write(0x9100, 0x40) // RTI
+
+	c.TriggerNMI()
+	c.Step() // dispatch
+	c.Step() // RTI
+	c.TriggerNMI()
+	c.Step()
+	if c.PC != 0x9100 {
+		t.Fatalf("re-armed NMI did not fire: PC=%04X", c.PC)
+	}
+}
+
+// --- Halted CPU wakes on interrupt ---
+
+func TestIRQ_WakesHaltedCPU(t *testing.T) {
+	// JMP self at $8000 (4C 00 80) — Step() marks Halted=true.
+	c, r := newTestCPU([]byte{0x4C, 0x00, 0x80})
+	installVector(r, VecIRQ, 0x9000)
+	c.setFlag(FlagI, false)
+	c.Step()
+	if !c.Halted {
+		t.Fatalf("self-JMP didn't halt CPU")
+	}
+	c.AssertIRQ()
+	c.Step()
+	if c.Halted {
+		t.Fatalf("IRQ didn't wake halted CPU")
+	}
+	if c.PC != 0x9000 {
+		t.Fatalf("IRQ from halted didn't vector: PC=%04X", c.PC)
+	}
+}


### PR DESCRIPTION
## Summary
- Replace immediate-fire `IRQ()`/`NMI()` with a pending-interrupt model serviced at instruction boundaries by `Step()`
- `AssertIRQ`/`ReleaseIRQ` are level-triggered; `TriggerNMI` is an edge-triggered latch
- Servicing pushes PC + (P with B clear, U set), sets `FlagI`, jumps via $FFFA / $FFFE, costs 7 cycles, and is the entire Step
- A pending interrupt wakes a self-jump-`Halted` CPU

## Tests
- IRQ masked when I=1; fires when I=0
- Pushed P has B clear, U set, and preserves caller flags
- NMI fires regardless of FlagI
- Level IRQ re-enters handler after RTI while line held; release stops re-fire
- Edge NMI fires once even with repeated `TriggerNMI`; re-arms after RTI
- Halted CPU (self-JMP) wakes on IRQ

Closes #10