### PR TITLE
feat(mmio): peripheral abstraction with Apple-1-style text+keyboard

### DIFF
--- a/cmd/chippy/main.go
+++ b/cmd/chippy/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/nkane/chippy/internal/cpu"
 	"github.com/nkane/chippy/internal/loader"
+	"github.com/nkane/chippy/internal/peripheral"
 	"github.com/nkane/chippy/internal/symbols"
 	"github.com/nkane/chippy/internal/tui"
 )
@@ -107,16 +108,37 @@ func main() {
 		}
 	}
 
-	c := cpu.NewVariant(ram, variant)
+	// MMIO bus sits between WBus and RAM. Peripherals registered here
+	// intercept reads/writes to their claimed regions; everything else
+	// falls through to RAM. Note: the loader and the reset-vector helpers
+	// above write directly to `ram`, deliberately bypassing MMIO, so a
+	// program loaded at $F001 would land in RAM and never reach the
+	// peripheral — peripherals live in addresses no ROM should occupy.
+	mmio := cpu.NewMMIO(ram)
+	textOut := peripheral.NewTextOutput(0xF001)
+	keyIn := peripheral.NewKeyboardInput(0xF004, 0xF005)
+	if err := mmio.Register(textOut); err != nil {
+		fmt.Fprintln(os.Stderr, "register text output:", err)
+		os.Exit(1)
+	}
+	if err := mmio.Register(keyIn); err != nil {
+		fmt.Fprintln(os.Stderr, "register keyboard:", err)
+		os.Exit(1)
+	}
+
+	c := cpu.NewVariant(mmio, variant)
 
 	// Wrap the bus with WBus so memory watchpoints can intercept reads/writes.
-	// We construct CPU on raw RAM first (to keep cpu.New's signature simple),
+	// We construct CPU on MMIO first (to keep cpu.New's signature simple),
 	// then swap c.Bus to the wrapper. WithWBus attaches the CPU pointer and
 	// hands the watch map to the wrapper.
-	wbus := tui.NewWBus(ram)
+	wbus := tui.NewWBus(mmio)
 	c.Bus = wbus
 
-	model := tui.New(c, ram).WithWBus(wbus)
+	model := tui.New(c, ram).
+		WithWBus(wbus).
+		WithTextOutput(textOut).
+		WithKeyboard(keyIn)
 	if syms != nil {
 		model = model.WithSymbols(syms)
 	}

--- a/example/Makefile
+++ b/example/Makefile
@@ -11,7 +11,7 @@
 
 CFG := load_five.cfg
 
-PROGRAMS := load_five count_to_ten fibonacci stack_demo bcd_add cmos_demo
+PROGRAMS := load_five count_to_ten fibonacci stack_demo bcd_add cmos_demo hello
 
 OBJS := $(PROGRAMS:=.o)
 BINS := $(PROGRAMS:=.bin)

--- a/example/hello.s
+++ b/example/hello.s
@@ -1,0 +1,34 @@
+; hello.s — write "HELLO\n" to the TextOutput peripheral, then halt.
+;
+; Demonstrates: memory-mapped I/O. The TextOutput peripheral lives at
+;   $F001 (write-only). Each byte written is appended to the TUI's
+;   Output panel. The KeyboardInput peripheral (not used here) lives at
+;   $F004/$F005.
+;
+; Build with cc65:
+;   ca65 hello.s -o hello.o
+;   ld65 -C load_five.cfg -o hello.bin --dbgfile hello.dbg hello.o
+;
+; Run in chippy:
+;   chippy -rom example/hello.bin
+
+OUT     = $F001
+
+.segment "CODE"
+
+.proc start
+        ldx     #$00            ; index into the message
+loop:   lda     msg,x           ; load next byte
+        beq     done            ; zero terminator -> stop
+        sta     OUT             ; emit to TextOutput
+        inx
+        bne     loop            ; <256 chars guaranteed
+done:   jmp     done            ; spin so the final state stays on screen
+.endproc
+
+msg:    .byte   "HELLO", $0D, $00
+
+.segment "VECTORS"
+        .word   start           ; NMI   ($FFFA)
+        .word   start           ; RESET ($FFFC)
+        .word   start           ; IRQ   ($FFFE)

