### PR TITLE
feat(tui): JSR-frame annotation in stack panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,11 @@ The disassembly panel is replaced by a source view when you press `v` (if
 a `.dbg` is loaded). A breakpoint manager modal opens with `B`; the help
 modal opens with `?`.
 
+The stack panel detects JSR-pushed return-address pairs and renders them as
+`ret $XXXX  callee  file:NN` rows, collapsing adjacent non-frame bytes into
+single `(N bytes)` lines so the call chain stays readable. Press `T` to
+toggle back to the raw one-byte-per-row layout.
+
 ---
 
 ## Status

--- a/docs/context.md
+++ b/docs/context.md
@@ -138,10 +138,11 @@ Bus chain: `CPU → tui.WBus → cpu.MMIO → cpu.RAM`
 - #33 — IRQ/NMI with edge/level semantics
 - #34 — MMIO peripheral abstraction (issue #16); routing bus + Apple-1-style TextOutput ($F001) and KeyboardInput ($F004/$F005)
 - #36 — Per-instruction execution trace (issue #21): `cpu.Tracer` hook on `Step()`, `cpu.FileTracer` (buffered 64K), `-trace PATH` CLI flag, `:trace PATH|on|off` TUI command
+- #38 — CLAUDE.md "docs are part of every PR" rule: README/context/help-modal/exported docs move with code
+- #39 — Stack panel JSR-frame annotation (issue #18): detects pushed return-address pairs via the `$20` opcode at `stored-2`; renders `ret $XXXX  callee  file:NN`; collapses non-frame runs; `T` toggles raw view
 
 ### Open issues
 - #17 (reverse step) — record/replay micro-history
-- #18 (stack panel) — visualise SP and stack contents
 - #19 (memory editor) — interactive hex editor in TUI
 - #20 (prompt history) — up-arrow recall in command prompt
 - #22 (homebrew-core) — blocked on stars

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -99,6 +99,12 @@ type Model struct {
 	// runtime and so quit can flush the buffer.
 	Tracer *cpu.FileTracer
 
+	// StackAnnotate controls the Stack panel's render mode. true (default):
+	// JSR return-address pairs are detected and shown as `ret $XXXX` rows
+	// with callee + source info; consecutive non-frame bytes are collapsed.
+	// false: legacy one-byte-per-row layout. `T` key toggles.
+	StackAnnotate bool
+
 	// Disassembly viewport: when DisasmFollow is true (default), the panel
 	// re-anchors on PC each frame. User scroll keys flip it off and pin
 	// DisasmAnchor as the address shown at the top of the window.
@@ -116,16 +122,17 @@ type disasmCacheEntry struct {
 
 func New(c *cpu.CPU, r *cpu.RAM) Model {
 	return Model{
-		CPU:          c,
-		RAM:          r,
-		Breakpoints:  map[uint16]*Breakpoint{},
-		MemBPs:       map[uint16]*MemBP{},
-		MemViewAddr:  0x0000,
-		Status:       "ready",
-		TargetHz:     0,
-		DisasmFollow: true,
-		W:            120,
-		H:            40,
+		CPU:           c,
+		RAM:           r,
+		Breakpoints:   map[uint16]*Breakpoint{},
+		MemBPs:        map[uint16]*MemBP{},
+		MemViewAddr:   0x0000,
+		Status:        "ready",
+		TargetHz:      0,
+		DisasmFollow:  true,
+		StackAnnotate: true,
+		W:             120,
+		H:             40,
 	}
 }
 
@@ -340,6 +347,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "'":
 			m.DisasmFollow = true
 			m.Status = "disasm: follow PC"
+		case "T":
+			m.StackAnnotate = !m.StackAnnotate
+			if m.StackAnnotate {
+				m.Status = "stack: annotated"
+			} else {
+				m.Status = "stack: raw bytes"
+			}
 		}
 		return m, m.scheduleTick()
 
@@ -824,6 +838,11 @@ func (m Model) helpModal() string {
 			{"{ / }", "scroll eight instructions up / down"},
 			{"'", "follow PC again"},
 		}},
