### PR TITLE
feat(tui): reverse-step via CPU+RAM snapshot ring

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,13 @@ opens a reverse-incremental search through history — each keystroke
 narrows the match, Ctrl-R again walks to the next older one, Esc restores
 the original line, Enter accepts.
 
+Press `<` to rewind one instruction. Each explicit step (`s`, `S`, `n`,
+`f`) records a full CPU + RAM snapshot beforehand, kept in a 256-entry
+FIFO ring; the status bar shows `rwd:N` while non-empty. Free-run via
+`r` does NOT snapshot — the 64 KiB-per-step cost would dominate at multi-MHz
+throughput — so reverse-step covers single-stepping sessions, not whole
+program executions.
+
 ---
 
 ## Status

--- a/docs/context.md
+++ b/docs/context.md
@@ -142,10 +142,13 @@ Bus chain: `CPU → tui.WBus → cpu.MMIO → cpu.RAM`
 - #39 — Stack panel JSR-frame annotation (issue #18): detects pushed return-address pairs via the `$20` opcode at `stored-2`; renders `ret $XXXX  callee  file:NN`; collapses non-frame runs; `T` toggles raw view
 - #40 — Memory editor (issue #19): byte-level `MemCursor` (arrow keys, auto-scroll), `e` enters hex edit mode at cursor; 1–2 hex chars, Enter commits, Esc cancels; cursor persists in state file; `:goto` aligns view AND moves cursor
 - #41 — Prompt history + tab-complete (issue #20): `~/.chippy/history` (cap 100, dedup, auto-save), Up/Down recall, Tab completes verbs and `:bp <symbol>` against the loaded `.dbg`, Ctrl-R reverse-incremental search (Ctrl-R again walks older). Added `symbols.Table.NamesWithPrefix`.
+- v0.0.2 — release cut after #41. 7 features since v0.0.1; binaries + brew tap auto-updated.
+- #54 — Reverse step (issue #17): `cpu.Snapshot` / `CPU.Snapshot`/`Restore` capture full regs + RAM + bookkeeping; `rewindRing` (cap 256, FIFO eviction, LIFO pop) records pre-step state on explicit-step paths only (free-run skipped to avoid 64 KiB/step cost); `<` pops one; status bar shows `rwd:N` depth.
 
 ### Open issues
-- #17 (reverse step) — record/replay micro-history
 - #22 (homebrew-core) — blocked on stars
+- #42 (CMOS-aware disasm), #43 (trace IRQ entry lines), #44 (--run-on-start), #45 (stack heuristic tighten)
+- #46 DAP epic + #47–#53 sub-issues
 
 ---
 

--- a/internal/cpu/snapshot.go
+++ b/internal/cpu/snapshot.go
@@ -1,0 +1,55 @@
+package cpu
+
+// Snapshot captures the full architectural and bookkeeping state of a CPU
+// plus a copy of the RAM contents. Used by the TUI's reverse-step ring
+// buffer.
+//
+// Caveat: peripherals connected via MMIO are NOT snapshotted — only RAM is.
+// Reverse-stepping across a peripheral side-effect (e.g. a keyboard register
+// drain) won't unwind the peripheral. Acceptable in v1 because real
+// reverse-debugging sessions rarely span peripheral interactions; programs
+// that do should pause the CPU first or use a longer ring with periodic
+// peripheral snapshots in a follow-up.
+type Snapshot struct {
+	A, X, Y, SP, P byte
+	PC             uint16
+	Cycles         uint64
+	Halted         bool
+
+	extraCycles int
+	irqLine     bool
+	nmiPending  bool
+
+	RAM [0x10000]byte
+}
+
+// Snapshot returns a full state capture of the CPU + the supplied RAM. ram
+// must be the same backing store the CPU's Bus eventually resolves to —
+// snapshots aren't useful if MMIO wraps a different RAM.
+func (c *CPU) Snapshot(ram *RAM) Snapshot {
+	s := Snapshot{
+		A: c.A, X: c.X, Y: c.Y, SP: c.SP, P: c.P,
+		PC:          c.PC,
+		Cycles:      c.Cycles,
+		Halted:      c.Halted,
+		extraCycles: c.extraCycles,
+		irqLine:     c.irqLine,
+		nmiPending:  c.nmiPending,
+	}
+	s.RAM = ram.Data
+	return s
+}
+
+// Restore writes the snapshot back into the CPU and RAM. The opcodes pointer
+// is left alone — Variant doesn't change at runtime, so the table binding
+// from New/Reset remains valid.
+func (c *CPU) Restore(s Snapshot, ram *RAM) {
+	c.A, c.X, c.Y, c.SP, c.P = s.A, s.X, s.Y, s.SP, s.P
+	c.PC = s.PC
+	c.Cycles = s.Cycles
+	c.Halted = s.Halted
+	c.extraCycles = s.extraCycles
+	c.irqLine = s.irqLine
+	c.nmiPending = s.nmiPending
+	ram.Data = s.RAM
+}