--- a/internal/cpu/mmio_e2e_test.go
+++ b/internal/cpu/mmio_e2e_test.go
@@ -1,0 +1,101 @@
+package cpu_test
+
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/nkane/chippy/internal/cpu"
+	"github.com/nkane/chippy/internal/loader"
+	"github.com/nkane/chippy/internal/peripheral"
+)
+
+// TestMMIOHelloDemo_E2E loads example/hello.bin under a MMIO bus that
+// routes $F001 writes to a TextOutput peripheral, and verifies the
+// peripheral's buffer ends with "HELLO\n" — covering the acceptance
+// criterion for issue #16.
+func TestMMIOHelloDemo_E2E(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Skip("can't locate test file")
+	}
+	bin := filepath.Join(filepath.Dir(thisFile), "..", "..", "example", "hello.bin")
+
+	ram := cpu.NewRAM()
+	if _, err := loader.Load(ram, bin, loader.Options{Addr: 0x8000}); err != nil {
+		t.Skipf("hello.bin not built (run `make -C example hello.bin`): %v", err)
+	}
+
+	mmio := cpu.NewMMIO(ram)
+	out := peripheral.NewTextOutput(0xF001)
+	if err := mmio.Register(out); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	c := cpu.New(mmio)
+	for i := 0; i < 200 && !c.Halted; i++ {
+		c.Step()
+	}
+	if !c.Halted {
+		t.Fatalf("program never halted; PC=%04X", c.PC)
+	}
+
+	// hello.s emits "HELLO" + CR; the peripheral translates CR to LF.
+	if got := out.String(); got != "HELLO\n" {
+		t.Fatalf("output = %q, want %q", got, "HELLO\n")
+	}
+
+	// Bytes that went to MMIO must NOT have leaked into RAM.
+	if ram.Data[0xF001] != 0 {
+		t.Fatalf("RAM at $F001 should be untouched; got %02X", ram.Data[0xF001])
+	}
+}
+
+// TestMMIOKeyboard_E2E uses a tiny inline program to verify the keyboard
+// status/data path through MMIO without depending on an assembled .bin.
+//
+// Program (at $8000):
+//
+//	loop:  LDA $F005       ; AD 05 F0  ; poll status (bit7 = key ready)
+//	       BPL loop        ; 10 FB     ; loop while bit7 clear
+//	       LDA $F004       ; AD 04 F0  ; read data — clears ready
+//	       STA $0010       ; 85 10     ; store at $0010 so the test can assert
+//	stop:  JMP stop        ; 4C 0A 80
+//
+// Push a key, run the program, expect $0010 = key | 0x80.
+func TestMMIOKeyboard_E2E(t *testing.T) {
+	ram := cpu.NewRAM()
+	prog := []byte{
+		0xAD, 0x05, 0xF0, // LDA $F005
+		0x10, 0xFB, //       BPL loop  (-5)
+		0xAD, 0x04, 0xF0, // LDA $F004
+		0x85, 0x10, //       STA $10
+		0x4C, 0x0A, 0x80, // JMP $800A  (stop:)
+	}
+	ram.Load(0x8000, prog)
+	ram.Write(cpu.VecReset, 0x00)
+	ram.Write(cpu.VecReset+1, 0x80)
+
+	mmio := cpu.NewMMIO(ram)
+	kb := peripheral.NewKeyboardInput(0xF004, 0xF005)
+	if err := mmio.Register(kb); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	c := cpu.New(mmio)
+	// Push 'Q' before stepping — program polls and reads on first ready.
+	kb.Push('Q')
+
+	for i := 0; i < 200 && !c.Halted; i++ {
+		c.Step()
+	}
+	if !c.Halted {
+		t.Fatalf("program never halted; PC=%04X", c.PC)
+	}
+	if got := ram.Read(0x0010); got != ('Q' | 0x80) {
+		t.Fatalf("$0010 = %02X, want %02X", got, byte('Q')|0x80)
+	}
+	if kb.Ready() {
+		t.Fatalf("keyboard Ready should have drained on data read")
+	}
+}

