### PR TITLE
feat(cpu): trace interrupt-entry lines

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -82,11 +82,12 @@ Bus chain: `CPU → tui.WBus → cpu.MMIO → cpu.RAM`
 - `internal/peripheral.KeyboardInput` — Apple-1-style data/status register pair ($F004/$F005); TUI pushes keypresses, CPU reads & status drains
 - Loader and reset-vector helpers write directly to `ram`, bypassing MMIO — peripherals must live at addresses no ROM will occupy
 
-### Execution trace (PR #36, issue #21)
-- `cpu.Tracer` interface — optional per-instruction hook on `CPU.Step()`
+### Execution trace (PR #36, issue #21; #57 issue #43)
+- `cpu.Tracer` interface — optional per-instruction hook on `CPU.Step()`. Methods: `LogStep`, `LogInterrupt`.
 - `cpu.FileTracer` — buffered file sink (64 KiB), Enable/Disable/Close/SetPath
 - CLI: `-trace PATH`; TUI: `:trace PATH | :trace on | :trace off | :trace`
-- Trace skips halted and interrupt-service steps; line format includes PC, opcode bytes, disasm, A/X/Y/P/SP, cumulative CYC
+- Instruction lines: PC, opcode bytes, disasm, A/X/Y/P/SP, cumulative CYC.
+- Interrupt-entry lines: `---- NMI -> $FFFA (PC=$XXXX P=PP SP=SS CYC:N)` emitted at the service boundary, before the 7-cycle push/vector-load, so a reader sees where the PC jump in the next instruction originated.
 
 ---
 
@@ -146,10 +147,11 @@ Bus chain: `CPU → tui.WBus → cpu.MMIO → cpu.RAM`
 - #54 — Reverse step (issue #17): `cpu.Snapshot` / `CPU.Snapshot`/`Restore` capture full regs + RAM + bookkeeping; `rewindRing` (cap 256, FIFO eviction, LIFO pop) records pre-step state on explicit-step paths only (free-run skipped to avoid 64 KiB/step cost); `<` pops one; status bar shows `rwd:N` depth.
 - #55 — CMOS-aware disasm (issue #42): `DisasmCPU` / `DisasmCPUWithSyms` route through the CPU's opcode table so CMOS-only mnemonics (STZ/PHX/BRA/etc.) render correctly in the disasm panel, trace lines, and any future caller. Legacy `Disasm`/`DisasmWithSyms` retained as NMOS-default shims.
 - #56 — `-run-on-start` flag (issue #44): start the CPU running instead of paused; pair with `-trace` for non-interactive capture.
+- #57 — Trace interrupt-entry lines (issue #43): `Tracer.LogInterrupt` hook + `FileTracer` emits `---- NMI -> $FFFA (PC=... P=... SP=... CYC:...)` markers at the service boundary, so trace readers can spot the PC jump in the next instruction.
 
 ### Open issues
 - #22 (homebrew-core) — blocked on stars
-- #43 (trace IRQ entry lines), #45 (stack heuristic tighten)
+- #45 (stack heuristic tighten)
 - #46 DAP epic + #47–#53 sub-issues
 
 ---

