### PR TITLE
feat(cpu): variant-aware disassembler (CMOS-only mnemonics)

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -144,10 +144,11 @@ Bus chain: `CPU → tui.WBus → cpu.MMIO → cpu.RAM`
 - #41 — Prompt history + tab-complete (issue #20): `~/.chippy/history` (cap 100, dedup, auto-save), Up/Down recall, Tab completes verbs and `:bp <symbol>` against the loaded `.dbg`, Ctrl-R reverse-incremental search (Ctrl-R again walks older). Added `symbols.Table.NamesWithPrefix`.
 - v0.0.2 — release cut after #41. 7 features since v0.0.1; binaries + brew tap auto-updated.
 - #54 — Reverse step (issue #17): `cpu.Snapshot` / `CPU.Snapshot`/`Restore` capture full regs + RAM + bookkeeping; `rewindRing` (cap 256, FIFO eviction, LIFO pop) records pre-step state on explicit-step paths only (free-run skipped to avoid 64 KiB/step cost); `<` pops one; status bar shows `rwd:N` depth.
+- #55 — CMOS-aware disasm (issue #42): `DisasmCPU` / `DisasmCPUWithSyms` route through the CPU's opcode table so CMOS-only mnemonics (STZ/PHX/BRA/etc.) render correctly in the disasm panel, trace lines, and any future caller. Legacy `Disasm`/`DisasmWithSyms` retained as NMOS-default shims.
 
 ### Open issues
 - #22 (homebrew-core) — blocked on stars
-- #42 (CMOS-aware disasm), #43 (trace IRQ entry lines), #44 (--run-on-start), #45 (stack heuristic tighten)
+- #43 (trace IRQ entry lines), #44 (--run-on-start), #45 (stack heuristic tighten)
 - #46 DAP epic + #47–#53 sub-issues
 
 ---
@@ -158,7 +159,7 @@ Bus chain: `CPU → tui.WBus → cpu.MMIO → cpu.RAM`
 - **Variant-based CPU dispatch via per-CPU table pointer** — chosen over a runtime switch in every opcode so future variants (65816, etc.) only need a new table file. Tables share NMOS as a base and override.
 - **CMOS table init via copy-then-override**, relying on Go's `init()` lex file ordering (`opcodes.go` < `opcodes_cmos.go` < `opcodes_illegal.go`). This is a load-bearing invariant — renaming files could break the init chain.
 - **ZPR addressing handler self-fetches operand bytes** and self-advances PC; `resolve()` returns `(0, false)` for ZPR. Simpler than encoding both zp byte and rel target through `resolve`.