--- a/internal/cpu/peripheral.go
+++ b/internal/cpu/peripheral.go
@@ -1,0 +1,74 @@
+package cpu
+
+import "fmt"
+
+// Peripheral is a memory-mapped device that claims an inclusive [lo, hi]
+// region of the 64KB address space. Reads and writes to that region are
+// routed to the peripheral instead of the underlying Bus.
+//
+// Range() must be stable for the lifetime of the peripheral. Read/Write are
+// called by the CPU through MMIO and may have side effects (e.g. a keyboard
+// status register that clears the "data ready" bit on data read).
+type Peripheral interface {
+	Range() (lo, hi uint16)
+	Read(addr uint16) byte
+	Write(addr uint16, v byte)
+}
+
+// MMIO is a Bus that dispatches reads and writes to registered peripherals
+// before falling back to an underlying Bus (typically RAM).
+//
+// Lookup is a linear scan: the number of peripherals in a typical 6502
+// system is small (single digits), and a scan stays branch-predictor-friendly
+// in the common no-MMIO case where the slice is empty. If a system grows
+// past ~16 peripherals, switch to a 256-entry page table keyed on addr>>8.
+type MMIO struct {
+	Inner       Bus
+	peripherals []Peripheral
+}
+
+func NewMMIO(inner Bus) *MMIO { return &MMIO{Inner: inner} }
+
+// Register adds a peripheral. Returns an error if its range overlaps an
+// already-registered peripheral. Order of registration does not matter
+// because overlap is forbidden.
+func (m *MMIO) Register(p Peripheral) error {
+	lo, hi := p.Range()
+	if lo > hi {
+		return fmt.Errorf("peripheral range invalid: lo=%04X > hi=%04X", lo, hi)
+	}
+	for _, q := range m.peripherals {
+		qlo, qhi := q.Range()
+		if lo <= qhi && qlo <= hi {
+			return fmt.Errorf("peripheral range %04X-%04X overlaps existing %04X-%04X", lo, hi, qlo, qhi)
+		}
+	}
+	m.peripherals = append(m.peripherals, p)
+	return nil
+}
+
+// Peripherals returns the currently registered peripherals in registration
+// order. The returned slice aliases internal storage; callers must not
+// mutate it.
+func (m *MMIO) Peripherals() []Peripheral { return m.peripherals }
+
+func (m *MMIO) Read(addr uint16) byte {
+	for _, p := range m.peripherals {
+		lo, hi := p.Range()
+		if addr >= lo && addr <= hi {
+			return p.Read(addr)
+		}
+	}
+	return m.Inner.Read(addr)
+}
+
+func (m *MMIO) Write(addr uint16, v byte) {
+	for _, p := range m.peripherals {
+		lo, hi := p.Range()
+		if addr >= lo && addr <= hi {
+			p.Write(addr, v)
+			return
+		}
+	}
+	m.Inner.Write(addr, v)
+}

