### PR TITLE
feat(tui): byte-level memory cursor and inline hex editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,11 @@ The stack panel detects JSR-pushed return-address pairs and renders them as
 single `(N bytes)` lines so the call chain stays readable. Press `T` to
 toggle back to the raw one-byte-per-row layout.
 
+The memory panel has a byte-level cursor (arrow keys move ±1 / ±$10, view
+auto-scrolls). Press `e` at the cursor to poke a byte: type 1–2 hex digits,
+Enter commits, Esc cancels. Edits are runtime-only — `R` (reset) reloads
+the original program bytes.
+
 ---
 
 ## Status

--- a/docs/context.md
+++ b/docs/context.md
@@ -140,10 +140,10 @@ Bus chain: `CPU → tui.WBus → cpu.MMIO → cpu.RAM`
 - #36 — Per-instruction execution trace (issue #21): `cpu.Tracer` hook on `Step()`, `cpu.FileTracer` (buffered 64K), `-trace PATH` CLI flag, `:trace PATH|on|off` TUI command
 - #38 — CLAUDE.md "docs are part of every PR" rule: README/context/help-modal/exported docs move with code
 - #39 — Stack panel JSR-frame annotation (issue #18): detects pushed return-address pairs via the `$20` opcode at `stored-2`; renders `ret $XXXX  callee  file:NN`; collapses non-frame runs; `T` toggles raw view
+- #40 — Memory editor (issue #19): byte-level `MemCursor` (arrow keys, auto-scroll), `e` enters hex edit mode at cursor; 1–2 hex chars, Enter commits, Esc cancels; cursor persists in state file; `:goto` aligns view AND moves cursor
 
 ### Open issues
 - #17 (reverse step) — record/replay micro-history
-- #19 (memory editor) — interactive hex editor in TUI
 - #20 (prompt history) — up-arrow recall in command prompt
 - #22 (homebrew-core) — blocked on stars
 

