### PR TITLE
feat(cpu): per-instruction execution trace (-trace flag + :trace cmd)

### DIFF
--- a/cmd/chippy/main.go
+++ b/cmd/chippy/main.go
@@ -17,12 +17,13 @@ import (
 
 func main() {
 	var (
-		romPath  = flag.String("rom", "", "program to load (.bin .prg .hex .o)")
-		loadAddr = flag.Uint("addr", 0x8000, "load address for raw .bin (ignored for .prg/.hex/.o)")
-		resetVec = flag.Uint("reset", 0, "reset vector override (0 = use file's existing vector or load address)")
-		cfg      = flag.String("cfg", "", "ld65 linker config (.cfg) — required when loading .o files")
-		dbgPath  = flag.String("dbg", "", "cc65 .dbg symbol file (auto-detected as <rom>.dbg if omitted)")
-		cpuFlag  = flag.String("cpu", "nmos", "CPU variant: nmos | 65c02")
+		romPath   = flag.String("rom", "", "program to load (.bin .prg .hex .o)")
+		loadAddr  = flag.Uint("addr", 0x8000, "load address for raw .bin (ignored for .prg/.hex/.o)")
+		resetVec  = flag.Uint("reset", 0, "reset vector override (0 = use file's existing vector or load address)")
+		cfg       = flag.String("cfg", "", "ld65 linker config (.cfg) — required when loading .o files")
+		dbgPath   = flag.String("dbg", "", "cc65 .dbg symbol file (auto-detected as <rom>.dbg if omitted)")
+		cpuFlag   = flag.String("cpu", "nmos", "CPU variant: nmos | 65c02")
+		tracePath = flag.String("trace", "", "write per-instruction execution trace to this file")
 	)
 	flag.Parse()
 
@@ -128,6 +129,17 @@ func main() {
 
 	c := cpu.NewVariant(mmio, variant)
 
+	tracer := cpu.NewFileTracer()
+	c.Tracer = tracer
+	defer func() { _ = tracer.Close() }()
+	if *tracePath != "" {
+		if err := tracer.SetPath(*tracePath); err != nil {
+			fmt.Fprintln(os.Stderr, "trace:", err)
+			os.Exit(1)
+		}
+		tracer.Enable()
+	}
+
 	// Wrap the bus with WBus so memory watchpoints can intercept reads/writes.
 	// We construct CPU on MMIO first (to keep cpu.New's signature simple),
 	// then swap c.Bus to the wrapper. WithWBus attaches the CPU pointer and
@@ -138,7 +150,8 @@ func main() {
 	model := tui.New(c, ram).
 		WithWBus(wbus).
 		WithTextOutput(textOut).
-		WithKeyboard(keyIn)
+		WithKeyboard(keyIn).
+		WithTracer(tracer)
 	if syms != nil {
 		model = model.WithSymbols(syms)
 	}

--- a/internal/cpu/cpu.go
+++ b/internal/cpu/cpu.go
@@ -44,6 +44,11 @@ type CPU struct {
 	Bus            Bus
 	Variant        Variant
 
+	// Optional per-instruction execution hook. When non-nil, Step() invokes
+	// Tracer.LogStep at the instruction boundary just before opcode fetch.
+	// Implementations must be cheap on the disabled path.
+	Tracer Tracer
+
 	// Debug helpers
 	Halted bool
 

--- a/internal/cpu/exec.go
+++ b/internal/cpu/exec.go
@@ -29,6 +29,9 @@ func (c *CPU) Step() int {
 	if c.Halted {
 		return 0
 	}
+	if c.Tracer != nil {
+		c.Tracer.LogStep(c, c.Bus)
+	}
 	startPC := c.PC
 	op := c.Bus.Read(c.PC)
 	c.PC++

--- a/internal/cpu/trace.go
+++ b/internal/cpu/trace.go
@@ -1,0 +1,115 @@
+package cpu
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+)
+
+// Tracer is an optional per-instruction execution hook. When set on CPU,
+// Step() calls LogStep at the instruction boundary just before opcode fetch,
+// so the logged PC/regs reflect the instruction about to execute. Halted
+// steps and interrupt-service steps are not traced — only real instructions.
+type Tracer interface {
+	LogStep(c *CPU, bus Bus)
+}
+
+// FileTracer writes one line per instruction to a file. Cheap when disabled
+// (single bool check) so it's safe to leave attached and toggle at runtime.
+// Buffer is 64K to keep multi-MHz traces from thrashing syscalls; Close (or
+// Disable) flushes.
+//
+// Line format:
+//
+//	PC    bytes        disasm           A:xx X:xx Y:xx P:xx SP:xx CYC:n
+//	8000  A9 42        LDA  #$42        A:00 X:00 Y:00 P:24 SP:FD CYC:7
+//
+// Reading opcode bytes goes through the live Bus, so don't enable tracing
+// for programs that execute from MMIO regions whose Read has side effects.
+type FileTracer struct {
+	f       *os.File
+	w       *bufio.Writer
+	out     io.Writer
+	path    string
+	enabled bool
+}
+
+func NewFileTracer() *FileTracer { return &FileTracer{out: io.Discard} }
+
+// SetPath redirects output to a fresh file at path (truncating any existing
+// file). Closes any previous file. The tracer is left in its current
+// enabled/disabled state — call Enable() afterwards if needed.
+func (t *FileTracer) SetPath(path string) error {
+	if err := t.closeFile(); err != nil {
+		return err
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	t.f = f
+	t.w = bufio.NewWriterSize(f, 64*1024)
+	t.out = t.w
+	t.path = path
+	return nil
+}
+
+func (t *FileTracer) Path() string  { return t.path }
+func (t *FileTracer) Enabled() bool { return t.enabled }
+func (t *FileTracer) Enable()       { t.enabled = true }
+
+func (t *FileTracer) Disable() {
+	t.enabled = false
+	if t.w != nil {
+		_ = t.w.Flush()
+	}
+}
+
+func (t *FileTracer) Close() error {
+	t.enabled = false
+	return t.closeFile()
+}
+
+func (t *FileTracer) closeFile() error {
+	if t.w != nil {
+		_ = t.w.Flush()
+		t.w = nil
+	}
+	var err error
+	if t.f != nil {
+		err = t.f.Close()
+		t.f = nil
+	}
+	t.out = io.Discard
+	return err
+}
+
+func (t *FileTracer) LogStep(c *CPU, bus Bus) {
+	if !t.enabled {
+		return
+	}
+	pc := c.PC
+	op := bus.Read(pc)
+	in := c.opcodes[op]
+	n := min(max(int(in.Bytes), 1), 3)
+	var b1, b2 byte
+	if n >= 2 {
+		b1 = bus.Read(pc + 1)
+	}
+	if n >= 3 {
+		b2 = bus.Read(pc + 2)
+	}
+	var bytesStr string
+	switch n {
+	case 1:
+		bytesStr = fmt.Sprintf("%02X      ", op)
+	case 2:
+		bytesStr = fmt.Sprintf("%02X %02X   ", op, b1)
+	case 3:
+		bytesStr = fmt.Sprintf("%02X %02X %02X", op, b1, b2)
+	}
+	dis, _ := Disasm(bus, pc)
+	fmt.Fprintf(t.out, "%04X  %s  %-13s  A:%02X X:%02X Y:%02X P:%02X SP:%02X CYC:%d\n",
+		pc, bytesStr, dis, c.A, c.X, c.Y, c.P, c.SP, c.Cycles)
+}

--- a/internal/cpu/trace_test.go
+++ b/internal/cpu/trace_test.go
@@ -1,0 +1,187 @@
+package cpu_test
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/nkane/chippy/internal/cpu"
+)
+
+// newTracedCPU builds a CPU executing `code` from $8000 with a FileTracer
+// pointed at a fresh temp file. Returns the CPU, tracer, and the path so
+// the test can inspect the file after Close.
+func newTracedCPU(t *testing.T, code []byte) (*cpu.CPU, *cpu.FileTracer, string) {
+	t.Helper()
+	ram := cpu.NewRAM()
+	ram.Load(0x8000, code)
+	ram.Write(cpu.VecReset, 0x00)
+	ram.Write(cpu.VecReset+1, 0x80)
+	c := cpu.New(ram)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "trace.log")
+	tr := cpu.NewFileTracer()
+	if err := tr.SetPath(path); err != nil {
+		t.Fatalf("SetPath: %v", err)
+	}
+	c.Tracer = tr
+	return c, tr, path
+}
+
+func readLines(t *testing.T, path string) []string {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open trace: %v", err)
+	}
+	defer f.Close()
+	var lines []string
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		lines = append(lines, s.Text())
+	}
+	if err := s.Err(); err != nil {
+		t.Fatalf("scan trace: %v", err)
+	}
+	return lines
+}
+
+func TestTraceDisabledByDefault(t *testing.T) {
+	c, tr, path := newTracedCPU(t, []byte{0xEA, 0xEA}) // NOP NOP
+	if tr.Enabled() {
+		t.Fatalf("tracer should start disabled")
+	}
+	c.Step()
+	c.Step()
+	if err := tr.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if got := readLines(t, path); len(got) != 0 {
+		t.Fatalf("expected no trace lines while disabled, got %d", len(got))
+	}
+}
+
+func TestTraceLineFormat(t *testing.T) {
+	// LDA #$42 ; NOP ; JMP $8000
+	c, tr, path := newTracedCPU(t, []byte{0xA9, 0x42, 0xEA, 0x4C, 0x00, 0x80})
+	tr.Enable()
+	c.Step() // LDA
+	c.Step() // NOP
+	c.Step() // JMP
+	if err := tr.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+
+	lines := readLines(t, path)
+	if len(lines) != 3 {
+		t.Fatalf("want 3 lines, got %d: %v", len(lines), lines)
+	}
+
+	// First line: LDA #$42 — 2 bytes (A9 42), regs all zero at reset, P=24
+	// (FlagU|FlagI), SP=FD, CYC=7 (the reset-baseline cycles set by Reset()).
+	want := regexp.MustCompile(
+		`^8000 +A9 42 +LDA +#\$42 +A:00 X:00 Y:00 P:24 SP:FD CYC:7$`)
+	if !want.MatchString(lines[0]) {
+		t.Fatalf("line 0 format mismatch:\n got: %q\nwant pattern: %s", lines[0], want)
+	}
+
+	// Second line: NOP at $8002, A now $42 (post-LDA), Z=0 N=0 still 24.
+	// LDA #imm takes 2 cycles; reset baseline 7 -> CYC:9.
+	if !strings.Contains(lines[1], "8002  EA      ") {
+		t.Fatalf("line 1 missing NOP at $8002: %q", lines[1])
+	}
+	if !strings.Contains(lines[1], "A:42") {
+		t.Fatalf("line 1 missing A:42 after LDA: %q", lines[1])
+	}
+	if !strings.Contains(lines[1], "CYC:9") {
+		t.Fatalf("line 1 missing CYC:9: %q", lines[1])
+	}
+
+	// Third line: JMP $8000 — 3 bytes 4C 00 80, CYC after NOP = 11.
+	if !strings.Contains(lines[2], "8003  4C 00 80  JMP") {
+		t.Fatalf("line 2 missing JMP bytes/disasm: %q", lines[2])
+	}
+	if !strings.Contains(lines[2], "CYC:11") {
+		t.Fatalf("line 2 missing CYC:11: %q", lines[2])
+	}
+}
+
+func TestTraceToggle(t *testing.T) {
+	// Five NOPs.
+	c, tr, path := newTracedCPU(t, []byte{0xEA, 0xEA, 0xEA, 0xEA, 0xEA})
+	tr.Enable()
+	c.Step()
+	tr.Disable()
+	c.Step()
+	c.Step()
+	tr.Enable()
+	c.Step()
+	c.Step()
+	if err := tr.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	lines := readLines(t, path)
+	if len(lines) != 3 {
+		t.Fatalf("want 3 lines (steps 1,4,5), got %d: %v", len(lines), lines)
+	}
+	// Lines should be PC=$8000, $8003, $8004 (step 1, then disabled for
+	// steps at $8001/$8002, re-enabled at $8003 and $8004).
+	for i, prefix := range []string{"8000  ", "8003  ", "8004  "} {
+		if !strings.HasPrefix(lines[i], prefix) {
+			t.Fatalf("line %d: want prefix %q, got %q", i, prefix, lines[i])
+		}
+	}
+}
+
+func TestTraceFlushOnDisable(t *testing.T) {
+	// Without flush-on-disable, buffered writes wouldn't reach disk yet —
+	// readLines would return empty. This verifies the buffer is flushed
+	// even before Close.
+	c, tr, path := newTracedCPU(t, []byte{0xEA, 0xEA})
+	tr.Enable()
+	c.Step()
+	tr.Disable() // must flush
+	lines := readLines(t, path)
+	if len(lines) != 1 {
+		t.Fatalf("want 1 flushed line after Disable, got %d", len(lines))
+	}
+	_ = tr.Close()
+}
+
+func TestTraceSetPathReopens(t *testing.T) {
+	c, tr, _ := newTracedCPU(t, []byte{0xEA, 0xEA, 0xEA, 0xEA})
+	tr.Enable()
+	c.Step()
+	// Redirect to a second file mid-stream.
+	dir := t.TempDir()
+	path2 := filepath.Join(dir, "trace2.log")
+	if err := tr.SetPath(path2); err != nil {
+		t.Fatalf("SetPath: %v", err)
+	}
+	c.Step()
+	c.Step()
+	if err := tr.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	got := readLines(t, path2)
+	if len(got) != 2 {
+		t.Fatalf("want 2 lines in second file, got %d: %v", len(got), got)
+	}
+	if !strings.HasPrefix(got[0], "8001  ") {
+		t.Fatalf("second file should start at $8001, got %q", got[0])
+	}
+}
+
+func TestTraceCloseIdempotent(t *testing.T) {
+	_, tr, _ := newTracedCPU(t, []byte{0xEA})
+	if err := tr.Close(); err != nil {
+		t.Fatalf("first close: %v", err)
+	}
+	if err := tr.Close(); err != nil {
+		t.Fatalf("second close: %v", err)
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -94,6 +94,11 @@ type Model struct {
 	Keyboard  *peripheral.KeyboardInput
 	InputMode bool
 
+	// Optional CPU execution tracer. The CPU does the actual logging; the
+	// Model holds a reference so `:trace on/off [path]` can flip it at
+	// runtime and so quit can flush the buffer.
+	Tracer *cpu.FileTracer
+
 	// Disassembly viewport: when DisasmFollow is true (default), the panel
 	// re-anchors on PC each frame. User scroll keys flip it off and pin
 	// DisasmAnchor as the address shown at the top of the window.
@@ -161,6 +166,12 @@ func (m Model) WithTextOutput(t *peripheral.TextOutput) Model {
 // keystrokes into the program (see InputMode).
 func (m Model) WithKeyboard(k *peripheral.KeyboardInput) Model {
 	m.Keyboard = k
+	return m
+}
+
+// WithTracer attaches a CPU execution tracer for runtime control via :trace.
+func (m Model) WithTracer(t *cpu.FileTracer) Model {
+	m.Tracer = t
 	return m
 }
 
@@ -835,6 +846,13 @@ func (m Model) helpModal() string {
 			{":rmbpr X", "remove (also :rmbpw / :rmbprw)"},
 			{"modifiers", "same: once / hits N / if E / log M"},
 			{"sigils", "👁 read  ✏ write  🔁 read+write"},
+		}},
+		{"Trace", [][2]string{
+			{":trace PATH", "open PATH and enable per-instruction trace"},
+			{":trace on", "re-enable using the last-set path"},
+			{":trace off", "disable + flush buffer to disk"},
+			{":trace", "show current state"},
+			{"--trace", "CLI flag: enable at startup with given path"},
 		}},
 	}
 

--- a/internal/tui/prompt.go
+++ b/internal/tui/prompt.go
@@ -214,6 +214,8 @@ func (m *Model) runCommand(line string) string {
 		delete(m.MemBPs, addr)
 		m.saveState()
 		return fmt.Sprintf("mem bp -$%04X", addr)
+	case "trace":
+		return m.cmdTrace(args)
 	case "help", "?":
 		m.ShowHelp = true
 		return "help"
@@ -221,6 +223,47 @@ func (m *Model) runCommand(line string) string {
 		return "use q outside prompt to quit"
 	}
 	return fmt.Sprintf("unknown: %s", cmd)
+}
+
+// cmdTrace implements `:trace`. No args: report status. `on [PATH]`,
+// `off`, or a bare `PATH` (shorthand for `on PATH`). Setting a path opens
+// a fresh file (truncating any existing) and the tracer keeps its
+// enabled/disabled state until Enable/Disable is called.
+func (m *Model) cmdTrace(args []string) string {
+	if m.Tracer == nil {
+		return "trace unavailable"
+	}
+	if len(args) == 0 {
+		if m.Tracer.Enabled() {
+			return fmt.Sprintf("trace: on -> %s", m.Tracer.Path())
+		}
+		if p := m.Tracer.Path(); p != "" {
+			return fmt.Sprintf("trace: off (last: %s)", p)
+		}
+		return "trace: off (no path)"
+	}
+	switch strings.ToLower(args[0]) {
+	case "on":
+		if len(args) >= 2 {
+			if err := m.Tracer.SetPath(args[1]); err != nil {
+				return fmt.Sprintf("trace: %v", err)
+			}
+		}
+		if m.Tracer.Path() == "" {
+			return "trace: no path — use :trace on PATH"
+		}
+		m.Tracer.Enable()
+		return fmt.Sprintf("trace: on -> %s", m.Tracer.Path())
+	case "off":
+		m.Tracer.Disable()
+		return "trace: off"
+	default:
+		if err := m.Tracer.SetPath(args[0]); err != nil {
+			return fmt.Sprintf("trace: %v", err)
+		}
+		m.Tracer.Enable()
+		return fmt.Sprintf("trace: on -> %s", m.Tracer.Path())
+	}
 }
 
 // parseAddrSym tries numeric forms then symbol lookup via m.Syms.


### PR DESCRIPTION
Closes #21.

## Summary
- New `cpu.Tracer` interface + `cpu.FileTracer` that writes one buffered line per executed instruction.
- `Step()` invokes the hook just before opcode fetch, so logged PC/regs reflect the instruction about to run. Halted and interrupt-service steps are skipped — trace lines match the program's instruction stream 1:1.
- CLI flag `-trace PATH` enables tracing at startup.
- TUI command `:trace PATH | :trace on | :trace off | :trace` controls it at runtime; buffer (64 KiB) flushes on `:trace off` and on Close.

## Line format
```
PC    bytes        disasm           A:xx X:xx Y:xx P:xx SP:xx CYC:n
8000  A9 42        LDA  #$42        A:00 X:00 Y:00 P:24 SP:FD CYC:7
```

## Notes
- The TUI starts paused. To produce a trace from `-trace`, launch then press `r` to run (or set breakpoints, single-step, etc.). `:trace on/off` works the same way during a live session.
- Reading opcode bytes for the bytes column goes through the live Bus. Don't enable tracing for programs that execute from MMIO regions whose Read has side effects (same caveat as the existing Disasm panel).
- Disasm column still uses the NMOS opcode table — a CMOS-only mnemonic (e.g. `STZ`) will print as the underlying NMOS slot. Pre-existing limitation of `Disasm`; tracked separately if needed.

## Test plan
- [x] `go build ./...`
- [x] `go test -race ./...` — new tests in `internal/cpu/trace_test.go` cover: disabled-by-default, line format, enable/disable toggle, flush-on-disable, `SetPath` reopens mid-stream, idempotent `Close`.
- [x] `golangci-lint run` — 0 issues.
- [ ] Manual: `chippy -trace /tmp/t.log`, press `r`, exit, inspect `/tmp/t.log`.