--- a/internal/cpu/peripheral_test.go
+++ b/internal/cpu/peripheral_test.go
@@ -1,0 +1,132 @@
+package cpu
+
+import "testing"
+
+// fakePeripheral is a counted-access stub used by the MMIO routing tests.
+type fakePeripheral struct {
+	lo, hi uint16
+	reads  []uint16
+	writes []struct {
+		addr uint16
+		v    byte
+	}
+	readVal byte
+}
+
+func (f *fakePeripheral) Range() (uint16, uint16) { return f.lo, f.hi }
+func (f *fakePeripheral) Read(addr uint16) byte {
+	f.reads = append(f.reads, addr)
+	return f.readVal
+}
+func (f *fakePeripheral) Write(addr uint16, v byte) {
+	f.writes = append(f.writes, struct {
+		addr uint16
+		v    byte
+	}{addr, v})
+}
+
+func TestMMIOFallthroughToRAM(t *testing.T) {
+	ram := NewRAM()
+	m := NewMMIO(ram)
+
+	m.Write(0x0200, 0x42)
+	if got := m.Read(0x0200); got != 0x42 {
+		t.Fatalf("want 0x42, got 0x%02X", got)
+	}
+	if ram.Data[0x0200] != 0x42 {
+		t.Fatalf("underlying RAM not written")
+	}
+}
+
+func TestMMIODispatchesReadsAndWrites(t *testing.T) {
+	ram := NewRAM()
+	m := NewMMIO(ram)
+	p := &fakePeripheral{lo: 0xF001, hi: 0xF001, readVal: 0xAB}
+	if err := m.Register(p); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	m.Write(0xF001, 0x55)
+	if len(p.writes) != 1 || p.writes[0].addr != 0xF001 || p.writes[0].v != 0x55 {
+		t.Fatalf("peripheral did not see write: %+v", p.writes)
+	}
+	if ram.Data[0xF001] != 0x00 {
+		t.Fatalf("RAM should not be written when peripheral claims address; got 0x%02X", ram.Data[0xF001])
+	}
+
+	got := m.Read(0xF001)
+	if got != 0xAB {
+		t.Fatalf("peripheral read mismatch: got 0x%02X", got)
+	}
+	if len(p.reads) != 1 || p.reads[0] != 0xF001 {
+		t.Fatalf("peripheral did not see read: %+v", p.reads)
+	}
+}
+
+func TestMMIOOnlyRoutesInsideRange(t *testing.T) {
+	ram := NewRAM()
+	m := NewMMIO(ram)
+	p := &fakePeripheral{lo: 0xF000, hi: 0xF00F, readVal: 0x11}
+	_ = m.Register(p)
+
+	// Address just below range falls through to RAM.
+	m.Write(0xEFFF, 0x77)
+	if ram.Data[0xEFFF] != 0x77 {
+		t.Fatalf("address below peripheral range should hit RAM")
+	}
+	if len(p.writes) != 0 {
+		t.Fatalf("peripheral should not see writes below its range")
+	}
+
+	// Address just above range falls through to RAM.
+	m.Write(0xF010, 0x88)
+	if ram.Data[0xF010] != 0x88 {
+		t.Fatalf("address above peripheral range should hit RAM")
+	}
+
+	// Boundary addresses are inclusive on both ends.
+	m.Write(0xF000, 0x01)
+	m.Write(0xF00F, 0x02)
+	if len(p.writes) != 2 {
+		t.Fatalf("peripheral should see both boundary writes, got %d", len(p.writes))
+	}
+}
+
+func TestMMIOOverlapRejected(t *testing.T) {
+	m := NewMMIO(NewRAM())
+	a := &fakePeripheral{lo: 0xF000, hi: 0xF00F}
+	b := &fakePeripheral{lo: 0xF008, hi: 0xF017}
+
+	if err := m.Register(a); err != nil {
+		t.Fatalf("first register failed: %v", err)
+	}
+	if err := m.Register(b); err == nil {
+		t.Fatalf("overlapping register should fail")
+	}
+}
+
+func TestMMIOInvalidRange(t *testing.T) {
+	m := NewMMIO(NewRAM())
+	if err := m.Register(&fakePeripheral{lo: 0xF010, hi: 0xF000}); err == nil {
+		t.Fatalf("inverted range should fail")
+	}
+}
+
+func TestMMIOFirstPeripheralWins(t *testing.T) {
+	// Non-overlapping siblings: each is routed to independently.
+	m := NewMMIO(NewRAM())
+	a := &fakePeripheral{lo: 0xF001, hi: 0xF001, readVal: 0xAA}
+	b := &fakePeripheral{lo: 0xF004, hi: 0xF005, readVal: 0xBB}
+	_ = m.Register(a)
+	_ = m.Register(b)
+
+	if v := m.Read(0xF001); v != 0xAA {
+		t.Fatalf("want 0xAA from a, got 0x%02X", v)
+	}
+	if v := m.Read(0xF004); v != 0xBB {
+		t.Fatalf("want 0xBB from b, got 0x%02X", v)
+	}
+	if v := m.Read(0xF005); v != 0xBB {
+		t.Fatalf("want 0xBB from b, got 0x%02X", v)
+	}
+}

--- a/internal/peripheral/keyboard.go
+++ b/internal/peripheral/keyboard.go
@@ -1,0 +1,65 @@
+package peripheral
+
+// KeyboardInput is an Apple-1-style keyboard at two consecutive addresses:
+//
+//	dataAddr   ($F004): read = last pressed key (bit 7 forced high to match
+//	                    Apple-1 monitor expectations); also clears the
+//	                    "ready" bit on the status register.
+//	statusAddr ($F005): read = 0x80 when a key is pending, 0x00 otherwise.
+//
+// Writes to either register are ignored — keyboards are input-only.
+//
+// Concurrency: in chippy the TUI's Update handler and the CPU's Step both
+// run in the Bubble Tea goroutine, so Push and Read are already serialized
+// by that ordering. Do not call Push from a separate goroutine without
+// adding a mutex.
+type KeyboardInput struct {
+	DataAddr   uint16
+	StatusAddr uint16
+
+	data  byte
+	ready bool
+}
+
+// NewKeyboardInput creates a peripheral at (dataAddr, statusAddr). The
+// canonical Apple-1 mapping is (0xF004, 0xF005); chippy follows that.
+func NewKeyboardInput(dataAddr, statusAddr uint16) *KeyboardInput {
+	return &KeyboardInput{DataAddr: dataAddr, StatusAddr: statusAddr}
+}
+
+func (k *KeyboardInput) Range() (uint16, uint16) {
+	if k.DataAddr <= k.StatusAddr {
+		return k.DataAddr, k.StatusAddr
+	}
+	return k.StatusAddr, k.DataAddr
+}
+
+// Push records a byte as the next key the 6502 will see. If a previous
+// keystroke has not yet been read, it is overwritten — matching the
+// Apple-1's single-byte latched PIA register.
+func (k *KeyboardInput) Push(b byte) {
+	k.data = b
+	k.ready = true
+}
+
+func (k *KeyboardInput) Read(addr uint16) byte {
+	switch addr {
+	case k.DataAddr:
+		k.ready = false
+		return k.data | 0x80 // Apple-1 monitor expects bit 7 set
+	case k.StatusAddr:
+		if k.ready {
+			return 0x80
+		}
+		return 0x00
+	}
+	return 0
+}
+
+func (k *KeyboardInput) Write(addr uint16, v byte) {
+	// Apple-1 keyboard PIA had no writable host-side state; ignore.
+}
+
+// Ready reports whether a keystroke is pending. Exposed for tests and the
+// TUI status line.
+func (k *KeyboardInput) Ready() bool { return k.ready }