--- a/internal/tui/memedit.go
+++ b/internal/tui/memedit.go
@@ -1,0 +1,98 @@
+package tui
+
+import (
+	"fmt"
+	"strconv"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// memEditResult is what handleMemEditKey reports back to the Update loop.
+//
+//	committed: the user pressed Enter with a valid hex byte; the RAM write
+//	           already happened. Status reflects the address + value.
+//	cancelled: Esc, ctrl+c, or Enter on an empty buffer. No RAM change.
+//	editing:   the key was consumed but we're still accumulating hex chars.
+type memEditResult int
+
+const (
+	memEditEditing memEditResult = iota
+	memEditCommitted
+	memEditCancelled
+	memEditQuit
+)
+
+// handleMemEditKey advances the memory editor's state machine. It owns
+// MemEditBuf while editing and writes RAM on commit. Keeping this separate
+// from updateMemEdit (which deals with the tea.KeyMsg + tea.Cmd dance)
+// makes it directly unit-testable with plain strings.
+func (m *Model) handleMemEditKey(s string) memEditResult {
+	switch s {
+	case "ctrl+c":
+		m.MemEditing = false
+		m.MemEditBuf = ""
+		return memEditQuit
+	case "esc":
+		m.MemEditing = false
+		m.MemEditBuf = ""
+		m.Status = "edit cancelled"
+		return memEditCancelled
+	case "enter":
+		if m.MemEditBuf == "" {
+			m.MemEditing = false
+			m.Status = "edit cancelled (empty)"
+			return memEditCancelled
+		}
+		v, err := strconv.ParseUint(m.MemEditBuf, 16, 8)
+		if err != nil {
+			m.Status = fmt.Sprintf("bad hex: %s", m.MemEditBuf)
+			m.MemEditing = false
+			m.MemEditBuf = ""
+			return memEditCancelled
+		}
+		m.RAM.Write(m.MemCursor, byte(v))
+		m.Status = fmt.Sprintf("$%04X <- $%02X", m.MemCursor, byte(v))
+		m.MemEditing = false
+		m.MemEditBuf = ""
+		return memEditCommitted
+	case "backspace":
+		if len(m.MemEditBuf) > 0 {
+			m.MemEditBuf = m.MemEditBuf[:len(m.MemEditBuf)-1]
+		}
+		return memEditEditing
+	}
+	if len(s) == 1 && isHexDigit(s[0]) && len(m.MemEditBuf) < 2 {
+		m.MemEditBuf += s
+	}
+	return memEditEditing
+}
+
+func isHexDigit(b byte) bool {
+	return (b >= '0' && b <= '9') ||
+		(b >= 'a' && b <= 'f') ||
+		(b >= 'A' && b <= 'F')
+}
+
+// updateMemEdit owns input while the memory editor is active. Quit (ctrl+c)
+// still flushes state via saveState/tracer.Close just like the normal quit
+// path.
+func (m Model) updateMemEdit(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch m.handleMemEditKey(msg.String()) {
+	case memEditQuit:
+		m.saveState()
+		return m, tea.Quit
+	default:
+		return m, m.scheduleTick()
+	}
+}
+
+// memCursorMoved snaps MemViewAddr to keep MemCursor visible. Approximates
+// the visible window as 16 rows (0x100 bytes) — close enough that a
+// fine-grained cursor doesn't disappear off-panel after a single arrow.
+func (m *Model) memCursorMoved() {
+	base := m.MemViewAddr & 0xFFF0
+	const approxVisible = uint16(0x100)
+	if m.MemCursor < base || m.MemCursor-base >= approxVisible {
+		m.MemViewAddr = m.MemCursor & 0xFFF0
+	}
+}

--- a/internal/tui/memedit_test.go
+++ b/internal/tui/memedit_test.go
@@ -1,0 +1,147 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/nkane/chippy/internal/cpu"
+)
+
+func newEditModel() Model {
+	ram := cpu.NewRAM()
+	c := cpu.New(ram)
+	m := New(c, ram)
+	return m
+}
+
+func TestMemEdit_CommitTwoChar(t *testing.T) {
+	m := newEditModel()
+	m.MemCursor = 0x0200
+	m.MemEditing = true
+
+	if r := m.handleMemEditKey("4"); r != memEditEditing {
+		t.Fatalf("after '4' want editing, got %v", r)
+	}
+	if r := m.handleMemEditKey("2"); r != memEditEditing {
+		t.Fatalf("after '2' want editing, got %v", r)
+	}
+	if m.MemEditBuf != "42" {
+		t.Fatalf("buffer want %q, got %q", "42", m.MemEditBuf)
+	}
+	if r := m.handleMemEditKey("enter"); r != memEditCommitted {
+		t.Fatalf("after enter want committed, got %v", r)
+	}
+	if got := m.RAM.Read(0x0200); got != 0x42 {
+		t.Fatalf("RAM[$0200] want $42, got $%02X", got)
+	}
+	if m.MemEditing {
+		t.Fatalf("editing flag should be cleared after commit")
+	}
+	if m.MemEditBuf != "" {
+		t.Fatalf("buffer should be cleared after commit, got %q", m.MemEditBuf)
+	}
+}
+
+func TestMemEdit_CommitSingleChar(t *testing.T) {
+	// One nibble = lower nibble; parseUint("a", 16) = 0x0A.
+	m := newEditModel()
+	m.MemCursor = 0x0205
+	m.MemEditing = true
+
+	m.handleMemEditKey("a")
+	if r := m.handleMemEditKey("enter"); r != memEditCommitted {
+		t.Fatalf("want committed, got %v", r)
+	}
+	if got := m.RAM.Read(0x0205); got != 0x0A {
+		t.Fatalf("RAM[$0205] want $0A, got $%02X", got)
+	}
+}
+
+func TestMemEdit_EnterEmptyCancels(t *testing.T) {
+	m := newEditModel()
+	m.MemCursor = 0x0210
+	m.MemEditing = true
+	m.RAM.Write(0x0210, 0x99)
+
+	if r := m.handleMemEditKey("enter"); r != memEditCancelled {
+		t.Fatalf("want cancelled, got %v", r)
+	}
+	if got := m.RAM.Read(0x0210); got != 0x99 {
+		t.Fatalf("byte should be untouched: got $%02X", got)
+	}
+}
+
+func TestMemEdit_Esc(t *testing.T) {
+	m := newEditModel()
+	m.MemCursor = 0x0211
+	m.MemEditing = true
+	m.RAM.Write(0x0211, 0x77)
+	m.handleMemEditKey("3")
+	m.handleMemEditKey("3")
+	if r := m.handleMemEditKey("esc"); r != memEditCancelled {
+		t.Fatalf("want cancelled, got %v", r)
+	}
+	if got := m.RAM.Read(0x0211); got != 0x77 {
+		t.Fatalf("esc should discard buffer: got $%02X", got)
+	}
+	if m.MemEditing {
+		t.Fatalf("editing should be off")
+	}
+}
+
+func TestMemEdit_Backspace(t *testing.T) {
+	m := newEditModel()
+	m.MemEditing = true
+	m.handleMemEditKey("a")
+	m.handleMemEditKey("b")
+	m.handleMemEditKey("backspace")
+	if m.MemEditBuf != "a" {
+		t.Fatalf("backspace want %q, got %q", "a", m.MemEditBuf)
+	}
+	m.handleMemEditKey("backspace")
+	m.handleMemEditKey("backspace") // no-op on empty
+	if m.MemEditBuf != "" {
+		t.Fatalf("backspace-empty want %q, got %q", "", m.MemEditBuf)
+	}
+}
+
+func TestMemEdit_RejectThirdChar(t *testing.T) {
+	m := newEditModel()
+	m.MemEditing = true
+	m.handleMemEditKey("f")
+	m.handleMemEditKey("f")
+	m.handleMemEditKey("a") // should be ignored — buffer full
+	if m.MemEditBuf != "ff" {
+		t.Fatalf("third char must be rejected, got %q", m.MemEditBuf)
+	}
+}
+
+func TestMemEdit_NonHexIgnored(t *testing.T) {
+	m := newEditModel()
+	m.MemEditing = true
+	m.handleMemEditKey("z")
+	m.handleMemEditKey("!")
+	m.handleMemEditKey(" ")
+	if m.MemEditBuf != "" {
+		t.Fatalf("non-hex chars must be ignored, got %q", m.MemEditBuf)
+	}
+}
+
+func TestMemCursorMoved_ReanchorsViewWhenOutOfRange(t *testing.T) {
+	m := newEditModel()
+	m.MemViewAddr = 0x0200
+	m.MemCursor = 0x0500
+	m.memCursorMoved()
+	if m.MemViewAddr != 0x0500 {
+		t.Fatalf("view should re-anchor to $0500, got $%04X", m.MemViewAddr)
+	}
+}
+
+func TestMemCursorMoved_KeepsViewWhenInRange(t *testing.T) {
+	m := newEditModel()
+	m.MemViewAddr = 0x0200
+	m.MemCursor = 0x0245
+	m.memCursorMoved()
+	if m.MemViewAddr != 0x0200 {
+		t.Fatalf("view shouldn't move while cursor in range, got $%04X", m.MemViewAddr)
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -29,6 +29,8 @@ var (
 	memBPRead  = lipgloss.NewStyle().Foreground(lipgloss.Color("33")).Bold(true)  // 👁 blue
 	memBPWrite = lipgloss.NewStyle().Foreground(lipgloss.Color("196")).Bold(true) // ✏ red
 	memBPRW    = lipgloss.NewStyle().Foreground(lipgloss.Color("213")).Bold(true) // 🔁 magenta
+	memCursor  = lipgloss.NewStyle().Reverse(true).Bold(true)                     // mem-panel byte cursor
+	memEdit    = lipgloss.NewStyle().Foreground(lipgloss.Color("226")).Background(lipgloss.Color("88")).Bold(true)
 )
 
 const (
@@ -104,6 +106,13 @@ type Model struct {
 	// with callee + source info; consecutive non-frame bytes are collapsed.
 	// false: legacy one-byte-per-row layout. `T` key toggles.
 	StackAnnotate bool
+
+	// Memory-panel byte cursor. MemViewAddr is the row-anchored top-left
+	// of the panel; MemCursor is the byte highlighted within (any address,
+	// not row-aligned). Arrow keys move the cursor; `e` enters edit mode.
+	MemCursor  uint16
+	MemEditing bool
+	MemEditBuf string
 
 	// Disassembly viewport: when DisasmFollow is true (default), the panel
 	// re-anchors on PC each frame. User scroll keys flip it off and pin
@@ -232,6 +241,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.InputMode {
 			return m.updateInputMode(msg)
 		}
+		// Memory editor owns input while open.
+		if m.MemEditing {
+			return m.updateMemEdit(msg)
+		}
 
 		switch msg.String() {
 		case "q", "ctrl+c":
@@ -324,9 +337,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.lastRunNS = 0
 			m.cycleDebt = 0
 			m.Status = "speed: max"
-		case "j", "down":
+		case "j":
 			m.MemViewAddr += 0x10
-		case "k", "up":
+		case "k":
 			m.MemViewAddr -= 0x10
 		case "J", "pgdown":
 			m.MemViewAddr += 0x100
@@ -336,6 +349,22 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.MemViewAddr = 0
 		case "G":
 			m.MemViewAddr = 0xFF00
+		case "left":
+			m.MemCursor--
+			m.memCursorMoved()
+		case "right":
+			m.MemCursor++
+			m.memCursorMoved()
+		case "up":
+			m.MemCursor -= 0x10
+			m.memCursorMoved()
+		case "down":
+			m.MemCursor += 0x10
+			m.memCursorMoved()
+		case "e":
+			m.MemEditing = true
+			m.MemEditBuf = ""
+			m.Status = fmt.Sprintf("edit $%04X (hex; enter=commit esc=cancel)", m.MemCursor)
 		case "[":
 			m.disasmScroll(-1)
 		case "]":
@@ -827,11 +856,13 @@ func (m Model) helpModal() string {
 			{"0", "unthrottled (max)"},
 		}},
 		{"Memory view", [][2]string{
-			{"j / ↓", "scroll down by $10"},
-			{"k / ↑", "scroll up by $10"},
+			{"j / k", "scroll down / up by $10"},
 			{"J / PgDn", "scroll down by $100"},
 			{"K / PgUp", "scroll up by $100"},
 			{"g / G", "jump to $0000 / $FF00"},
+			{"← →", "move byte cursor ±1"},
+			{"↑ ↓", "move byte cursor ±$10 (auto-scrolls)"},
+			{"e", "edit byte at cursor (hex; enter=commit esc=cancel)"},
 		}},
 		{"Disassembly", [][2]string{
 			{"[ / ]", "scroll one instruction up / down"},
@@ -1421,15 +1452,32 @@ func (m Model) memView(w, h int) string {
 		for col := 0; col < 16; col++ {
 			a := base + uint16(col)
 			v := m.RAM.Read(a)
-			cell := fmt.Sprintf(" %02X", v)
+			byteStr := fmt.Sprintf("%02X", v)
+			cell := " " + byteStr
+
 			if mbp, ok := m.MemBPs[a]; ok && mbp != nil {
 				switch mbp.Kind {
 				case MemBPRead:
-					cell = " " + memBPRead.Render(fmt.Sprintf("%02X", v))
+					cell = " " + memBPRead.Render(byteStr)
 				case MemBPWrite:
-					cell = " " + memBPWrite.Render(fmt.Sprintf("%02X", v))
+					cell = " " + memBPWrite.Render(byteStr)
 				case MemBPReadWrite:
-					cell = " " + memBPRW.Render(fmt.Sprintf("%02X", v))
+					cell = " " + memBPRW.Render(byteStr)
+				}
+			}
+			if a == m.MemCursor {
+				switch {
+				case m.MemEditing:
+					buf := m.MemEditBuf
+					switch len(buf) {
+					case 0:
+						buf = "__"
+					case 1:
+						buf = "_" + buf
+					}
+					cell = " " + memEdit.Render(buf)
+				default:
+					cell = " " + memCursor.Render(byteStr)
 				}
 			}
 			b.WriteString(cell)
@@ -1441,6 +1489,6 @@ func (m Model) memView(w, h int) string {
 		}
 		b.WriteString("  " + ascii.String() + "\n")
 	}
-	hint := help.Render("  (j/k ±$10  J/K ±$100  g/G top/bot)")
+	hint := help.Render(fmt.Sprintf("  (cur $%04X  arrows move  e edit)", m.MemCursor))
 	return fitPanel("Memory"+hint, strings.TrimRight(b.String(), "\n"), w, h)
 }

--- a/internal/tui/prompt.go
+++ b/internal/tui/prompt.go
@@ -60,7 +60,8 @@ func (m *Model) runCommand(line string) string {
 			return err.Error()
 		}
 		m.MemViewAddr = addr & 0xFFF0
-		return fmt.Sprintf("mem -> $%04X", m.MemViewAddr)
+		m.MemCursor = addr
+		return fmt.Sprintf("mem -> $%04X", addr)
 	case "pc":
 		if len(args) == 0 {
 			return "usage: :pc $XXXX"

--- a/internal/tui/state.go
+++ b/internal/tui/state.go
@@ -15,6 +15,7 @@ type savedState struct {
 	Breakpoints json.RawMessage `json:"breakpoints,omitempty"`
 	MemBPs      json.RawMessage `json:"mem_bps,omitempty"`
 	MemViewAddr uint16          `json:"mem_view_addr"`
+	MemCursor   uint16          `json:"mem_cursor,omitempty"`
 	Watches     []Watch         `json:"watches"`
 	TargetHz    int             `json:"target_hz"`
 }
@@ -29,6 +30,7 @@ func loadState(m *Model, path string) {
 		return
 	}
 	m.MemViewAddr = s.MemViewAddr
+	m.MemCursor = s.MemCursor
 	m.Watches = s.Watches
 	m.TargetHz = s.TargetHz
 	if m.Breakpoints == nil {
@@ -138,6 +140,7 @@ func (m *Model) saveState() {
 		Breakpoints: raw,
 		MemBPs:      mraw,
 		MemViewAddr: m.MemViewAddr,
+		MemCursor:   m.MemCursor,
 		Watches:     m.Watches,
 		TargetHz:    m.TargetHz,
 	}


### PR DESCRIPTION
Closes #19.

## Summary
- New `MemCursor` field on Model — a byte-level cursor distinct from the row-anchored `MemViewAddr`.
- Arrow keys move the cursor (`← →` ±1, `↑ ↓` ±$10) with auto-scroll; `j/k` still scroll the view by rows.
- `e` enters edit mode at the cursor. Hex buffer rendered inverse-video in the cell. 1-2 hex digits accepted; Enter commits, Esc cancels, Backspace pops. Single-digit commit treated as low nibble (`a` → $0A).
- `:goto ADDR` now sets both view AND cursor.
- Cursor address persists across sessions via an appended `mem_cursor` field in the state file.

## Behavior split
| keys              | behavior                                          |
|-------------------|---------------------------------------------------|
| `j` / `k`     | view scroll ±$10 (cursor stays where it is)       |
| `J` / `K`     | view scroll ±$100                                |
| `g` / `G`     | view jump $0000 / $FF00                          |
| `←` `→` `↑` `↓` | move cursor ±1 / ±$10, auto-scroll view       |
| `e`             | edit byte at cursor                               |

## Docs (per CLAUDE.md \"docs in every PR\")
- README: paragraph on the byte cursor + edit flow.
- docs/context.md: #19 moves to Merged-PRs-of-note.
- TUI help modal: Memory-view section rewritten.

## Test plan
- [x] `go build ./...` — green.
- [x] `go test -race ./...` — 9 new `memedit` tests cover: 2-char commit, single-nibble commit, empty-enter cancel, Esc cancel, backspace, third-char rejected, non-hex ignored, cursor re-anchor + cursor in-range.
- [x] `golangci-lint run` — 0 issues.
- [x] Live TUI smoke: down×3, right×2 puts cursor at $0032; `e`, `4`, `2`, Enter writes $42; ASCII column shows `..B..`; status: `$0032 ← $42`.