### PR TITLE
feat(tui): -run-on-start flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Flags:
 | `-reset` | `0`     | Override reset vector. `0` keeps the existing `$FFFC/D` bytes (or falls back to the load address if those are zero) |
 | `--cpu`  | `nmos`  | CPU variant: `nmos` (MOS 6502) or `65c02` (WDC/Rockwell CMOS) |
 | `-trace` | —       | Write per-instruction execution trace to this file. Also toggleable at runtime via `:trace PATH \| :trace on \| :trace off`. |
+| `-run-on-start` | `false` | Start the CPU running instead of paused. Pair with `-trace` for non-interactive capture (`chippy -rom prog.bin -trace t.log -run-on-start`). |
 
 Examples:
 

--- a/cmd/chippy/main.go
+++ b/cmd/chippy/main.go
@@ -17,13 +17,14 @@ import (
 
 func main() {
 	var (
-		romPath   = flag.String("rom", "", "program to load (.bin .prg .hex .o)")
-		loadAddr  = flag.Uint("addr", 0x8000, "load address for raw .bin (ignored for .prg/.hex/.o)")
-		resetVec  = flag.Uint("reset", 0, "reset vector override (0 = use file's existing vector or load address)")
-		cfg       = flag.String("cfg", "", "ld65 linker config (.cfg) — required when loading .o files")
-		dbgPath   = flag.String("dbg", "", "cc65 .dbg symbol file (auto-detected as <rom>.dbg if omitted)")
-		cpuFlag   = flag.String("cpu", "nmos", "CPU variant: nmos | 65c02")
-		tracePath = flag.String("trace", "", "write per-instruction execution trace to this file")
+		romPath    = flag.String("rom", "", "program to load (.bin .prg .hex .o)")
+		loadAddr   = flag.Uint("addr", 0x8000, "load address for raw .bin (ignored for .prg/.hex/.o)")
+		resetVec   = flag.Uint("reset", 0, "reset vector override (0 = use file's existing vector or load address)")
+		cfg        = flag.String("cfg", "", "ld65 linker config (.cfg) — required when loading .o files")
+		dbgPath    = flag.String("dbg", "", "cc65 .dbg symbol file (auto-detected as <rom>.dbg if omitted)")
+		cpuFlag    = flag.String("cpu", "nmos", "CPU variant: nmos | 65c02")
+		tracePath  = flag.String("trace", "", "write per-instruction execution trace to this file")
+		runOnStart = flag.Bool("run-on-start", false, "start the CPU running instead of paused (pair with -trace for non-interactive capture)")
 	)
 	flag.Parse()
 
@@ -152,7 +153,8 @@ func main() {
 		WithTextOutput(textOut).
 		WithKeyboard(keyIn).
 		WithTracer(tracer).
-		WithHistoryPath(tui.DefaultHistoryPath())
+		WithHistoryPath(tui.DefaultHistoryPath()).
+		WithRunOnStart(*runOnStart)
 	if syms != nil {
 		model = model.WithSymbols(syms)
 	}

--- a/docs/context.md
+++ b/docs/context.md
@@ -145,10 +145,11 @@ Bus chain: `CPU → tui.WBus → cpu.MMIO → cpu.RAM`
 - v0.0.2 — release cut after #41. 7 features since v0.0.1; binaries + brew tap auto-updated.
 - #54 — Reverse step (issue #17): `cpu.Snapshot` / `CPU.Snapshot`/`Restore` capture full regs + RAM + bookkeeping; `rewindRing` (cap 256, FIFO eviction, LIFO pop) records pre-step state on explicit-step paths only (free-run skipped to avoid 64 KiB/step cost); `<` pops one; status bar shows `rwd:N` depth.
 - #55 — CMOS-aware disasm (issue #42): `DisasmCPU` / `DisasmCPUWithSyms` route through the CPU's opcode table so CMOS-only mnemonics (STZ/PHX/BRA/etc.) render correctly in the disasm panel, trace lines, and any future caller. Legacy `Disasm`/`DisasmWithSyms` retained as NMOS-default shims.
+- #56 — `-run-on-start` flag (issue #44): start the CPU running instead of paused; pair with `-trace` for non-interactive capture.
 
 ### Open issues
 - #22 (homebrew-core) — blocked on stars
-- #43 (trace IRQ entry lines), #44 (--run-on-start), #45 (stack heuristic tighten)
+- #43 (trace IRQ entry lines), #45 (stack heuristic tighten)
 - #46 DAP epic + #47–#53 sub-issues
 
 ---

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -227,6 +227,17 @@ func (m Model) WithHistoryPath(p string) Model {
 	return m
 }
 
+// WithRunOnStart starts the CPU running immediately instead of paused.
+// Useful with -trace for non-interactive capture sessions where there's no
+// user to press `r`.
+func (m Model) WithRunOnStart(run bool) Model {
+	if run {
+		m.Running = true
+		m.Status = "running"
+	}
+	return m
+}
+
 // WithSourceMap loads PC->(file,line) mapping from cc65 .dbg file lines.
 func (m Model) WithSourceMap(sm *symbols.SourceMap) Model {
 	if sm == nil {

--- a/internal/tui/runonstart_test.go
+++ b/internal/tui/runonstart_test.go
@@ -1,0 +1,29 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/nkane/chippy/internal/cpu"
+)
+
+func TestWithRunOnStart_True(t *testing.T) {
+	c := cpu.New(cpu.NewRAM())
+	m := New(c, cpu.NewRAM()).WithRunOnStart(true)
+	if !m.Running {
+		t.Fatalf("Running should be true after WithRunOnStart(true)")
+	}
+	if m.Status != "running" {
+		t.Fatalf("Status should reflect the running state, got %q", m.Status)
+	}
+}
+
+func TestWithRunOnStart_False(t *testing.T) {
+	c := cpu.New(cpu.NewRAM())
+	m := New(c, cpu.NewRAM()).WithRunOnStart(false)
+	if m.Running {
+		t.Fatalf("Running should be false by default")
+	}
+	if m.Status != "ready" {
+		t.Fatalf("Status should be unchanged from default, got %q", m.Status)
+	}
+}


### PR DESCRIPTION
Closes #44.

## Summary
- New CLI flag `-run-on-start` (default false) flips Model.Running=true at startup so the CPU executes immediately instead of waiting for `r`.
- New `Model.WithRunOnStart(bool)` builder mirrors the existing builder pattern.

## Motivation
`chippy -trace t.log` produces no output until the user presses `r` — a footgun for non-interactive workflows (regression diff vs. another emulator, scripted CI captures). `-run-on-start` makes `chippy -rom prog.bin -trace t.log -run-on-start` a complete hands-off capture command.

## Test plan
- [x] `go build ./...` — green.
- [x] `go test -race ./...` — 2 new tests cover Running=true status and the default-false case.
- [x] `golangci-lint run` — 0 issues.
- [x] Live smoke: tmux launches `chippy --trace t.log --run-on-start`, no keys sent → 439k trace lines after 1.0 s, 735k after 1.5 s. Trace populates without intervention.

## Docs (per CLAUDE.md \"docs in every PR\")
- README: flag table row + example.
- docs/context.md: #44 moves to Merged-PRs-of-note.