--- a/internal/peripheral/keyboard_test.go
+++ b/internal/peripheral/keyboard_test.go
@@ -1,0 +1,78 @@
+package peripheral
+
+import "testing"
+
+func TestKeyboardStatusEmpty(t *testing.T) {
+	k := NewKeyboardInput(0xF004, 0xF005)
+	if v := k.Read(0xF005); v != 0x00 {
+		t.Fatalf("status should be 0 before any key; got %02X", v)
+	}
+	if k.Ready() {
+		t.Fatalf("Ready should be false initially")
+	}
+}
+
+func TestKeyboardPushSetsReady(t *testing.T) {
+	k := NewKeyboardInput(0xF004, 0xF005)
+	k.Push('A')
+	if !k.Ready() {
+		t.Fatalf("Ready should be true after Push")
+	}
+	if v := k.Read(0xF005); v != 0x80 {
+		t.Fatalf("status should be 0x80 with key pending; got %02X", v)
+	}
+	// Reading status must NOT clear ready — only data read clears it.
+	if !k.Ready() {
+		t.Fatalf("status read must not drain ready")
+	}
+}
+
+func TestKeyboardDataReadClearsReady(t *testing.T) {
+	k := NewKeyboardInput(0xF004, 0xF005)
+	k.Push('X')
+	if v := k.Read(0xF004); v != ('X' | 0x80) {
+		t.Fatalf("data read want %02X; got %02X", 'X'|0x80, v)
+	}
+	if k.Ready() {
+		t.Fatalf("data read must clear ready")
+	}
+	if v := k.Read(0xF005); v != 0x00 {
+		t.Fatalf("status should be 0 after data drain; got %02X", v)
+	}
+}
+
+func TestKeyboardLatchOverwritesPrev(t *testing.T) {
+	k := NewKeyboardInput(0xF004, 0xF005)
+	k.Push('A')
+	k.Push('B') // overwrite — Apple-1 single-byte latch
+	if v := k.Read(0xF004); v != ('B' | 0x80) {
+		t.Fatalf("want B; got %02X", v)
+	}
+}
+
+func TestKeyboardWriteIgnored(t *testing.T) {
+	k := NewKeyboardInput(0xF004, 0xF005)
+	k.Push('A')
+	k.Write(0xF004, 0xFF)
+	k.Write(0xF005, 0xFF)
+	if !k.Ready() {
+		t.Fatalf("writes should not drain ready")
+	}
+	if v := k.Read(0xF004); v != ('A' | 0x80) {
+		t.Fatalf("write should not change data; got %02X", v)
+	}
+}
+
+func TestKeyboardRange(t *testing.T) {
+	k := NewKeyboardInput(0xF004, 0xF005)
+	lo, hi := k.Range()
+	if lo != 0xF004 || hi != 0xF005 {
+		t.Fatalf("Range want F004,F005; got %04X,%04X", lo, hi)
+	}
+	// Reversed construction still produces canonical range.
+	k2 := NewKeyboardInput(0xF005, 0xF004)
+	lo, hi = k2.Range()
+	if lo != 0xF004 || hi != 0xF005 {
+		t.Fatalf("reversed Range want F004,F005; got %04X,%04X", lo, hi)
+	}
+}