-- **`disasm.go` still NMOS-only** (uses global `Opcodes`). A variant-aware disasm is deferred — not blocking any active work.
+- **Disassembler is variant-aware** (PR #55, issue #42). Legacy `Disasm` / `DisasmWithSyms` still use the NMOS table for back-compat; `DisasmCPU` / `DisasmCPUWithSyms` route through `c.opcodes` so CMOS-only mnemonics (STZ, PHX, BRA, etc.) render correctly. TUI + trace switched to the CPU-aware path.
 
 ### Bug fixes worth remembering
 - **PR #31:** `branch()` was mutating `c.Cycles` directly but `Step()` returned only `in.Cycles`. Result: taken branches undercounted return value by 1–2. Fix: `extraCycles int` field, reset each `Step`, folded into the return.
@@ -240,7 +241,7 @@ chippy -rom <file> [-addr 0x8000] [-reset 0xADDR] [-cfg linker.cfg] [-dbg syms.d
 - `internal/cpu/opcodes.go` — NMOS opcode table (199 LOC)
 - `internal/cpu/opcodes_cmos.go` — CMOS overrides (BRA, PHX/PHY/PLX/PLY, STZ, TRB, TSB, INA/DEA, BIT #imm, RMB/SMB/BBR/BBS, adcDecimalCMOS, sbcDecimalCMOS, cmosNOPs)
 - `internal/cpu/opcodes_illegal.go` — NMOS unofficial opcodes (320 LOC)
-- `internal/cpu/disasm.go` — disassembler; NMOS-only (uses global `Opcodes`)
+- `internal/cpu/disasm.go` — disassembler; variant-aware via `DisasmCPU` / `DisasmCPUWithSyms`. Legacy NMOS-fixed `Disasm` still exported for callers without a CPU handy.
 - `internal/cpu/memory.go` — `Bus` interface + `RAM` impl
 
 ### Tests
@@ -277,7 +278,7 @@ chippy -rom <file> [-addr 0x8000] [-reset 0xADDR] [-cfg linker.cfg] [-dbg syms.d
 ## 8. Next Steps (immediate)
 
 1. Choose next from open issues: #17 (reverse step), #18 (stack panel), #19 (mem editor), #20 (prompt history). #22 (homebrew-core) is gated on ~30 stars.
-2. **Deferred:** CMOS-aware disasm (`disasm.go` still NMOS-only; affects trace output too — CMOS-only mnemonics render as their NMOS slot). CI job for the CMOS e2e test (self-skips because binary is gitignored).
+2. **Deferred:** CI job for the CMOS e2e test (self-skips because binary is gitignored).
 3. **Possible:** integrate Bruce Clark's BCD timing test or 6502_decimal_test as a klaus-style build-tagged suite — would also exercise the CMOS BCD path.
 4. **User-side:** mascot image generation (prompts in `docs/mascot-prompts.md`).
 

--- a/internal/cpu/disasm.go
+++ b/internal/cpu/disasm.go
@@ -5,17 +5,42 @@ import "fmt"
 // SymLookup returns a name for an address, or "" if none.
 type SymLookup func(uint16) string
 
-// Disasm produces a single-instruction disassembly starting at addr.
+// Disasm produces a single-instruction NMOS disassembly starting at addr.
 // Returns formatted text + number of bytes consumed.
+//
+// CMOS-aware callers should use DisasmCPU / DisasmCPUWithSyms instead so
+// CMOS-only mnemonics (STZ, PHX, BRA, BBR0-7, etc.) render correctly. This
+// function is kept as a thin NMOS-default wrapper for tests and callers
+// without a CPU handy.
 func Disasm(bus Bus, addr uint16) (string, int) {
-	return DisasmWithSyms(bus, addr, nil)
+	return disasmWithTable(bus, addr, &Opcodes, nil)
 }
 
 // DisasmWithSyms is like Disasm but substitutes symbol names for absolute
 // targets when the lookup returns a non-empty name.
 func DisasmWithSyms(bus Bus, addr uint16, sym SymLookup) (string, int) {
+	return disasmWithTable(bus, addr, &Opcodes, sym)
+}
+
+// DisasmCPU is the variant-aware disassembler. It uses the opcode table the
+// CPU is actually executing, so a 65C02 program shows CMOS mnemonics
+// (STZ, PHX, BRA, BBR0-7, …) instead of whatever the NMOS slot happens
+// to be (often an illegal NOP).
+func DisasmCPU(c *CPU, addr uint16) (string, int) {
+	return disasmWithTable(c.Bus, addr, c.opcodes, nil)
+}
+
+// DisasmCPUWithSyms is the symbol-aware variant of DisasmCPU.
+func DisasmCPUWithSyms(c *CPU, addr uint16, sym SymLookup) (string, int) {
+	return disasmWithTable(c.Bus, addr, c.opcodes, sym)
+}
+
+// disasmWithTable is the shared core. Both the legacy NMOS-fixed API and
+// the CPU-variant-aware API funnel through here so there's exactly one
+// formatter to maintain.
+func disasmWithTable(bus Bus, addr uint16, table *[256]Instr, sym SymLookup) (string, int) {
 	op := bus.Read(addr)
-	in := Opcodes[op]
+	in := table[op]
 	b1 := bus.Read(addr + 1)
 	b2 := bus.Read(addr + 2)
 

--- a/internal/cpu/disasm_test.go
+++ b/internal/cpu/disasm_test.go
@@ -1,0 +1,105 @@
+package cpu_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nkane/chippy/internal/cpu"
+)
+
+// TestDisasm_NMOSDefault confirms the legacy Disasm function still routes
+// through the NMOS table.
+func TestDisasm_NMOSDefault(t *testing.T) {
+	ram := cpu.NewRAM()
+	ram.Write(0x8000, 0xA9) // LDA #imm
+	ram.Write(0x8001, 0x42)
+	got, n := cpu.Disasm(ram, 0x8000)
+	if n != 2 {
+		t.Fatalf("byte count: want 2, got %d", n)
+	}
+	if !strings.Contains(got, "LDA") || !strings.Contains(got, "#$42") {
+		t.Fatalf("LDA #$42 disasm: got %q", got)
+	}
+}
+
+// TestDisasm_CMOSOnlyOpcodeOnNMOS shows the failure mode this PR fixes:
+// Disasm()'s fixed NMOS table can't decode CMOS-only opcodes correctly. We
+// don't assert any particular wrong output — just demonstrate that without
+// variant dispatch the result differs from the CMOS-aware path below.
+func TestDisasm_CMOSOnlyOpcodeOnNMOS(t *testing.T) {
+	ram := cpu.NewRAM()
+	// $80 is BRA on CMOS, an illegal NOP on NMOS.
+	ram.Write(0x8000, 0x80)
+	ram.Write(0x8001, 0x10)
+	nmosOut, _ := cpu.Disasm(ram, 0x8000)
+	if strings.Contains(nmosOut, "BRA") {
+		t.Fatalf("legacy Disasm should NOT decode BRA (NMOS-only path); got %q", nmosOut)
+	}
+}
+
+// TestDisasmCPU_CMOS demonstrates the fix: a CPU constructed with the CMOS
+// variant disassembles its own opcodes correctly.
+func TestDisasmCPU_CMOS(t *testing.T) {
+	ram := cpu.NewRAM()
+	// CMOS opcodes that don't exist on NMOS:
+	//   $80 rel   BRA
+	//   $DA       PHX
+	//   $5A       PHY
+	//   $64 zp    STZ
+	//   $9C abs   STZ
+	ram.Write(0x8000, 0x80) // BRA $8004
+	ram.Write(0x8001, 0x02)
+	ram.Write(0x8002, 0xDA) // PHX
+	ram.Write(0x8003, 0x5A) // PHY
+	ram.Write(0x8004, 0x64) // STZ $42
+	ram.Write(0x8005, 0x42)
+	ram.Write(0x8006, 0x9C) // STZ $0200
+	ram.Write(0x8007, 0x00)
+	ram.Write(0x8008, 0x02)
+	ram.Write(cpu.VecReset, 0x00)
+	ram.Write(cpu.VecReset+1, 0x80)
+
+	c := cpu.NewVariant(ram, cpu.VariantCMOS65C02)
+
+	cases := []struct {
+		addr uint16
+		want string
+		size int
+	}{
+		{0x8000, "BRA ", 2},
+		{0x8002, "PHX", 1},
+		{0x8003, "PHY", 1},
+		{0x8004, "STZ ", 2},
+		{0x8006, "STZ ", 3},
+	}
+	for _, tc := range cases {
+		got, n := cpu.DisasmCPU(c, tc.addr)
+		if !strings.Contains(got, tc.want) {
+			t.Errorf("$%04X CMOS disasm: want substring %q, got %q", tc.addr, tc.want, got)
+		}
+		if n != tc.size {
+			t.Errorf("$%04X size: want %d, got %d", tc.addr, tc.size, n)
+		}
+	}
+}
+
+// TestDisasmCPU_NMOSPreservesLegacyBehavior ensures the new CPU-aware API
+// produces the same output as the legacy API when the CPU happens to be
+// NMOS — the path through disasmWithTable is identical.
+func TestDisasmCPU_NMOSPreservesLegacyBehavior(t *testing.T) {
+	ram := cpu.NewRAM()
+	ram.Write(0x8000, 0xA9)
+	ram.Write(0x8001, 0x42)
+	ram.Write(cpu.VecReset, 0x00)
+	ram.Write(cpu.VecReset+1, 0x80)
+	c := cpu.New(ram) // NMOS default
+
+	legacy, n1 := cpu.Disasm(ram, 0x8000)
+	cpuOut, n2 := cpu.DisasmCPU(c, 0x8000)
+	if legacy != cpuOut {
+		t.Fatalf("NMOS legacy vs CPU disagree:\n legacy: %q\n cpu:    %q", legacy, cpuOut)
+	}
+	if n1 != n2 {
+		t.Fatalf("size disagreement: legacy=%d cpu=%d", n1, n2)
+	}
+}

--- a/internal/cpu/trace.go
+++ b/internal/cpu/trace.go
@@ -109,7 +109,7 @@ func (t *FileTracer) LogStep(c *CPU, bus Bus) {
 	case 3:
 		bytesStr = fmt.Sprintf("%02X %02X %02X", op, b1, b2)
 	}
-	dis, _ := Disasm(bus, pc)
+	dis, _ := DisasmCPU(c, pc)
 	fmt.Fprintf(t.out, "%04X  %s  %-13s  A:%02X X:%02X Y:%02X P:%02X SP:%02X CYC:%d\n",
 		pc, bytesStr, dis, c.A, c.X, c.Y, c.P, c.SP, c.Cycles)
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1211,7 +1211,7 @@ func (m Model) disasmView(w, h int) string {
 				}
 			}
 		}
-		text, _ := cpu.DisasmWithSyms(m.RAM, a, lookup)
+		text, _ := cpu.DisasmCPUWithSyms(m.CPU, a, lookup)
 		if m.isDataAddr(a) {
 			text = fmt.Sprintf(".byte $%02X", m.RAM.Read(a))
 		}
@@ -1248,9 +1248,9 @@ func (m Model) disasmView(w, h int) string {
 // alignment that produces the longest contiguous decode that lands exactly on
 // pc. This works well for normal code; it can mis-align in data regions, but
 // the worst case is a few wrong lines at the top of the window.
-func disasmAddrsAround(ram cpu.Bus, pc uint16, above, below int, isData func(uint16) bool) []uint16 {
+func disasmAddrsAround(c *cpu.CPU, pc uint16, above, below int, isData func(uint16) bool) []uint16 {
 	// Walk back collecting instruction starts.
-	back := walkBack(ram, pc, above)
+	back := walkBack(c, pc, above)
 	addrs := append([]uint16{}, back...)
 	addrs = append(addrs, pc)
 	// Walk forward from PC.
@@ -1260,7 +1260,7 @@ func disasmAddrsAround(ram cpu.Bus, pc uint16, above, below int, isData func(uin
 		if isData != nil && isData(cur) {
 			step = 1
 		} else {
-			_, n := cpu.DisasmWithSyms(ram, cur, nil)
+			_, n := cpu.DisasmCPUWithSyms(c, cur, nil)
 			step = uint32(n)
 		}
 		next := uint32(cur) + step
@@ -1277,7 +1277,7 @@ func disasmAddrsAround(ram cpu.Bus, pc uint16, above, below int, isData func(uin
 // `pc`, in ascending order. Strategy: try every starting offset 1..MaxLook
 // behind pc; the alignment that decodes cleanly all the way to pc with the
 // most instructions wins.
-func walkBack(ram cpu.Bus, pc uint16, n int) []uint16 {
+func walkBack(c *cpu.CPU, pc uint16, n int) []uint16 {
 	if n <= 0 || pc == 0 {
 		return nil
 	}
@@ -1295,7 +1295,7 @@ func walkBack(ram cpu.Bus, pc uint16, n int) []uint16 {
 		ok := true
 		for cur < pc {
 			seq = append(seq, cur)
-			_, sz := cpu.DisasmWithSyms(ram, cur, nil)
+			_, sz := cpu.DisasmCPUWithSyms(c, cur, nil)
 			next := uint32(cur) + uint32(sz)
 			if next > uint32(pc) {
 				ok = false
@@ -1332,7 +1332,7 @@ func (m Model) cachedDisasmAddrs(anchor uint16, above, below int) []uint16 {
 		disasmCacheGlobal.below == below {
 		return disasmCacheGlobal.addrs
 	}
-	addrs := disasmAddrsAround(m.RAM, anchor, above, below, m.isDataAddr)
+	addrs := disasmAddrsAround(m.CPU, anchor, above, below, m.isDataAddr)
 	disasmCacheGlobal = disasmCacheEntry{anchor: anchor, above: above, below: below, addrs: addrs}
 	return addrs
 }
@@ -1378,7 +1378,7 @@ func (m *Model) disasmScroll(delta int) {
 		}
 	} else if delta < 0 {
 		// Walk back |delta| instructions using same heuristic as walkBack.
-		back := walkBack(m.RAM, a, -delta)
+		back := walkBack(m.CPU, a, -delta)
 		if len(back) > 0 {
 			a = back[0]
 		} else if a > 0 {


### PR DESCRIPTION
Closes #42.

## Summary
- New `DisasmCPU(c, addr)` and `DisasmCPUWithSyms(c, addr, sym)` route through the CPU's own opcode table (`c.opcodes`), so 65C02 programs disassemble correctly.
- Shared core `disasmWithTable(bus, addr, table, sym)` — single formatter, no duplication.
- Legacy `Disasm` / `DisasmWithSyms` retained as NMOS-defaulted shims.

## Surfaces fixed
- **Disassembly panel** (`internal/tui/model.go`): all five callers switched to `DisasmCPUWithSyms`. The forward/backward decode walkers (`disasmAddrsAround` / `walkBack`) now take `*cpu.CPU` so they agree with the executing variant.
- **Trace lines** (`internal/cpu/trace.go`): the per-instruction text matches the executing CPU.
- **Stack panel** (callee annotation in #39): inherits the fix transparently — the symbol table lookup is unchanged.

## Test plan
- [x] `go build ./...` — green.
- [x] `go test -race ./...` — 4 new disasm tests cover: legacy NMOS default; CMOS-only opcode on NMOS shows the failure mode; CPU-aware path decodes BRA/PHX/PHY/STZ-zp/STZ-abs correctly on CMOS; NMOS CPU + legacy path produce identical output.
- [x] `golangci-lint run` — 0 issues.
- [ ] Manual: run `example/cmos_demo` and verify the disasm column shows CMOS mnemonics. (binary is gitignored; deferred to the CI-CMOS-e2e follow-up.)

## Docs (per CLAUDE.md \"docs in every PR\")
- docs/context.md: load-bearing-invariant note updated, package-files note updated, deferred-work list trimmed, open-issues + merged-PRs lists refreshed.