+		{"Stack panel", [][2]string{
+			{"T", "toggle JSR-frame annotation / raw bytes"},
+			{"annotated", "ret $XXXX + callee + source line per JSR pair"},
+			{"raw", "one byte per row from SP up"},
+		}},
 		{"General", [][2]string{
 			{":", "command line (:goto :pc :watch :speed :bp)"},
 			{"v", "toggle source / disassembly view"},
@@ -1044,31 +1063,6 @@ func (m Model) regValue(name string) string {
 		return fmt.Sprintf("$%04X", m.CPU.PC)
 	}
 	return "  ?"
-}
-
-func (m Model) stackView(w, h int) string {
-	innerH := h - 2
-	if innerH < 1 {
-		innerH = 1
-	}
-	rows := innerH - 1
-	if rows < 1 {
-		rows = 1
-	}
-	var b strings.Builder
-	for i := 0; i < rows; i++ {
-		spByte := uint16(m.CPU.SP) + 1 + uint16(i)
-		if spByte > 0xFF {
-			break
-		}
-		sp := 0x100 | spByte
-		marker := "  "
-		if i == 0 {
-			marker = curLine.Render(" >")
-		}
-		fmt.Fprintf(&b, "%s %s  %02X\n", marker, dimAddr.Render(fmt.Sprintf("$%04X", sp)), m.RAM.Read(sp))
-	}
-	return fitPanel("Stack", strings.TrimRight(b.String(), "\n"), w, h)
 }
 
 func (m Model) disasmView(w, h int) string {

--- a/internal/tui/stack.go
+++ b/internal/tui/stack.go
@@ -1,0 +1,178 @@
+package tui
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/nkane/chippy/internal/cpu"
+)
+
+// stackEntry is one row in the annotated stack panel. A frame represents the
+// two-byte JSR return-address pair pushed at addrLo / addrLo+1; a run is a
+// collapsed group of consecutive non-frame bytes.
+type stackEntry struct {
+	isFrame bool
+	addrLo  uint16
+	bytes   int    // frame: always 2; run: byte count
+	retAddr uint16 // frame only — cooked return address (stored + 1)
+	callee  string // frame only — symbol name at JSR target, if known
+	src     string // frame only — "file.s:NN" if a source map covers retAddr
+}
+
+// detectStackFrame reports whether the byte pair at $01XX (spLo, spLo+1)
+// looks like a JSR-pushed return address: the byte two below the stored
+// 16-bit value should be the JSR opcode ($20). retAddr is `stored + 1`
+// (the address RTS will jump to); target is the JSR's call target read
+// from the operand bytes.
+//
+// This is a heuristic. Random byte pairs whose value happens to point one
+// past a $20 in RAM will register as a false-positive frame; the cost is
+// a misleading annotation, never a crash.
+func detectStackFrame(ram *cpu.RAM, spLo uint16) (retAddr, target uint16, ok bool) {
+	if (spLo & 0xFF) == 0xFF {
+		return 0, 0, false
+	}
+	lo := ram.Read(spLo)
+	hi := ram.Read(spLo + 1)
+	stored := uint16(hi)<<8 | uint16(lo)
+	if stored < 2 {
+		return 0, 0, false
+	}
+	if ram.Read(stored-2) != 0x20 {
+		return 0, 0, false
+	}
+	targetLo := ram.Read(stored - 1)
+	targetHi := ram.Read(stored)
+	target = uint16(targetHi)<<8 | uint16(targetLo)
+	return stored + 1, target, true
+}
+
+// stackEntries walks upward from SP+1 building rendered rows for the stack
+// panel. Frame rows consume two bytes; runs of non-frame bytes are
+// collapsed into a single row per contiguous run. Stops at the panel-row
+// budget or at the top of the stack page ($01FF).
+func (m Model) stackEntries(maxRows int) []stackEntry {
+	out := make([]stackEntry, 0, maxRows)
+	a := uint16(m.CPU.SP) + 1
+	runStart := uint16(0)
+	runLen := 0
+	flushRun := func() {
+		if runLen == 0 {
+			return
+		}
+		out = append(out, stackEntry{addrLo: runStart, bytes: runLen})
+		runLen = 0
+	}
+	for a <= 0xFF && len(out) < maxRows {
+		sp := uint16(0x0100) | a
+		if m.StackAnnotate {
+			if ret, target, ok := detectStackFrame(m.RAM, sp); ok && len(out) < maxRows {
+				flushRun()
+				if len(out) >= maxRows {
+					break
+				}
+				e := stackEntry{
+					isFrame: true,
+					addrLo:  sp,
+					bytes:   2,
+					retAddr: ret,
+				}
+				if m.Syms != nil {
+					e.callee = m.Syms.Lookup(target)
+				}
+				if loc, ok := m.PCToSrc[ret]; ok {
+					e.src = fmt.Sprintf("%s:%d", filepath.Base(loc.File), loc.Line)
+				}
+				out = append(out, e)
+				a += 2
+				continue
+			}
+		}
+		if runLen == 0 {
+			runStart = sp
+		}
+		runLen++
+		a++
+	}
+	flushRun()
+	// flushRun may have pushed past maxRows by one — trim.
+	if len(out) > maxRows {
+		out = out[:maxRows]
+	}
+	return out
+}
+
+// stackView renders the Stack panel. When m.StackAnnotate is true (default),
+// JSR return-address pairs are surfaced as `ret $XXXX  callee  file:NN`
+// rows and adjacent non-frame bytes are collapsed. The `T` key toggles
+// the flag back to the raw one-byte-per-row layout.
+func (m Model) stackView(w, h int) string {
+	innerH := h - 2
+	if innerH < 1 {
+		innerH = 1
+	}
+	rows := innerH - 1
+	if rows < 1 {
+		rows = 1
+	}
+
+	var b strings.Builder
+
+	if !m.StackAnnotate {
+		for i := 0; i < rows; i++ {
+			spByte := uint16(m.CPU.SP) + 1 + uint16(i)
+			if spByte > 0xFF {
+				break
+			}
+			sp := 0x100 | spByte
+			marker := "  "
+			if i == 0 {
+				marker = curLine.Render(" >")
+			}
+			fmt.Fprintf(&b, "%s %s  %02X\n",
+				marker,
+				dimAddr.Render(fmt.Sprintf("$%04X", sp)),
+				m.RAM.Read(sp))
+		}
+		return fitPanel("Stack", strings.TrimRight(b.String(), "\n"), w, h)
+	}
+
+	entries := m.stackEntries(rows)
+	frameStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("214")).Bold(true)
+	runStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("244")).Italic(true)
+
+	for i, e := range entries {
+		marker := "  "
+		if i == 0 {
+			marker = curLine.Render(" >")
+		}
+		switch {
+		case e.isFrame:
+			rng := dimAddr.Render(fmt.Sprintf("$%04X-%02X", e.addrLo, (e.addrLo+1)&0xFF))
+			label := frameStyle.Render(fmt.Sprintf("ret $%04X", e.retAddr))
+			if e.callee != "" {
+				label += "  " + labelStyle.Render(e.callee)
+			}
+			if e.src != "" {
+				label += dimAddr.Render("  " + e.src)
+			}
+			fmt.Fprintf(&b, "%s %s  %s\n", marker, rng, label)
+		case e.bytes == 1:
+			fmt.Fprintf(&b, "%s %s  %02X\n",
+				marker,
+				dimAddr.Render(fmt.Sprintf("$%04X", e.addrLo)),
+				m.RAM.Read(e.addrLo))
+		default:
+			rng := dimAddr.Render(fmt.Sprintf("$%04X-%02X",
+				e.addrLo,
+				(e.addrLo+uint16(e.bytes)-1)&0xFF))
+			fmt.Fprintf(&b, "%s %s  %s\n",
+				marker, rng,
+				runStyle.Render(fmt.Sprintf("(%d bytes)", e.bytes)))
+		}
+	}
+	return fitPanel("Stack", strings.TrimRight(b.String(), "\n"), w, h)
+}