--- a/internal/peripheral/textoutput.go
+++ b/internal/peripheral/textoutput.go
@@ -1,0 +1,56 @@
+// Package peripheral provides memory-mapped I/O devices that plug into
+// cpu.MMIO. Each peripheral claims a small region of the 6502 address
+// space; reads and writes to that region are routed to the device.
+package peripheral
+
+// TextOutput is an Apple-1-style write-only console at a single address
+// (conventionally $F001). Each byte written is appended to an internal
+// buffer that the TUI can render.
+//
+// The Apple-1 monitor uses bit 7 as a "ready" sentinel and ASCII in the
+// lower bits; for chippy we accept the raw byte and let the renderer
+// decide. CR (0x0D) is translated to LF (0x0A) so naive monitor programs
+// produce the line breaks a Unix terminal expects.
+type TextOutput struct {
+	Addr uint16
+	buf  []byte
+}
+
+// NewTextOutput creates a TextOutput peripheral at addr.
+func NewTextOutput(addr uint16) *TextOutput { return &TextOutput{Addr: addr} }
+
+func (t *TextOutput) Range() (uint16, uint16) { return t.Addr, t.Addr }
+
+// Read returns 0; the Apple-1 PIA never wired a read path for $D012.
+// Returning a stable zero matches that convention and keeps the bus
+// well-defined for code that probes the region.
+func (t *TextOutput) Read(addr uint16) byte { return 0 }
+
+func (t *TextOutput) Write(addr uint16, v byte) {
+	if addr != t.Addr {
+		return
+	}
+	// Apple-1 ROMs send CR; translate to LF for terminal-friendly output.
+	if v == 0x0D {
+		v = 0x0A
+	}
+	// Apple-1 conventions: bit 7 set on the high ASCII. Strip it so the
+	// buffer carries plain 7-bit text.
+	t.buf = append(t.buf, v&0x7F)
+}
+
+// Bytes returns a copy of the buffered output.
+func (t *TextOutput) Bytes() []byte {
+	out := make([]byte, len(t.buf))
+	copy(out, t.buf)
+	return out
+}
+
+// String returns the buffered output as a string.
+func (t *TextOutput) String() string { return string(t.buf) }
+
+// Len returns the number of bytes buffered.
+func (t *TextOutput) Len() int { return len(t.buf) }
+
+// Reset clears the buffer.
+func (t *TextOutput) Reset() { t.buf = t.buf[:0] }

