### PR TITLE
feat(tui): prompt history + tab-complete + reverse-i-search

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,13 @@ auto-scrolls). Press `e` at the cursor to poke a byte: type 1–2 hex digits,
 Enter commits, Esc cancels. Edits are runtime-only — `R` (reset) reloads
 the original program bytes.
 
+The command prompt (`:`) remembers up to 100 entries in `~/.chippy/history`.
+Up / Down walk recent commands; Tab completes the verb (when there's no
+space yet) or the symbol after `:bp` / `:goto` / `:watch` etc.; Ctrl-R
+opens a reverse-incremental search through history — each keystroke
+narrows the match, Ctrl-R again walks to the next older one, Esc restores
+the original line, Enter accepts.
+
 ---
 
 ## Status

--- a/cmd/chippy/main.go
+++ b/cmd/chippy/main.go
@@ -151,7 +151,8 @@ func main() {
 		WithWBus(wbus).
 		WithTextOutput(textOut).
 		WithKeyboard(keyIn).
-		WithTracer(tracer)
+		WithTracer(tracer).
+		WithHistoryPath(tui.DefaultHistoryPath())
 	if syms != nil {
 		model = model.WithSymbols(syms)
 	}

--- a/docs/context.md
+++ b/docs/context.md
@@ -141,10 +141,10 @@ Bus chain: `CPU → tui.WBus → cpu.MMIO → cpu.RAM`
 - #38 — CLAUDE.md "docs are part of every PR" rule: README/context/help-modal/exported docs move with code
 - #39 — Stack panel JSR-frame annotation (issue #18): detects pushed return-address pairs via the `$20` opcode at `stored-2`; renders `ret $XXXX  callee  file:NN`; collapses non-frame runs; `T` toggles raw view
 - #40 — Memory editor (issue #19): byte-level `MemCursor` (arrow keys, auto-scroll), `e` enters hex edit mode at cursor; 1–2 hex chars, Enter commits, Esc cancels; cursor persists in state file; `:goto` aligns view AND moves cursor
+- #41 — Prompt history + tab-complete (issue #20): `~/.chippy/history` (cap 100, dedup, auto-save), Up/Down recall, Tab completes verbs and `:bp <symbol>` against the loaded `.dbg`, Ctrl-R reverse-incremental search (Ctrl-R again walks older). Added `symbols.Table.NamesWithPrefix`.
 
 ### Open issues
 - #17 (reverse step) — record/replay micro-history
-- #20 (prompt history) — up-arrow recall in command prompt
 - #22 (homebrew-core) — blocked on stars
 
 ---

--- a/internal/symbols/symbols.go
+++ b/internal/symbols/symbols.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 )
@@ -51,6 +52,22 @@ func (t *Table) LookupName(name string) (uint16, bool) {
 
 // Has reports whether any symbols are loaded.
 func (t *Table) Has() bool { return t != nil && len(t.byAddr) > 0 }
+
+// NamesWithPrefix returns all symbol names whose string starts with prefix,
+// sorted lexicographically. Used for tab-completion in the TUI prompt.
+func (t *Table) NamesWithPrefix(prefix string) []string {
+	if t == nil {
+		return nil
+	}
+	out := make([]string, 0, 16)
+	for name := range t.byName {
+		if strings.HasPrefix(name, prefix) {
+			out = append(out, name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
 
 // LoadDbg parses a cc65 .dbg file and returns a populated Table.
 func LoadDbg(path string) (*Table, error) {

--- a/internal/tui/complete.go
+++ b/internal/tui/complete.go
@@ -1,0 +1,125 @@
+package tui
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/nkane/chippy/internal/symbols"
+)
+
+// defaultVerbs is the static set of prompt commands. Kept in sync with the
+// switch in runCommand. Sorted at init so completePrompt can scan linearly.
+var defaultVerbs = func() []string {
+	v := []string{
+		"goto", "g",
+		"pc",
+		"run",
+		"watch", "w",
+		"rmwatch", "unwatch",
+		"clearwatch",
+		"speed",
+		"bp", "bpr", "bpw", "bprw",
+		"rmbpr", "rmbpw", "rmbprw",
+		"trace",
+		"help", "?",
+		"q", "quit",
+	}
+	sort.Strings(v)
+	return v
+}()
+
+// verbsTakingAddr lists prompt verbs whose first argument is an address or
+// a symbol name — these get tab-completion against the loaded symbol table.
+var verbsTakingAddr = map[string]bool{
+	"goto":    true,
+	"g":       true,
+	"pc":      true,
+	"run":     true,
+	"watch":   true,
+	"w":       true,
+	"rmwatch": true,
+	"unwatch": true,
+	"bp":      true,
+	"bpr":     true,
+	"bpw":     true,
+	"bprw":    true,
+	"rmbpr":   true,
+	"rmbpw":   true,
+	"rmbprw":  true,
+}
+
+// completePrompt extends buf toward the longest unambiguous completion.
+// Returns (newBuf, ok) where ok=true means buf grew. Two regimes:
+//
+//   - no space yet -> complete the verb against defaultVerbs.
+//   - first arg of an address-taking verb -> complete against syms.
+//
+// All other inputs return (buf, false) so a caller can tell when to ring
+// the bell or just no-op.
+func completePrompt(buf string, syms *symbols.Table) (string, bool) {
+	spaceIdx := strings.Index(buf, " ")
+	if spaceIdx < 0 {
+		match := matchesWithPrefix(defaultVerbs, buf)
+		if len(match) == 0 {
+			return buf, false
+		}
+		// Unique match -> commit it and add a trailing space so the user
+		// can keep typing the argument without re-tabbing. Handles both
+		// "bpr" -> "bpr " (extension) and "bprw" -> "bprw " (already full).
+		if len(match) == 1 {
+			return match[0] + " ", true
+		}
+		lcp := longestCommonPrefix(match)
+		if lcp == "" || lcp == buf {
+			return buf, false
+		}
+		return lcp, true
+	}
+	verb := buf[:spaceIdx]
+	if !verbsTakingAddr[verb] {
+		return buf, false
+	}
+	prefix := buf[:spaceIdx+1]
+	arg := buf[spaceIdx+1:]
+	if syms == nil {
+		return buf, false
+	}
+	names := syms.NamesWithPrefix(arg)
+	lcp := longestCommonPrefix(names)
+	if lcp == "" || lcp == arg {
+		return buf, false
+	}
+	return prefix + lcp, true
+}
+
+func matchesWithPrefix(pool []string, prefix string) []string {
+	out := make([]string, 0, 4)
+	for _, s := range pool {
+		if strings.HasPrefix(s, prefix) {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func longestCommonPrefix(ss []string) string {
+	if len(ss) == 0 {
+		return ""
+	}
+	p := ss[0]
+	for _, s := range ss[1:] {
+		n := len(p)
+		if len(s) < n {
+			n = len(s)
+		}
+		i := 0
+		for i < n && p[i] == s[i] {
+			i++
+		}
+		p = p[:i]
+		if p == "" {
+			return ""
+		}
+	}
+	return p
+}

--- a/internal/tui/complete_test.go
+++ b/internal/tui/complete_test.go
@@ -1,0 +1,119 @@
+package tui
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nkane/chippy/internal/symbols"
+)
+
+func TestComplete_VerbExactlyOne(t *testing.T) {
+	got, ok := completePrompt("clearw", nil)
+	if !ok {
+		t.Fatalf("expected match")
+	}
+	if got != "clearwatch " {
+		t.Fatalf("want %q (with trailing space), got %q", "clearwatch ", got)
+	}
+}
+
+func TestComplete_VerbAmbiguousNoExtension(t *testing.T) {
+	if _, ok := completePrompt("bp", nil); ok {
+		t.Fatalf("ambiguous prefix shouldn't complete: bp matches bp/bpr/bpw/bprw")
+	}
+}
+
+func TestComplete_VerbUniqueAddsSpace(t *testing.T) {
+	got, ok := completePrompt("bprw", nil)
+	if !ok {
+		t.Fatalf("bprw unique -> should add trailing space")
+	}
+	if got != "bprw " {
+		t.Fatalf("want %q, got %q", "bprw ", got)
+	}
+}
+
+func TestComplete_VerbNoMatch(t *testing.T) {
+	if _, ok := completePrompt("zzz", nil); ok {
+		t.Fatalf("no-match prefix should not complete")
+	}
+}
+
+func TestComplete_SymbolUnique(t *testing.T) {
+	tbl := buildSyms(t, "main", 0x8000)
+	got, ok := completePrompt("bp m", tbl)
+	if !ok {
+		t.Fatalf("expected completion of `bp m` -> `bp main`")
+	}
+	if got != "bp main" {
+		t.Fatalf("want %q, got %q", "bp main", got)
+	}
+}
+
+func TestComplete_SymbolAmbiguous(t *testing.T) {
+	tbl := buildSyms(t, "main", 0x8000, "main_loop", 0x8010, "main_end", 0x8030)
+	got, ok := completePrompt("bp m", tbl)
+	if !ok {
+		t.Fatalf("expected partial completion to `main`")
+	}
+	if got != "bp main" {
+		t.Fatalf("want partial %q, got %q", "bp main", got)
+	}
+	if _, ok := completePrompt("bp main", tbl); ok {
+		t.Fatalf("further tab when lcp == input should not extend")
+	}
+}
+
+func TestComplete_VerbThatDoesNotTakeAddr(t *testing.T) {
+	tbl := buildSyms(t, "main", 0x8000)
+	if _, ok := completePrompt("clearwatch m", tbl); ok {
+		t.Fatalf("non-addr verb should not get symbol completion")
+	}
+}
+
+func TestLongestCommonPrefix(t *testing.T) {
+	cases := []struct {
+		in   []string
+		want string
+	}{
+		{nil, ""},
+		{[]string{}, ""},
+		{[]string{"foo"}, "foo"},
+		{[]string{"foo", "foobar"}, "foo"},
+		{[]string{"foo", "fab"}, "f"},
+		{[]string{"foo", "bar"}, ""},
+		{[]string{"aaa", "aab", "aac"}, "aa"},
+	}
+	for _, c := range cases {
+		if got := longestCommonPrefix(c.in); got != c.want {
+			t.Errorf("lcp(%v): want %q, got %q", c.in, c.want, got)
+		}
+	}
+}
+
+// buildSyms writes a minimal cc65-style .dbg file with one `sym` record
+// per (name, addr) pair, then loads it through the real parser so the test
+// exercises the public Table type without relying on internal fields.
+func buildSyms(t *testing.T, nameAddr ...interface{}) *symbols.Table {
+	t.Helper()
+	if len(nameAddr)%2 != 0 {
+		t.Fatalf("buildSyms: odd number of name/addr args")
+	}
+	path := filepath.Join(t.TempDir(), "x.dbg")
+	var body []byte
+	for i := 0; i < len(nameAddr); i += 2 {
+		name := nameAddr[i].(string)
+		addr := nameAddr[i+1].(int)
+		body = append(body, []byte(fmt.Sprintf("sym\tname=\"%s\",val=0x%04X\n", name, addr))...)
+	}
+	if err := os.WriteFile(path, body, 0o644); err != nil {
+		t.Fatalf("write dbg: %v", err)
+	}
+	tbl, err := symbols.LoadDbg(path)
+	if err != nil {
+		t.Fatalf("LoadDbg: %v", err)
+	}
+	return tbl
+}

--- a/internal/tui/history.go
+++ b/internal/tui/history.go
@@ -1,0 +1,76 @@
+package tui
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+)
+
+// histCap caps the in-memory + on-disk history. 100 lines is plenty for
+// interactive debugger sessions and keeps the file under a few KB.
+const histCap = 100
+
+// loadHistory reads up to histCap most-recent lines from path. Missing or
+// unreadable files yield a nil slice — never an error — so the prompt is
+// usable on first run.
+func loadHistory(path string) []string {
+	if path == "" {
+		return nil
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+	var out []string
+	s := bufio.NewScanner(f)
+	s.Buffer(make([]byte, 0, 4096), 64*1024)
+	for s.Scan() {
+		line := s.Text()
+		if line != "" {
+			out = append(out, line)
+		}
+	}
+	if len(out) > histCap {
+		out = out[len(out)-histCap:]
+	}
+	return out
+}
+
+// saveHistory writes history to path, creating the parent directory as
+// needed. Failures are silently swallowed at the call site — losing
+// history is a quality-of-life regression, not a correctness bug.
+func saveHistory(path string, history []string) error {
+	if path == "" {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	w := bufio.NewWriter(f)
+	for _, line := range history {
+		if _, err := w.WriteString(line); err != nil {
+			return err
+		}
+		if err := w.WriteByte('\n'); err != nil {
+			return err
+		}
+	}
+	return w.Flush()
+}
+
+// DefaultHistoryPath returns ~/.chippy/history. Unlike state files, history
+// isn't per-ROM — debugger muscle-memory commands (`:bp main`, `:speed 1000`)
+// carry over across projects.
+func DefaultHistoryPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".chippy", "history")
+}

--- a/internal/tui/history_test.go
+++ b/internal/tui/history_test.go
@@ -1,0 +1,171 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/nkane/chippy/internal/cpu"
+)
+
+func TestHistory_LoadMissingFile(t *testing.T) {
+	if got := loadHistory(filepath.Join(t.TempDir(), "nope")); got != nil {
+		t.Fatalf("missing file should yield nil, got %v", got)
+	}
+	if got := loadHistory(""); got != nil {
+		t.Fatalf("empty path should yield nil, got %v", got)
+	}
+}
+
+func TestHistory_SaveLoadRoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "history")
+	want := []string{":bp main", ":speed 1000", ":goto $0200"}
+	if err := saveHistory(path, want); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got := loadHistory(path)
+	if len(got) != len(want) {
+		t.Fatalf("count: want %d, got %d", len(want), len(got))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("entry %d: want %q, got %q", i, want[i], got[i])
+		}
+	}
+}
+
+func TestHistory_CapAtHistCap(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "history")
+	big := make([]string, histCap+50)
+	for i := range big {
+		big[i] = "cmd"
+	}
+	if err := saveHistory(path, big); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	// Manually write more lines than the cap to verify loader trims to last
+	// histCap.
+	extra := make([]byte, 0)
+	for i := 0; i < histCap+50; i++ {
+		extra = append(extra, []byte("x\n")...)
+	}
+	if err := os.WriteFile(path, extra, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got := loadHistory(path)
+	if len(got) != histCap {
+		t.Fatalf("cap: want %d, got %d", histCap, len(got))
+	}
+}
+
+func newPromptModel() Model {
+	c := cpu.New(cpu.NewRAM())
+	return New(c, cpu.NewRAM()).WithHistoryPath("")
+}
+
+func TestAppendHistory_DedupConsecutive(t *testing.T) {
+	m := newPromptModel()
+	m.appendHistory(":bp main")
+	m.appendHistory(":bp main")
+	if len(m.History) != 1 {
+		t.Fatalf("consecutive dup should not duplicate; got %v", m.History)
+	}
+	m.appendHistory(":speed 100")
+	m.appendHistory(":bp main")
+	if len(m.History) != 3 {
+		t.Fatalf("non-consecutive dup is allowed; got %v", m.History)
+	}
+}
+
+func TestAppendHistory_EmptyIgnored(t *testing.T) {
+	m := newPromptModel()
+	m.appendHistory("")
+	m.appendHistory("   ")
+	// `appendHistory` already trims via caller; empty after trim filters here.
+	// We pass non-trimmed strings to confirm logic path.
+	if len(m.History) != 1 {
+		// "   " is non-empty technically — only "" is rejected by the func
+		// directly, "   " requires runCommand's TrimSpace to filter. That's
+		// expected.
+		t.Logf("note: appendHistory only rejects truly-empty strings, got %v", m.History)
+	}
+}
+
+func TestHistoryBackForward_Sequence(t *testing.T) {
+	m := newPromptModel()
+	m.appendHistory(":a")
+	m.appendHistory(":b")
+	m.appendHistory(":c")
+	m.PromptBuf = "draft"
+	m.historyBack() // idx 0 -> ":c"
+	if m.PromptBuf != ":c" {
+		t.Fatalf("back#1: want :c, got %q", m.PromptBuf)
+	}
+	m.historyBack() // idx 1 -> ":b"
+	if m.PromptBuf != ":b" {
+		t.Fatalf("back#2: want :b, got %q", m.PromptBuf)
+	}
+	m.historyBack() // idx 2 -> ":a"
+	if m.PromptBuf != ":a" {
+		t.Fatalf("back#3: want :a, got %q", m.PromptBuf)
+	}
+	m.historyBack() // out of range, stays at :a
+	if m.PromptBuf != ":a" {
+		t.Fatalf("back-clamp: want :a, got %q", m.PromptBuf)
+	}
+	m.historyForward()
+	if m.PromptBuf != ":b" {
+		t.Fatalf("fwd#1: want :b, got %q", m.PromptBuf)
+	}
+	m.historyForward()
+	if m.PromptBuf != ":c" {
+		t.Fatalf("fwd#2: want :c, got %q", m.PromptBuf)
+	}
+	m.historyForward() // restores HistTemp "draft"
+	if m.PromptBuf != "draft" {
+		t.Fatalf("fwd-restore-draft: want draft, got %q", m.PromptBuf)
+	}
+	if m.HistIdx != -1 {
+		t.Fatalf("HistIdx after restore: want -1, got %d", m.HistIdx)
+	}
+}
+
+func TestRISearchMatch_NewestFirst(t *testing.T) {
+	m := newPromptModel()
+	m.appendHistory(":bp foo")
+	m.appendHistory(":bp main")
+	m.appendHistory(":speed 100")
+	m.appendHistory(":bp loop")
+	m.RISearchActive = true
+	m.RISearchBuf = "bp"
+	m.refreshRIMatch()
+	if m.PromptBuf != ":bp loop" {
+		t.Fatalf("newest bp-match should be :bp loop, got %q", m.PromptBuf)
+	}
+	m.advanceRIMatch()
+	if m.PromptBuf != ":bp main" {
+		t.Fatalf("next older: want :bp main, got %q", m.PromptBuf)
+	}
+	m.advanceRIMatch()
+	if m.PromptBuf != ":bp foo" {
+		t.Fatalf("oldest: want :bp foo, got %q", m.PromptBuf)
+	}
+	m.advanceRIMatch() // no older match
+	if m.PromptBuf != ":bp foo" {
+		t.Fatalf("advance past oldest should clamp, got %q", m.PromptBuf)
+	}
+}
+
+func TestRISearchMatch_EmptyPatternClears(t *testing.T) {
+	m := newPromptModel()
+	m.appendHistory(":bp main")
+	m.RISearchActive = true
+	m.RISearchBuf = ""
+	m.refreshRIMatch()
+	if m.PromptBuf != "" {
+		t.Fatalf("empty pattern should clear PromptBuf, got %q", m.PromptBuf)
+	}
+	if m.RIMatchIdx != -1 {
+		t.Fatalf("empty pattern should null match idx, got %d", m.RIMatchIdx)
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -85,6 +85,24 @@ type Model struct {
 	PromptActive bool
 	PromptBuf    string
 
+	// Prompt command history. Persisted to HistPath when set, capped at
+	// histCap entries. HistIdx walks back from the newest entry; -1 means
+	// "not navigating, PromptBuf is live". HistTemp saves the in-progress
+	// buffer when the user starts walking with Up so Down restores it.
+	History  []string
+	HistPath string
+	HistIdx  int
+	HistTemp string
+
+	// Reverse-incremental search (Ctrl+R) sub-state. When RISearchActive,
+	// keystrokes feed RISearchBuf, PromptBuf shows the matched entry, and
+	// RIOrigBuf is restored on Esc. RIMatchIdx is the History index of
+	// the current match or -1 if none.
+	RISearchActive bool
+	RISearchBuf    string
+	RIOrigBuf      string
+	RIMatchIdx     int
+
 	// State persistence
 	StatePath string
 
@@ -140,6 +158,8 @@ func New(c *cpu.CPU, r *cpu.RAM) Model {
 		TargetHz:      0,
 		DisasmFollow:  true,
 		StackAnnotate: true,
+		HistIdx:       -1,
+		RIMatchIdx:    -1,
 		W:             120,
 		H:             40,
 	}
@@ -188,6 +208,15 @@ func (m Model) WithKeyboard(k *peripheral.KeyboardInput) Model {
 // WithTracer attaches a CPU execution tracer for runtime control via :trace.
 func (m Model) WithTracer(t *cpu.FileTracer) Model {
 	m.Tracer = t
+	return m
+}
+
+// WithHistoryPath enables persistent prompt history at path (typically
+// tui.DefaultHistoryPath()). Loads existing history on attach; the prompt
+// auto-saves on every committed command.
+func (m Model) WithHistoryPath(p string) Model {
+	m.HistPath = p
+	m.History = loadHistory(p)
 	return m
 }
 
@@ -873,6 +902,12 @@ func (m Model) helpModal() string {
 			{"T", "toggle JSR-frame annotation / raw bytes"},
 			{"annotated", "ret $XXXX + callee + source line per JSR pair"},
 			{"raw", "one byte per row from SP up"},
+		}},
+		{"Prompt", [][2]string{
+			{"↑ / ↓", "walk command history (persisted to ~/.chippy/history)"},
+			{"Tab", "complete verb (no space yet) or symbol (after :bp etc.)"},
+			{"Ctrl-R", "reverse-incremental search through history (Ctrl-R again = next)"},
+			{"Esc", "cancel prompt or RI search"},
 		}},
 		{"General", [][2]string{
 			{":", "command line (:goto :pc :watch :speed :bp)"},

--- a/internal/tui/prompt.go
+++ b/internal/tui/prompt.go
@@ -16,17 +16,27 @@ var promptStyle = lipgloss.NewStyle().
 	Padding(0, 1)
 
 // updatePrompt handles keystrokes while the `:` command line is active.
+// Reverse-i-search sub-mode takes precedence when active.
 func (m Model) updatePrompt(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.RISearchActive {
+		return m.updateRISearch(msg)
+	}
 	switch msg.String() {
 	case "esc", "ctrl+c":
 		m.PromptActive = false
 		m.PromptBuf = ""
+		m.HistIdx = -1
+		m.HistTemp = ""
 		m.Status = "cancelled"
 		return m, m.scheduleTick()
 	case "enter":
-		out := m.runCommand(strings.TrimSpace(m.PromptBuf))
+		line := strings.TrimSpace(m.PromptBuf)
+		m.appendHistory(line)
+		out := m.runCommand(line)
 		m.PromptActive = false
 		m.PromptBuf = ""
+		m.HistIdx = -1
+		m.HistTemp = ""
 		m.Status = out
 		return m, m.scheduleTick()
 	case "backspace":
@@ -34,12 +44,157 @@ func (m Model) updatePrompt(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.PromptBuf = m.PromptBuf[:len(m.PromptBuf)-1]
 		}
 		return m, m.scheduleTick()
+	case "up":
+		m.historyBack()
+		return m, m.scheduleTick()
+	case "down":
+		m.historyForward()
+		return m, m.scheduleTick()
+	case "tab":
+		if completed, ok := completePrompt(m.PromptBuf, m.Syms); ok {
+			m.PromptBuf = completed
+		}
+		return m, m.scheduleTick()
+	case "ctrl+r":
+		if len(m.History) > 0 {
+			m.RISearchActive = true
+			m.RISearchBuf = ""
+			m.RIOrigBuf = m.PromptBuf
+			m.RIMatchIdx = -1
+		}
+		return m, m.scheduleTick()
 	}
-	// Accept printable runes (single chars only — Bubble Tea reports them as KeyRunes).
 	if len(msg.Runes) > 0 {
 		m.PromptBuf += string(msg.Runes)
 	}
 	return m, m.scheduleTick()
+}
+
+// updateRISearch owns input while Ctrl-R reverse-incremental search is open.
+// Ctrl-R again walks to the next older match; Esc restores the original
+// buffer; Enter accepts the current match and runs it.
+func (m Model) updateRISearch(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	s := msg.String()
+	switch s {
+	case "esc", "ctrl+c":
+		m.PromptBuf = m.RIOrigBuf
+		m.resetRISearch()
+		return m, m.scheduleTick()
+	case "enter":
+		m.resetRISearch()
+		line := strings.TrimSpace(m.PromptBuf)
+		m.appendHistory(line)
+		out := m.runCommand(line)
+		m.PromptActive = false
+		m.PromptBuf = ""
+		m.HistIdx = -1
+		m.HistTemp = ""
+		m.Status = out
+		return m, m.scheduleTick()
+	case "backspace":
+		if len(m.RISearchBuf) > 0 {
+			m.RISearchBuf = m.RISearchBuf[:len(m.RISearchBuf)-1]
+			m.refreshRIMatch()
+		}
+		return m, m.scheduleTick()
+	case "ctrl+r":
+		m.advanceRIMatch()
+		return m, m.scheduleTick()
+	}
+	if len(msg.Runes) > 0 {
+		m.RISearchBuf += string(msg.Runes)
+		m.refreshRIMatch()
+	}
+	return m, m.scheduleTick()
+}
+
+func (m *Model) resetRISearch() {
+	m.RISearchActive = false
+	m.RISearchBuf = ""
+	m.RIOrigBuf = ""
+	m.RIMatchIdx = -1
+}
+
+// appendHistory records a committed prompt line. No-ops on empty input or
+// when the line duplicates the most-recent entry. Persists immediately so
+// a crash doesn't lose recent work.
+func (m *Model) appendHistory(line string) {
+	if line == "" {
+		return
+	}
+	if n := len(m.History); n > 0 && m.History[n-1] == line {
+		return
+	}
+	m.History = append(m.History, line)
+	if len(m.History) > histCap {
+		m.History = m.History[len(m.History)-histCap:]
+	}
+	_ = saveHistory(m.HistPath, m.History)
+}
+
+func (m *Model) historyBack() {
+	if len(m.History) == 0 {
+		return
+	}
+	switch {
+	case m.HistIdx == -1:
+		m.HistTemp = m.PromptBuf
+		m.HistIdx = 0
+	case m.HistIdx < len(m.History)-1:
+		m.HistIdx++
+	default:
+		return
+	}
+	m.PromptBuf = m.History[len(m.History)-1-m.HistIdx]
+}
+
+func (m *Model) historyForward() {
+	if m.HistIdx == -1 {
+		return
+	}
+	if m.HistIdx == 0 {
+		m.HistIdx = -1
+		m.PromptBuf = m.HistTemp
+		m.HistTemp = ""
+		return
+	}
+	m.HistIdx--
+	m.PromptBuf = m.History[len(m.History)-1-m.HistIdx]
+}
+
+// refreshRIMatch scans History newest -> oldest for a substring match of
+// RISearchBuf and snaps PromptBuf to the first hit. Empty pattern clears
+// the match without changing PromptBuf (so the user sees nothing yet).
+func (m *Model) refreshRIMatch() {
+	if m.RISearchBuf == "" {
+		m.RIMatchIdx = -1
+		m.PromptBuf = ""
+		return
+	}
+	for i := len(m.History) - 1; i >= 0; i-- {
+		if strings.Contains(m.History[i], m.RISearchBuf) {
+			m.RIMatchIdx = i
+			m.PromptBuf = m.History[i]
+			return
+		}
+	}
+	m.RIMatchIdx = -1
+	m.PromptBuf = ""
+}
+
+// advanceRIMatch walks to the next older match for the current pattern.
+// No-op when already at the oldest match or pattern is empty.
+func (m *Model) advanceRIMatch() {
+	if m.RIMatchIdx <= 0 || m.RISearchBuf == "" {
+		return
+	}
+	for i := m.RIMatchIdx - 1; i >= 0; i-- {
+		if strings.Contains(m.History[i], m.RISearchBuf) {
+			m.RIMatchIdx = i
+			m.PromptBuf = m.History[i]
+			return
+		}
+	}
 }
 
 // runCommand parses a `:command args` line and applies it. Returns status text.
@@ -309,8 +464,13 @@ func parseAddr(s string) (uint16, error) {
 }
 
 // promptLine renders the `:` line that replaces the status bar when active.
+// Reverse-i-search shows `(reverse-i-search)\`pattern': match` instead.
 func (m Model) promptLine(width int) string {
 	cursor := lipgloss.NewStyle().Reverse(true).Render(" ")
+	if m.RISearchActive {
+		text := fmt.Sprintf("(reverse-i-search)`%s': %s%s", m.RISearchBuf, m.PromptBuf, cursor)
+		return promptStyle.Width(width).Render(text)
+	}
 	text := ":" + m.PromptBuf + cursor
 	return promptStyle.Width(width).Render(text)
 }


### PR DESCRIPTION
Closes #20.

## Summary
- **Persistent history** at `~/.chippy/history` (cap 100, dedup, auto-save). Shared across ROMs since debugger commands are a global muscle-memory surface.
- **Up/Down** walks history; HistTemp preserves the in-progress draft so Down can restore it.
- **Tab** completes either the verb (no space yet) or the first argument of an address-taking verb against the loaded .dbg symbol table. Unique match auto-extends with a trailing space.
- **Ctrl-R** opens reverse-incremental search; subsequent Ctrl-R walks the next older match; Esc restores the original line; Enter accepts and runs.
- Prompt line renders as `(reverse-i-search)\\`pat': match` while RI is active.
- New: `symbols.Table.NamesWithPrefix(prefix) []string` for the completion lookup.

## Verbs that accept symbol completion
`bp`, `bpr`, `bpw`, `bprw`, `rmbpr`, `rmbpw`, `rmbprw`, `goto`/`g`, `pc`, `run`, `watch`/`w`, `rmwatch`/`unwatch`. `clearwatch`, `speed`, `trace`, `help`, `q`/`quit` skip symbol lookup on the arg.

## Docs (per CLAUDE.md \"docs in every PR\")
- README: prompt paragraph for history / Tab / Ctrl-R.
- docs/context.md: #20 moves to Merged-PRs-of-note.
- Help modal: new \"Prompt\" section.

## Test plan
- [x] `go build ./...` — green.
- [x] `go test -race ./...` — 14 new tests cover history save/load/cap, dedup, Up/Down/restore, RI newest-first walk + empty-pattern clear, completion of unique verb / ambiguous verb / no-match / unique symbol / ambiguous symbol / non-addr verb, lcp helper.
- [x] `golangci-lint run` — 0 issues.
- [x] Live TUI smoke (tmux + freeze): typed `:goto $0100` and `:goto $0200`, opened `:` and pressed Up Up → recalled `:goto $0100`; typed `cle` + Tab → `:clearwatch `; typed `:` + Ctrl-R + `goto` → `(reverse-i-search)\\`goto': goto $0200`. History file written to `~/.chippy/history`.