--- a/internal/tui/stack_test.go
+++ b/internal/tui/stack_test.go
@@ -1,0 +1,141 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/nkane/chippy/internal/cpu"
+)
+
+func TestDetectStackFrame_Positive(t *testing.T) {
+	ram := cpu.NewRAM()
+	// Caller routine at $8000: JSR $9000
+	//   $8000  20 00 90    JSR $9000
+	//   $8003  ...         (return target)
+	ram.Write(0x8000, 0x20) // JSR opcode
+	ram.Write(0x8001, 0x00) // operand lo
+	ram.Write(0x8002, 0x90) // operand hi
+
+	// Simulate the stack state after JSR has executed: push16(PC-1) with
+	// PC = $8003 means stored value $8002 with hi=$80 at $01FF and lo=$02
+	// at $01FE.
+	ram.Write(0x01FE, 0x02) // lo of stored ($8002)
+	ram.Write(0x01FF, 0x80) // hi
+
+	ret, target, ok := detectStackFrame(ram, 0x01FE)
+	if !ok {
+		t.Fatalf("expected frame to be detected")
+	}
+	if ret != 0x8003 {
+		t.Fatalf("want ret $8003, got $%04X", ret)
+	}
+	if target != 0x9000 {
+		t.Fatalf("want target $9000, got $%04X", target)
+	}
+}
+
+func TestDetectStackFrame_NotAJSR(t *testing.T) {
+	// Same stored value but the byte at stored-2 isn't $20 — should be
+	// rejected as a false candidate.
+	ram := cpu.NewRAM()
+	ram.Write(0x8000, 0xEA) // NOP, not JSR
+	ram.Write(0x01FE, 0x02)
+	ram.Write(0x01FF, 0x80)
+
+	if _, _, ok := detectStackFrame(ram, 0x01FE); ok {
+		t.Fatalf("should not have detected a frame without a JSR opcode")
+	}
+}
+
+func TestDetectStackFrame_TopOfPage(t *testing.T) {
+	// The high byte of the pair would live at $0200 (off the stack page).
+	// Detection must refuse so the panel renderer never reaches outside
+	// the stack window.
+	ram := cpu.NewRAM()
+	ram.Write(0x8000, 0x20)
+	ram.Write(0x01FF, 0x02)
+	ram.Write(0x0200, 0x80) // would-be hi byte — outside stack page
+
+	if _, _, ok := detectStackFrame(ram, 0x01FF); ok {
+		t.Fatalf("should refuse the very last stack slot — no pair available")
+	}
+}
+
+func TestDetectStackFrame_StoredTooLow(t *testing.T) {
+	// Stored value < 2 means there's no room for a JSR opcode below it.
+	ram := cpu.NewRAM()
+	ram.Write(0x01FE, 0x01)
+	ram.Write(0x01FF, 0x00)
+	if _, _, ok := detectStackFrame(ram, 0x01FE); ok {
+		t.Fatalf("stored=$0001 has no opcode-2 byte; should be rejected")
+	}
+}
+
+func TestStackEntries_FrameAndRun(t *testing.T) {
+	// Build a stack with two frames separated by three non-frame bytes:
+	//   $01FE-FF : frame ret $8003 (JSR at $8000)
+	//   $01FD    : random byte
+	//   $01FC    : random byte
+	//   $01FB    : random byte
+	//   $01F9-FA : frame ret $7003 (JSR at $7000)
+	ram := cpu.NewRAM()
+	ram.Write(0x8000, 0x20)
+	ram.Write(0x8001, 0x00)
+	ram.Write(0x8002, 0x90)
+	ram.Write(0x7000, 0x20)
+	ram.Write(0x7001, 0x34)
+	ram.Write(0x7002, 0x12)
+
+	// Top frame at $01FE/FF -> stored=$8002
+	ram.Write(0x01FE, 0x02)
+	ram.Write(0x01FF, 0x80)
+	// Random in-between bytes
+	ram.Write(0x01FB, 0xAA)
+	ram.Write(0x01FC, 0xBB)
+	ram.Write(0x01FD, 0xCC)
+	// Lower frame at $01F9/FA -> stored=$7002
+	ram.Write(0x01F9, 0x02)
+	ram.Write(0x01FA, 0x70)
+
+	c := cpu.New(ram)
+	c.SP = 0xF8 // SP+1 = $F9 → walk from $01F9
+
+	m := New(c, ram)
+	entries := m.stackEntries(10)
+
+	if len(entries) != 3 {
+		t.Fatalf("want 3 entries (frame, run-of-3, frame), got %d", len(entries))
+	}
+	if !entries[0].isFrame || entries[0].retAddr != 0x7003 {
+		t.Fatalf("entry 0: want frame ret $7003, got %+v", entries[0])
+	}
+	if entries[1].isFrame || entries[1].bytes != 3 || entries[1].addrLo != 0x01FB {
+		t.Fatalf("entry 1: want 3-byte run at $01FB, got %+v", entries[1])
+	}
+	if !entries[2].isFrame || entries[2].retAddr != 0x8003 {
+		t.Fatalf("entry 2: want frame ret $8003, got %+v", entries[2])
+	}
+}
+
+func TestStackEntries_DisabledAnnotation(t *testing.T) {
+	// With StackAnnotate=false the walker should collapse the entire visible
+	// region into a single run (frame detection is skipped). Renderer takes
+	// the legacy path; we still exercise stackEntries directly to confirm
+	// the flag is honored.
+	ram := cpu.NewRAM()
+	ram.Write(0x8000, 0x20)
+	ram.Write(0x01FE, 0x02)
+	ram.Write(0x01FF, 0x80)
+
+	c := cpu.New(ram)
+	c.SP = 0xFD
+
+	m := New(c, ram)
+	m.StackAnnotate = false
+	entries := m.stackEntries(4)
+
+	for i, e := range entries {
+		if e.isFrame {
+			t.Fatalf("entry %d should not be a frame when annotation is disabled: %+v", i, e)
+		}
+	}
+}