--- a/internal/peripheral/textoutput_test.go
+++ b/internal/peripheral/textoutput_test.go
@@ -1,0 +1,75 @@
+package peripheral
+
+import "testing"
+
+func TestTextOutputBuffersWrites(t *testing.T) {
+	out := NewTextOutput(0xF001)
+	for _, b := range []byte("HELLO") {
+		out.Write(0xF001, b)
+	}
+	if got := out.String(); got != "HELLO" {
+		t.Fatalf("want %q, got %q", "HELLO", got)
+	}
+	if out.Len() != 5 {
+		t.Fatalf("want len 5, got %d", out.Len())
+	}
+}
+
+func TestTextOutputTranslatesCR(t *testing.T) {
+	out := NewTextOutput(0xF001)
+	out.Write(0xF001, 'A')
+	out.Write(0xF001, 0x0D)
+	out.Write(0xF001, 'B')
+	if got := out.String(); got != "A\nB" {
+		t.Fatalf("want %q, got %q", "A\nB", got)
+	}
+}
+
+func TestTextOutputStripsHighBit(t *testing.T) {
+	out := NewTextOutput(0xF001)
+	out.Write(0xF001, 0x80|'X') // Apple-1 monitor sets bit 7
+	if got := out.String(); got != "X" {
+		t.Fatalf("want %q, got %q", "X", got)
+	}
+}
+
+func TestTextOutputIgnoresAddrOutsideRange(t *testing.T) {
+	// In production, MMIO never routes off-address writes here. Defensive
+	// guard exists so test or harness code can't poison the buffer by
+	// calling Write directly with a wrong addr.
+	out := NewTextOutput(0xF001)
+	out.Write(0xF002, 'Z')
+	if out.Len() != 0 {
+		t.Fatalf("write to wrong addr should not buffer; got %q", out.String())
+	}
+}
+
+func TestTextOutputRangeAndRead(t *testing.T) {
+	out := NewTextOutput(0xF001)
+	lo, hi := out.Range()
+	if lo != 0xF001 || hi != 0xF001 {
+		t.Fatalf("Range want F001,F001; got %04X,%04X", lo, hi)
+	}
+	if v := out.Read(0xF001); v != 0 {
+		t.Fatalf("Read want 0; got %02X", v)
+	}
+}
+
+func TestTextOutputReset(t *testing.T) {
+	out := NewTextOutput(0xF001)
+	out.Write(0xF001, 'A')
+	out.Reset()
+	if out.Len() != 0 {
+		t.Fatalf("Reset should empty buffer")
+	}
+}
+
+func TestTextOutputBytesIsCopy(t *testing.T) {
+	out := NewTextOutput(0xF001)
+	out.Write(0xF001, 'A')
+	b := out.Bytes()
+	b[0] = 'Z'
+	if out.String() != "A" {
+		t.Fatalf("Bytes() must return a copy; internal buffer mutated")
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 
 	"github.com/nkane/chippy/internal/cpu"
+	"github.com/nkane/chippy/internal/peripheral"
 	"github.com/nkane/chippy/internal/symbols"
 )
 
@@ -85,6 +86,14 @@ type Model struct {
 	// State persistence
 	StatePath string
 
+	// Memory-mapped peripherals (optional). When set, the View grows an
+	// Output panel and the `i` key toggles InputMode: while active, all
+	// keystrokes are routed to Keyboard.Push instead of debugger bindings,
+	// and Esc exits input mode.
+	TextOut   *peripheral.TextOutput
+	Keyboard  *peripheral.KeyboardInput
+	InputMode bool
+
 	// Disassembly viewport: when DisasmFollow is true (default), the panel
 	// re-anchors on PC each frame. User scroll keys flip it off and pin
 	// DisasmAnchor as the address shown at the top of the window.
@@ -140,6 +149,21 @@ func (m Model) WithStatePath(p string) Model {
 	return m
 }
 
+// WithTextOutput attaches a TextOutput peripheral so the TUI can render its
+// buffered output. The peripheral must already be registered with the MMIO
+// bus the CPU reads/writes through — this method only wires display.
+func (m Model) WithTextOutput(t *peripheral.TextOutput) Model {
+	m.TextOut = t
+	return m
+}
+
+// WithKeyboard attaches a KeyboardInput peripheral so the TUI can route
+// keystrokes into the program (see InputMode).
+func (m Model) WithKeyboard(k *peripheral.KeyboardInput) Model {
+	m.Keyboard = k
+	return m
+}
+
 // WithSourceMap loads PC->(file,line) mapping from cc65 .dbg file lines.
 func (m Model) WithSourceMap(sm *symbols.SourceMap) Model {
 	if sm == nil {
@@ -185,11 +209,23 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.ShowBPs {
 			return m.updateBPManager(msg)
 		}
+		// Input mode: route most keys to the keyboard peripheral instead
+		// of debugger bindings. Ctrl+C always quits; Esc exits the mode.
+		if m.InputMode {
+			return m.updateInputMode(msg)
+		}
 
 		switch msg.String() {
 		case "q", "ctrl+c":
 			m.saveState()
 			return m, tea.Quit
+		case "i":
+			if m.Keyboard != nil {
+				m.InputMode = true
+				m.Status = "input mode — Esc to exit"
+			} else {
+				m.Status = "no keyboard peripheral registered"
+			}
 		case "?", "h":
 			m.ShowHelp = true
 			m.Status = "help"
@@ -325,6 +361,53 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.scheduleTick()
 	}
 	return m, nil
+}
+
+// updateInputMode routes keystrokes to the keyboard peripheral. Esc exits;
+// Ctrl+C still quits. Printable ASCII and a small set of control keys are
+// mapped to bytes; everything else is silently dropped so an unmapped
+// special key (e.g. a function key) doesn't poison the program input.
+func (m Model) updateInputMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	s := msg.String()
+	switch s {
+	case "ctrl+c":
+		m.saveState()
+		return m, tea.Quit
+	case "esc":
+		m.InputMode = false
+		m.Status = "input mode off"
+		return m, m.scheduleTick()
+	}
+	if b, ok := keyMsgToByte(msg); ok {
+		m.Keyboard.Push(b)
+		m.Status = fmt.Sprintf("key -> $%02X", b)
+	}
+	return m, m.scheduleTick()
+}
+
+// keyMsgToByte maps a Bubble Tea key event to the byte the 6502 program
+// will see. Returns ok=false for keys that have no useful mapping (function
+// keys, modifier-only chords, etc.).
+func keyMsgToByte(msg tea.KeyMsg) (byte, bool) {
+	s := msg.String()
+	switch s {
+	case "enter":
+		return 0x0D, true
+	case "tab":
+		return 0x09, true
+	case "space":
+		return 0x20, true
+	case "backspace":
+		return 0x08, true
+	}
+	// Single-rune printable.
+	if len(s) == 1 {
+		r := s[0]
+		if r >= 0x20 && r < 0x7F {
+			return r, true
+		}
+	}
+	return 0, false
 }
 
 // statusAfterStep updates Status reflecting halt or normal stepping outcome.
@@ -598,14 +681,18 @@ func (m Model) View() string {
 		stackH = 6
 	}
 
+	outH := 0
+	if m.TextOut != nil {
+		outH = 8
+	}
 	disH := innerH * 6 / 10
 	if disH < 10 {
 		disH = 10
 	}
-	memH := innerH - disH
+	memH := innerH - disH - outH
 	if memH < 8 {
 		memH = 8
-		disH = innerH - memH
+		disH = innerH - memH - outH
 	}
 
 	leftPanels := []string{
@@ -624,10 +711,11 @@ func (m Model) View() string {
 	} else {
 		topRight = m.disasmView(rightW, disH)
 	}
-	right := lipgloss.JoinVertical(lipgloss.Left,
-		topRight,
-		m.memView(rightW, memH),
-	)
+	rightPanels := []string{topRight, m.memView(rightW, memH)}
+	if m.TextOut != nil {
+		rightPanels = append(rightPanels, m.outputView(rightW, outH))
+	}
+	right := lipgloss.JoinVertical(lipgloss.Left, rightPanels...)
 	body := lipgloss.JoinHorizontal(lipgloss.Top, left, strings.Repeat(" ", gap), right)
 
 	title := titleStyle.Render(" chippy — 6502 TUI debugger ")
@@ -728,6 +816,7 @@ func (m Model) helpModal() string {
 		{"General", [][2]string{
 			{":", "command line (:goto :pc :watch :speed :bp)"},
 			{"v", "toggle source / disassembly view"},
+			{"i", "input mode → keystrokes go to keyboard peripheral (Esc exits)"},
 			{"? / h", "toggle this help"},
 			{"q / ^C", "quit"},
 		}},
@@ -1255,6 +1344,50 @@ func (m Model) sourceView(w, h int) string {
 		b.WriteString(text + "\n")
 	}
 	return fitPanel(title, strings.TrimRight(b.String(), "\n"), w, h)
+}
+
+// outputView renders the TextOutput peripheral's buffer. The newest content
+// is shown — older lines scroll off the top when the buffer overflows the
+// panel height.
+func (m Model) outputView(w, h int) string {
+	innerH := h - 2
+	if innerH < 1 {
+		innerH = 1
+	}
+	rows := innerH - 1
+	if rows < 1 {
+		rows = 1
+	}
+	innerW := w - panelWChrome
+	if innerW < 1 {
+		innerW = 1
+	}
+
+	out := m.TextOut.String()
+	lines := strings.Split(out, "\n")
+	// Wrap any line wider than the panel.
+	wrapped := make([]string, 0, len(lines))
+	for _, ln := range lines {
+		if len(ln) <= innerW {
+			wrapped = append(wrapped, ln)
+			continue
+		}
+		for len(ln) > innerW {
+			wrapped = append(wrapped, ln[:innerW])
+			ln = ln[innerW:]
+		}
+		wrapped = append(wrapped, ln)
+	}
+	// Trim to last `rows` lines.
+	if len(wrapped) > rows {
+		wrapped = wrapped[len(wrapped)-rows:]
+	}
+
+	title := "Output"
+	if m.InputMode {
+		title = "Output  " + lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Bold(true).Render("[INPUT]")
+	}
+	return fitPanel(title, strings.Join(wrapped, "\n"), w, h)
 }
 
 func (m Model) memView(w, h int) string {


### PR DESCRIPTION
## Summary
- Add `cpu.Peripheral` interface and `cpu.MMIO` routing bus. Bus chain is now CPU → `tui.WBus` → `cpu.MMIO` → `cpu.RAM`. Loader and reset-vector helpers write directly to RAM to avoid triggering peripherals during setup.
- Ship Apple-1-style peripherals: `TextOutput` at `$F001` (CR→LF, high-bit strip) and `KeyboardInput` at `$F004`/`$F005` (data + status, ready-drain on data read).
- TUI grows an Output panel and an `i` keybinding that toggles InputMode (Esc to exit) so keystrokes are pushed to `KeyboardInput` instead of debugger commands.
- `example/hello.s` writes "HELLO" + CR to `$F001`; the new e2e test loads it under MMIO and asserts the TextOutput buffer ends with `"HELLO\n"` — the acceptance criterion from issue #16.

Closes #16

## Test plan
- [ ] `go build ./...` passes.
- [ ] `go test -race -count=1 ./...` passes (all packages).
- [ ] `golangci-lint run ./...` is clean.
- [ ] `make -C example hello.bin` builds.
- [ ] `chippy -rom example/hello.bin` runs — Output panel renders "HELLO", program halts on JMP-self.
- [ ] `i` enters input mode; `Esc` exits.
- [ ] Existing persistence files (`~/.chippy/state-<rom>.json`) still load — `savedState` schema is unchanged, peripherals are attached at startup not from disk.