--- a/internal/cpu/exec.go
+++ b/internal/cpu/exec.go
@@ -15,12 +15,18 @@ func (c *CPU) Step() int {
 	// the handler.
 	if c.nmiPending {
 		c.Halted = false
+		if c.Tracer != nil {
+			c.Tracer.LogInterrupt(c, "NMI", VecNMI)
+		}
 		before := c.Cycles
 		c.serviceNMI()
 		return int(c.Cycles - before)
 	}
 	if c.irqLine && !c.hasFlag(FlagI) {
 		c.Halted = false
+		if c.Tracer != nil {
+			c.Tracer.LogInterrupt(c, "IRQ", VecIRQ)
+		}
 		before := c.Cycles
 		c.serviceIRQ()
 		return int(c.Cycles - before)

--- a/internal/cpu/trace.go
+++ b/internal/cpu/trace.go
@@ -7,12 +7,19 @@ import (
 	"os"
 )
 
-// Tracer is an optional per-instruction execution hook. When set on CPU,
-// Step() calls LogStep at the instruction boundary just before opcode fetch,
-// so the logged PC/regs reflect the instruction about to execute. Halted
-// steps and interrupt-service steps are not traced — only real instructions.
+// Tracer is an optional execution hook. When set on CPU, Step() calls:
+//
+//   - LogStep at the instruction boundary just before opcode fetch, so the
+//     logged PC/regs reflect the instruction about to execute.
+//   - LogInterrupt at the same boundary when an NMI or IRQ is about to be
+//     serviced, *before* the 7-cycle service writes PC/P to the stack.
+//     This lets viewers spot service boundaries that would otherwise look
+//     like an unexplained PC jump in the trace.
+//
+// Halted-only steps remain silent (no instruction, no interrupt).
 type Tracer interface {
 	LogStep(c *CPU, bus Bus)
+	LogInterrupt(c *CPU, kind string, vector uint16)
 }
 
 // FileTracer writes one line per instruction to a file. Cheap when disabled
@@ -83,6 +90,14 @@ func (t *FileTracer) closeFile() error {
 	}
 	t.out = io.Discard
 	return err
+}
+
+func (t *FileTracer) LogInterrupt(c *CPU, kind string, vector uint16) {
+	if !t.enabled {
+		return
+	}
+	fmt.Fprintf(t.out, "---- %s -> $%04X (PC=$%04X P=%02X SP=%02X CYC:%d)\n",
+		kind, vector, c.PC, c.P, c.SP, c.Cycles)
 }
 
 func (t *FileTracer) LogStep(c *CPU, bus Bus) {

--- a/internal/cpu/trace_irq_test.go
+++ b/internal/cpu/trace_irq_test.go
@@ -1,0 +1,114 @@
+package cpu_test
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nkane/chippy/internal/cpu"
+)
+
+func newTracedCPUForIRQ(t *testing.T) (*cpu.CPU, *cpu.FileTracer, string) {
+	t.Helper()
+	ram := cpu.NewRAM()
+	// Trivial program: NOP NOP NOP (so Step has something to do after service).
+	ram.Load(0x8000, []byte{0xEA, 0xEA, 0xEA})
+	ram.Write(cpu.VecReset, 0x00)
+	ram.Write(cpu.VecReset+1, 0x80)
+	// Vector handlers: NMI at $9000, IRQ at $A000.
+	ram.Write(cpu.VecNMI, 0x00)
+	ram.Write(cpu.VecNMI+1, 0x90)
+	ram.Write(cpu.VecIRQ, 0x00)
+	ram.Write(cpu.VecIRQ+1, 0xA0)
+	ram.Load(0x9000, []byte{0x40}) // RTI
+	ram.Load(0xA000, []byte{0x40}) // RTI
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "trace.log")
+	tr := cpu.NewFileTracer()
+	if err := tr.SetPath(path); err != nil {
+		t.Fatalf("SetPath: %v", err)
+	}
+	tr.Enable()
+	c := cpu.New(ram)
+	c.Tracer = tr
+	return c, tr, path
+}
+
+func readTraceLines(t *testing.T, path string) []string {
+	t.Helper()
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+	var lines []string
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		lines = append(lines, s.Text())
+	}
+	return lines
+}
+
+func TestTrace_NMIEntryLine(t *testing.T) {
+	c, tr, path := newTracedCPUForIRQ(t)
+	c.TriggerNMI()
+	c.Step() // services NMI, no instruction
+	if err := tr.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	lines := readTraceLines(t, path)
+	if len(lines) != 1 {
+		t.Fatalf("want exactly 1 trace line (NMI marker), got %d: %v", len(lines), lines)
+	}
+	if !strings.HasPrefix(lines[0], "---- NMI -> $FFFA") {
+		t.Fatalf("expected NMI marker, got %q", lines[0])
+	}
+	if !strings.Contains(lines[0], "PC=$8000") {
+		t.Fatalf("expected pre-service PC=$8000 in marker, got %q", lines[0])
+	}
+}
+
+func TestTrace_IRQEntryLine(t *testing.T) {
+	c, tr, path := newTracedCPUForIRQ(t)
+	c.P &^= 0x04 // clear FlagI so IRQ is accepted
+	c.AssertIRQ()
+	c.Step() // services IRQ
+	if err := tr.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	lines := readTraceLines(t, path)
+	if len(lines) != 1 {
+		t.Fatalf("want 1 line, got %d: %v", len(lines), lines)
+	}
+	if !strings.HasPrefix(lines[0], "---- IRQ -> $FFFE") {
+		t.Fatalf("expected IRQ marker, got %q", lines[0])
+	}
+}
+
+func TestTrace_NMIThenHandlerInstruction(t *testing.T) {
+	// Verify the marker precedes the first handler instruction in the trace,
+	// so a reader can see the service boundary right before the vector code.
+	c, tr, path := newTracedCPUForIRQ(t)
+	c.TriggerNMI()
+	c.Step() // marker only (service)
+	c.Step() // RTI at $9000 — but wait, that returns to the original PC.
+	// Actually we want to verify the marker shows BEFORE the handler's first
+	// instruction. Service step doesn't fetch an instruction; the next Step
+	// fetches RTI. So expect: [marker, RTI line].
+	if err := tr.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	lines := readTraceLines(t, path)
+	if len(lines) < 2 {
+		t.Fatalf("want at least 2 lines, got %d: %v", len(lines), lines)
+	}
+	if !strings.HasPrefix(lines[0], "---- NMI") {
+		t.Fatalf("line 0 should be NMI marker, got %q", lines[0])
+	}
+	if !strings.HasPrefix(lines[1], "9000 ") {
+		t.Fatalf("line 1 should be RTI at $9000, got %q", lines[1])
+	}
+}


### PR DESCRIPTION
Closes #43.

## Summary
- Adds `Tracer.LogInterrupt(c, kind, vector)` to the trace interface.
- `Step()` calls it on NMI / IRQ service before the 7-cycle push/vector-load.
- `FileTracer.LogInterrupt` emits a regex-distinguishable line:

  ```
  ---- NMI -> $FFFA (PC=$8042 P=24 SP=FD CYC:1234)
  ---- IRQ -> $FFFE (PC=$8042 P=24 SP=FD CYC:1234)
  ```

  The `----` prefix lets post-processing scripts filter / count / collapse interrupt markers without affecting normal instruction-line parsing.

## Why
Without these markers a trace shows a PC jump from the pre-interrupt instruction to the handler with no explanation. Now the boundary is visible inline.

## Test plan
- [x] `go build ./...` — green.
- [x] `go test -race ./...` — 3 new tests cover NMI marker emission, IRQ marker emission (with FlagI cleared), and the marker-before-handler-instruction ordering. Existing 6 trace tests still pass.
- [x] `golangci-lint run` — 0 issues.

## Docs (per CLAUDE.md \"docs in every PR\")
- docs/context.md: trace section updated; #43 moves to Merged-PRs-of-note.