--- a/internal/cpu/snapshot_test.go
+++ b/internal/cpu/snapshot_test.go
@@ -1,0 +1,74 @@
+package cpu_test
+
+import (
+	"testing"
+
+	"github.com/nkane/chippy/internal/cpu"
+)
+
+func TestSnapshotRestore_RoundTrip(t *testing.T) {
+	ram := cpu.NewRAM()
+	// LDA #$42 ; STA $0200 ; JMP $8000
+	ram.Load(0x8000, []byte{0xA9, 0x42, 0x8D, 0x00, 0x02, 0x4C, 0x00, 0x80})
+	ram.Write(cpu.VecReset, 0x00)
+	ram.Write(cpu.VecReset+1, 0x80)
+	c := cpu.New(ram)
+
+	pre := c.Snapshot(ram)
+	c.Step() // LDA #$42 -> A=$42, PC=$8002
+	c.Step() // STA $0200 -> RAM[$0200]=$42, PC=$8005
+	if c.A != 0x42 {
+		t.Fatalf("post-step A want $42, got $%02X", c.A)
+	}
+	if ram.Read(0x0200) != 0x42 {
+		t.Fatalf("post-step RAM[$0200] want $42, got $%02X", ram.Read(0x0200))
+	}
+
+	c.Restore(pre, ram)
+	if c.PC != 0x8000 {
+		t.Fatalf("restore PC want $8000, got $%04X", c.PC)
+	}
+	if c.A != 0 {
+		t.Fatalf("restore A want $00, got $%02X", c.A)
+	}
+	if ram.Read(0x0200) != 0 {
+		t.Fatalf("restore RAM[$0200] want $00, got $%02X", ram.Read(0x0200))
+	}
+}
+
+func TestSnapshotRestore_BookkeepingFields(t *testing.T) {
+	ram := cpu.NewRAM()
+	ram.Write(cpu.VecReset, 0x00)
+	ram.Write(cpu.VecReset+1, 0x80)
+	ram.Load(0x8000, []byte{0xEA, 0xEA}) // NOP NOP
+	c := cpu.New(ram)
+
+	c.AssertIRQ()
+	c.TriggerNMI()
+	s := c.Snapshot(ram)
+
+	c.ReleaseIRQ() // clear IRQ line
+	// Step to service the NMI; nmiPending flips false post-service.
+	c.Step()
+	if c.IRQAsserted() {
+		t.Fatalf("between snapshot and step, ReleaseIRQ cleared the line; CPU should reflect that")
+	}
+
+	c.Restore(s, ram)
+	if !c.IRQAsserted() {
+		t.Fatalf("restore should rehydrate the IRQ line that was set at snapshot time")
+	}
+}
+
+func TestSnapshot_RAMIsDeepCopy(t *testing.T) {
+	ram := cpu.NewRAM()
+	ram.Write(0x0500, 0xAA)
+	c := cpu.New(ram)
+
+	s := c.Snapshot(ram)
+	ram.Write(0x0500, 0xBB) // mutate after snapshot
+	c.Restore(s, ram)
+	if ram.Read(0x0500) != 0xAA {
+		t.Fatalf("snapshot.RAM must be an independent copy: got $%02X, want $AA", ram.Read(0x0500))
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -132,6 +132,12 @@ type Model struct {
 	MemEditing bool
 	MemEditBuf string
 
+	// Reverse-step ring. Each explicit step (s/n/f and their loops) pushes
+	// a pre-step snapshot here so `<` can rewind. Free-run via tickMsg does
+	// NOT push — 64 KiB per snapshot at multi-MHz throughput would dominate
+	// the runtime cost. Nil disables the feature; default cap is set in New.
+	Rewind *rewindRing
+
 	// Disassembly viewport: when DisasmFollow is true (default), the panel
 	// re-anchors on PC each frame. User scroll keys flip it off and pin
 	// DisasmAnchor as the address shown at the top of the window.
@@ -160,6 +166,7 @@ func New(c *cpu.CPU, r *cpu.RAM) Model {
 		StackAnnotate: true,
 		HistIdx:       -1,
 		RIMatchIdx:    -1,
+		Rewind:        newRewindRing(defaultRewindCap),
 		W:             120,
 		H:             40,
 	}
@@ -308,7 +315,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.CPU.Halted {
 				m.Status = "halted (press R to reset)"
 			} else {
-				m.CPU.Step()
+				m.step()
 				m.statusAfterStep("stepped")
 			}
 		case "S":
@@ -317,7 +324,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				break
 			}
 			for i := 0; i < 16 && !m.CPU.Halted; i++ {
-				m.CPU.Step()
+				m.step()
 				if mpause, mmsg := m.processMemHits(); mpause {
 					m.Status = mmsg
 					break
@@ -348,7 +355,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		case "R":
 			m.CPU.Reset()
+			if m.Rewind != nil {
+				m.Rewind.Reset()
+			}
 			m.Status = "reset"
+		case "<":
+			if m.Rewind == nil || m.Rewind.Len() == 0 {
+				m.Status = "rewind: empty"
+				break
+			}
+			s, _ := m.Rewind.Pop()
+			m.CPU.Restore(s, m.RAM)
+			m.Status = fmt.Sprintf("rewind -> $%04X (depth %d)", m.CPU.PC, m.Rewind.Len())
 		case "b":
 			if _, ok := m.Breakpoints[m.CPU.PC]; ok {
 				delete(m.Breakpoints, m.CPU.PC)
@@ -493,6 +511,18 @@ func keyMsgToByte(msg tea.KeyMsg) (byte, bool) {
 	return 0, false
 }
 
+// step takes one CPU instruction *and* records a rewind snapshot first so
+// `<` can undo it. Use this in all explicit-step keypaths (`s` / `S` / `n` /
+// `f` and the inner loops of stepOver / runToNextLine). The tickMsg
+// free-run loop calls m.CPU.Step() directly to avoid the 64 KiB snapshot
+// cost per cycle at multi-MHz throughput.
+func (m *Model) step() int {
+	if m.Rewind != nil {
+		m.Rewind.Push(m.CPU.Snapshot(m.RAM))
+	}
+	return m.CPU.Step()
+}
+
 // statusAfterStep updates Status reflecting halt or normal stepping outcome.
 func (m *Model) statusAfterStep(normal string) {
 	if m.CPU.Halted {
@@ -521,14 +551,14 @@ func (m *Model) stepOver() {
 	}
 	op := m.RAM.Read(m.CPU.PC)
 	if op != 0x20 {
-		m.CPU.Step()
+		m.step()
 		m.statusAfterStep("stepped")
 		return
 	}
 	retPC := m.CPU.PC + 3
 	const guard = 2_000_000
 	for i := 0; i < guard; i++ {
-		m.CPU.Step()
+		m.step()
 		if m.CPU.Halted {
 			m.Status = fmt.Sprintf("halted at $%04X", m.CPU.PC)
 			return
@@ -561,13 +591,13 @@ func (m *Model) runToNextLine() {
 	}
 	startLoc, hasMap := m.PCToSrc[m.CPU.PC]
 	if !hasMap || m.PCToSrc == nil {
-		m.CPU.Step()
+		m.step()
 		m.statusAfterStep("stepped (no src map)")
 		return
 	}
 	const guard = 1_000_000
 	for i := 0; i < guard; i++ {
-		m.CPU.Step()
+		m.step()
 		if m.CPU.Halted {
 			m.Status = fmt.Sprintf("halted at $%04X", m.CPU.PC)
 			return
@@ -804,9 +834,13 @@ func (m Model) View() string {
 	title := titleStyle.Render(" chippy — 6502 TUI debugger ")
 	titleRow := lipgloss.PlaceHorizontal(m.W, lipgloss.Center, title)
 
+	rewindSeg := ""
+	if d := m.Rewind.Len(); d > 0 {
+		rewindSeg = fmt.Sprintf(" │ rwd:%d", d)
+	}
 	statusText := fmt.Sprintf(
-		" %s │ cyc=%d │ PC=$%04X │ %s │ [?] help  [:] cmd  [s/n] step  [r] run  [v] src  [q] quit",
-		m.Status, m.CPU.Cycles, m.CPU.PC, speedLabel(m.TargetHz),
+		" %s │ cyc=%d │ PC=$%04X │ %s%s │ [?] help  [:] cmd  [s/n] step  [r] run  [<] back  [v] src  [q] quit",
+		m.Status, m.CPU.Cycles, m.CPU.PC, speedLabel(m.TargetHz), rewindSeg,
 	)
 	bar := statusBar.Width(m.W).Render(statusText)
 	if m.PromptActive {
@@ -874,6 +908,7 @@ func (m Model) helpModal() string {
 			{"S", "step 16 instructions"},
 			{"n", "step over (run JSR to RTS)"},
 			{"f", "run to next source line"},
+			{"<", "rewind one step (snapshot ring; depth shown as `rwd:N`)"},
 			{"r", "run / pause"},
 			{"R", "reset CPU"},
 			{"b", "toggle breakpoint at PC"},

--- a/internal/tui/rewind.go
+++ b/internal/tui/rewind.go
@@ -1,0 +1,63 @@
+package tui
+
+import "github.com/nkane/chippy/internal/cpu"
+
+// defaultRewindCap is the ring buffer size. 256 snapshots × 64 KiB RAM = 16
+// MiB worst-case, well within budget for a debugger.
+const defaultRewindCap = 256
+
+// rewindRing is a fixed-size FIFO of CPU snapshots. Push overwrites the
+// oldest entry when full; Pop removes the most-recently-pushed entry (LIFO
+// for reverse-step semantics — most recent forward step is undone first).
+type rewindRing struct {
+	buf  []cpu.Snapshot
+	head int // next-write index
+	size int // filled count, ≤ cap
+	cap  int
+}
+
+func newRewindRing(cap int) *rewindRing {
+	if cap <= 0 {
+		return nil
+	}
+	return &rewindRing{buf: make([]cpu.Snapshot, cap), cap: cap}
+}
+
+func (r *rewindRing) Push(s cpu.Snapshot) {
+	if r == nil || r.cap == 0 {
+		return
+	}
+	r.buf[r.head] = s
+	r.head = (r.head + 1) % r.cap
+	if r.size < r.cap {
+		r.size++
+	}
+}
+
+// Pop removes and returns the most recently pushed snapshot. (Snapshot{},
+// false) when empty.
+func (r *rewindRing) Pop() (cpu.Snapshot, bool) {
+	if r == nil || r.size == 0 {
+		return cpu.Snapshot{}, false
+	}
+	r.head = (r.head - 1 + r.cap) % r.cap
+	s := r.buf[r.head]
+	r.size--
+	return s, true
+}
+
+func (r *rewindRing) Len() int {
+	if r == nil {
+		return 0
+	}
+	return r.size
+}
+
+// Reset drops all snapshots without freeing the backing buffer.
+func (r *rewindRing) Reset() {
+	if r == nil {
+		return
+	}
+	r.head = 0
+	r.size = 0
+}

--- a/internal/tui/rewind_test.go
+++ b/internal/tui/rewind_test.go
@@ -1,0 +1,152 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/nkane/chippy/internal/cpu"
+)
+
+func TestRewindRing_PushPopLIFO(t *testing.T) {
+	r := newRewindRing(4)
+	for i := byte(0); i < 3; i++ {
+		s := cpu.Snapshot{}
+		s.A = i
+		r.Push(s)
+	}
+	if r.Len() != 3 {
+		t.Fatalf("len: want 3, got %d", r.Len())
+	}
+	// LIFO order — most recently pushed pops first.
+	for want := byte(2); want != 255; want-- {
+		s, ok := r.Pop()
+		if !ok {
+			t.Fatalf("expected pop at A=%d", want)
+		}
+		if s.A != want {
+			t.Fatalf("pop order: want A=%d, got A=%d", want, s.A)
+		}
+		if want == 0 {
+			break
+		}
+	}
+	if r.Len() != 0 {
+		t.Fatalf("after pops: want 0, got %d", r.Len())
+	}
+	if _, ok := r.Pop(); ok {
+		t.Fatalf("empty pop should return ok=false")
+	}
+}
+
+func TestRewindRing_OverflowDropsOldest(t *testing.T) {
+	r := newRewindRing(3)
+	for i := byte(0); i < 5; i++ {
+		s := cpu.Snapshot{}
+		s.A = i
+		r.Push(s)
+	}
+	if r.Len() != 3 {
+		t.Fatalf("cap=3 should clamp size; got %d", r.Len())
+	}
+	// Newest 3 are A=2,3,4. Pop order: 4, 3, 2.
+	for _, want := range []byte{4, 3, 2} {
+		s, _ := r.Pop()
+		if s.A != want {
+			t.Fatalf("overflow LIFO: want A=%d, got A=%d", want, s.A)
+		}
+	}
+}
+
+func TestRewindRing_ZeroCap(t *testing.T) {
+	r := newRewindRing(0)
+	if r != nil {
+		t.Fatalf("cap=0 should yield nil ring")
+	}
+	// Push / Pop / Len on nil are safe.
+	r.Push(cpu.Snapshot{})
+	if r.Len() != 0 {
+		t.Fatalf("nil Len: want 0")
+	}
+	if _, ok := r.Pop(); ok {
+		t.Fatalf("nil Pop: want ok=false")
+	}
+}
+
+func TestRewindRing_Reset(t *testing.T) {
+	r := newRewindRing(4)
+	r.Push(cpu.Snapshot{A: 1})
+	r.Push(cpu.Snapshot{A: 2})
+	r.Reset()
+	if r.Len() != 0 {
+		t.Fatalf("reset should empty ring")
+	}
+	r.Push(cpu.Snapshot{A: 7})
+	s, _ := r.Pop()
+	if s.A != 7 {
+		t.Fatalf("post-reset push/pop want A=7, got A=%d", s.A)
+	}
+}
+
+func TestRewind_StepThenRewindRestoresState(t *testing.T) {
+	ram := cpu.NewRAM()
+	ram.Load(0x8000, []byte{0xA9, 0x42, 0xA9, 0x77}) // LDA #$42 ; LDA #$77
+	ram.Write(cpu.VecReset, 0x00)
+	ram.Write(cpu.VecReset+1, 0x80)
+	c := cpu.New(ram)
+	m := New(c, ram)
+
+	// Step once via the snapshot-recording helper.
+	m.step()
+	if c.A != 0x42 {
+		t.Fatalf("post-step A want $42, got $%02X", c.A)
+	}
+	if m.Rewind.Len() != 1 {
+		t.Fatalf("rewind depth want 1, got %d", m.Rewind.Len())
+	}
+
+	// Pop + restore — register should revert.
+	s, ok := m.Rewind.Pop()
+	if !ok {
+		t.Fatalf("expected pop to succeed")
+	}
+	c.Restore(s, ram)
+	if c.A != 0 {
+		t.Fatalf("rewound A want $00, got $%02X", c.A)
+	}
+	if c.PC != 0x8000 {
+		t.Fatalf("rewound PC want $8000, got $%04X", c.PC)
+	}
+}
+
+func TestRewind_StepRewindStepParity(t *testing.T) {
+	// Forward, back, forward should land on identical state.
+	ram := cpu.NewRAM()
+	ram.Load(0x8000, []byte{0xA9, 0x11, 0xAA, 0xE8}) // LDA #$11 ; TAX ; INX
+	ram.Write(cpu.VecReset, 0x00)
+	ram.Write(cpu.VecReset+1, 0x80)
+	c := cpu.New(ram)
+	m := New(c, ram)
+
+	m.step()
+	m.step()
+	m.step()
+	want := cpuSnapshotFingerprint(c)
+
+	// Rewind one, then re-step.
+	s, _ := m.Rewind.Pop()
+	c.Restore(s, ram)
+	m.step()
+	got := cpuSnapshotFingerprint(c)
+
+	if got != want {
+		t.Fatalf("step/rewind/step diverged from straight step:\n want %s\n  got %s", want, got)
+	}
+}
+
+// cpuSnapshotFingerprint returns a stable string summarising the architectural
+// state we care about for parity checks. We don't include cycle counters
+// because re-stepping from a restored snapshot legitimately advances cycles
+// from the same starting point (test only checks PC/regs/RAM diff).
+func cpuSnapshotFingerprint(c *cpu.CPU) string {
+	return string([]byte{c.A, c.X, c.Y, c.SP, c.P}) +
+		string([]byte{byte(c.PC), byte(c.PC >> 8)})
+}


### PR DESCRIPTION
Closes #17.

## Summary
- New `cpu.Snapshot` type + `CPU.Snapshot(*RAM)` / `CPU.Restore(Snapshot, *RAM)` methods. Captures regs, P, PC, Cycles, Halted, plus bookkeeping (extraCycles, irqLine, nmiPending) and a full 64 KiB RAM image.
- `internal/tui/rewind.go`: 256-entry FIFO ring buffer (`rewindRing`) with LIFO pop semantics — most-recently-pushed undoes first.
- `<` key pops one snapshot and restores. Status bar reports `rwd:N` while ring is non-empty.
- Each explicit step path (`s`, `S`, `n`, `f` + the loops inside `stepOver` / `runToNextLine`) pushes a snapshot via the new `m.step()` helper.
- `R` (reset) clears the ring.

## Free-run intentionally skipped
The tickMsg run loop calls `m.CPU.Step()` directly, NOT `m.step()`. At multi-MHz throughput the 64 KiB memcpy per step would dominate runtime cost; CoW is the right answer when memory pressure becomes real but isn't needed for v1. So reverse-step covers single-stepping sessions, not whole executions. Documented in README.

## Caveat: peripherals not snapshotted
`Snapshot` only captures RAM. Reverse-stepping across a peripheral read with side effects (e.g. keyboard register drain) won't unwind the peripheral. Acceptable today because debuggers rarely rewind across peripheral interactions; a follow-up issue can extend Snapshot to include peripheral state.

## Docs (per CLAUDE.md \"docs in every PR\")
- README: paragraph on `<` + ring semantics + free-run caveat.
- docs/context.md: #17 moves to Merged-PRs-of-note; open issues refreshed.
- TUI help modal: new `<` entry under Execution.
- Status bar: `rwd:N` segment + `[<] back` hint.

## Test plan
- [x] `go build ./...` — green.
- [x] `go test -race ./...` — 9 new tests: Snapshot/Restore round-trip; bookkeeping fields (IRQ line); RAM deep-copy; ring FIFO push/LIFO pop; overflow drops oldest; zero-cap nil ring; Reset; step→rewind restores state; step/rewind/step parity vs straight step.
- [x] `golangci-lint run` — 0 issues.
- [x] Live TUI smoke (tmux + freeze): 5 single-steps push depth to 5 (status `rwd:5`, PC=$8007, A=$02); 3 rewinds drop depth to 2, PC to $8003, A back to $00, cycles 17 → 11 — exactly matches the forward path.