### PR DESCRIPTION
Closes #18.

## Summary
- New `stackEntries` walker + `detectStackFrame` helper in `internal/tui/stack.go`.
- Stack panel now surfaces JSR-pushed return-address pairs as `ret $XXXX  callee  file:NN` rows; non-frame bytes collapse into single `(N bytes)` lines.
- `T` keybinding toggles back to the legacy raw layout when the heuristic misfires or you want raw bytes.
- `StackAnnotate` field on `Model`, defaults true.

## Detection heuristic
For each candidate pair `(lo, hi)` at `$01XX` / `$01XX+1`:
1. `stored = (hi << 8) | lo` — what JSR pushed (PC-1 at the boundary).
2. Check `RAM[stored-2] == $20` (JSR opcode).
3. `retAddr = stored + 1` — what RTS will jump to.
4. `target = (RAM[stored] << 8) | RAM[stored-1]` — JSR's call target.
5. Resolve callee name via `Syms` and `(file:line)` via `PCToSrc` if available.

Random byte pairs pointing one past a $20 in RAM will register as a false-positive frame. The cost is a misleading annotation, never a crash. `T` reveals the underlying bytes.

## Docs (per CLAUDE.md \"docs in every PR\")
- README.md: stack panel paragraph + `T` keybinding.
- docs/context.md: moves #18 from Open to Merged-PRs-of-note.
- TUI help modal: new \"Stack panel\" section.

## Test plan
- [x] `go build ./...` — green.
- [x] `go test -race ./...` — 6 new stack tests cover detection positives, negatives (no JSR / page boundary / stored<2), and the walker (frame+run+frame layout, disabled-annotation path).
- [x] `golangci-lint run` — 0 issues.
- [x] Live TUI smoke test: panel renders without crash; demo's no-JSR stack shows the SP pair as a collapsed run (no false-positive frame).