### PR TITLE
docs(claude): require doc updates in every feature PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,17 @@ Go-based TUI 6502 emulator + debugger (Bubble Tea, Lipgloss). Targets ca65/cc65 
 - PR body ends with `Closes #N`.
 - Squash-merge with `--delete-branch`. Defer follow-ups by filing new issues.
 
+## Docs are part of every PR (not a follow-up)
+Every PR ships with the documentation changes its diff implies. Update **in the same PR**, never as a separate cleanup:
+
+- **`README.md`** — when CLI flags, install instructions, or user-facing behavior change. Flag tables, examples, and the feature list must stay accurate.
+- **`docs/context.md`** — the architecture / progress / decisions handoff doc. When a PR merges, move the issue from "Open issues" to "Merged PRs of note", drop any "in progress" stubs that referred to it, and add an architecture section if the PR introduced a new subsystem (e.g. MMIO, trace).
+- **TUI help modal** (`internal/tui/model.go` `helpModal()`) — when a new `:command`, keybinding, or panel ships.
+- **Code-level doc comments** — when an exported type/function changes shape or contract.
+- **This file (`CLAUDE.md`)** — when load-bearing invariants change, or when a convention itself changes.
+
+A PR that adds a feature without updating its docs is incomplete. Reviewers will flag it; pre-empt by updating in the same diff.
+
 ## Quality bar (must pass before commit)
 - `go build ./...`
 - `go test -race -count=1 ./...`


### PR DESCRIPTION
## Summary
Adds a \"Docs are part of every PR\" section to `CLAUDE.md` that names the four doc surfaces which must update alongside code:
- `README.md` — CLI flags, install steps, user-facing behavior
- `docs/context.md` — architecture / progress handoff; move closed issues, drop \"in progress\" stubs, add subsystem sections
- TUI help modal (`internal/tui/model.go` `helpModal()`) — new `:command` / keybinding / panel
- exported doc comments and `CLAUDE.md` itself when invariants/conventions shift

## Motivation
The trace and MMIO merges left `README.md` and `docs/context.md` stale for a session before being cleaned up in a separate PR (#37). Folding docs into the feature PR prevents that drift on future work.

## Test plan
- [x] `CLAUDE.md` renders cleanly on GitHub.
- [ ] Next feature PR (e.g. #18 / #19) ships with corresponding doc updates per the new rule.