### PR TITLE
feat(tui): tighten stack-frame heuristic with code-range gates

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -148,10 +148,10 @@ Bus chain: `CPU → tui.WBus → cpu.MMIO → cpu.RAM`
 - #55 — CMOS-aware disasm (issue #42): `DisasmCPU` / `DisasmCPUWithSyms` route through the CPU's opcode table so CMOS-only mnemonics (STZ/PHX/BRA/etc.) render correctly in the disasm panel, trace lines, and any future caller. Legacy `Disasm`/`DisasmWithSyms` retained as NMOS-default shims.
 - #56 — `-run-on-start` flag (issue #44): start the CPU running instead of paused; pair with `-trace` for non-interactive capture.
 - #57 — Trace interrupt-entry lines (issue #43): `Tracer.LogInterrupt` hook + `FileTracer` emits `---- NMI -> $FFFA (PC=... P=... SP=... CYC:...)` markers at the service boundary, so trace readers can spot the PC jump in the next instruction.
+- #58 — Stack heuristic tightening (issue #45): `detectStackFrame` now also rejects frames whose stored return-address or JSR target falls below `codeMinAddr = $0200` (zero-page + stack-page). Cuts most false positives without losing real frames.
 
 ### Open issues
 - #22 (homebrew-core) — blocked on stars
-- #45 (stack heuristic tighten)
 - #46 DAP epic + #47–#53 sub-issues
 
 ---

--- a/internal/tui/stack.go
+++ b/internal/tui/stack.go
@@ -22,15 +22,32 @@ type stackEntry struct {
 	src     string // frame only — "file.s:NN" if a source map covers retAddr
 }
 
+// codeMinAddr is the lowest address we accept as plausibly executable code.
+// $0000-$00FF is the zero page, $0100-$01FF is the stack page. Real programs
+// don't put JSR opcodes or JSR targets in those regions, so requiring the
+// stored return address AND the JSR target to be ≥ $0200 cuts most of the
+// false-positive frames the bare opcode check produces. (Programs that DO
+// abuse zero-page as code will lose frame annotation in the affected range
+// but are degenerate cases — the panel still renders the bytes.)
+const codeMinAddr uint16 = 0x0200
+
 // detectStackFrame reports whether the byte pair at $01XX (spLo, spLo+1)
-// looks like a JSR-pushed return address: the byte two below the stored
-// 16-bit value should be the JSR opcode ($20). retAddr is `stored + 1`
-// (the address RTS will jump to); target is the JSR's call target read
-// from the operand bytes.
+// looks like a JSR-pushed return address. The heuristic checks three
+// signals; all must hold:
 //
-// This is a heuristic. Random byte pairs whose value happens to point one
-// past a $20 in RAM will register as a false-positive frame; the cost is
-// a misleading annotation, never a crash.
+//  1. The byte two below the stored 16-bit value is the JSR opcode ($20).
+//  2. The stored return address points at executable space (≥ codeMinAddr).
+//  3. The JSR's call target (read from the two operand bytes that follow
+//     the opcode) also points at executable space.
+//
+// retAddr is `stored + 1` (what RTS will jump to); target is the JSR's
+// call target. Random byte pairs satisfying signal 1 alone get filtered
+// out by 2 and 3 unless the noise happens to look like a real call into
+// a real code region — exceedingly rare.
+//
+// False positives are still possible (misleading annotation, never a
+// crash); `T` toggles the panel back to raw bytes when the heuristic
+// misfires.
 func detectStackFrame(ram *cpu.RAM, spLo uint16) (retAddr, target uint16, ok bool) {
 	if (spLo & 0xFF) == 0xFF {
 		return 0, 0, false
@@ -38,7 +55,7 @@ func detectStackFrame(ram *cpu.RAM, spLo uint16) (retAddr, target uint16, ok boo
 	lo := ram.Read(spLo)
 	hi := ram.Read(spLo + 1)
 	stored := uint16(hi)<<8 | uint16(lo)
-	if stored < 2 {
+	if stored < codeMinAddr {
 		return 0, 0, false
 	}
 	if ram.Read(stored-2) != 0x20 {
@@ -47,6 +64,9 @@ func detectStackFrame(ram *cpu.RAM, spLo uint16) (retAddr, target uint16, ok boo
 	targetLo := ram.Read(stored - 1)
 	targetHi := ram.Read(stored)
 	target = uint16(targetHi)<<8 | uint16(targetLo)
+	if target < codeMinAddr {
+		return 0, 0, false
+	}
 	return stored + 1, target, true
 }
 

--- a/internal/tui/stack_test.go
+++ b/internal/tui/stack_test.go
@@ -61,12 +61,43 @@ func TestDetectStackFrame_TopOfPage(t *testing.T) {
 }
 
 func TestDetectStackFrame_StoredTooLow(t *testing.T) {
-	// Stored value < 2 means there's no room for a JSR opcode below it.
+	// Stored value < codeMinAddr means RAM the return points into is
+	// zero-page or stack-page — degenerate, reject.
 	ram := cpu.NewRAM()
 	ram.Write(0x01FE, 0x01)
 	ram.Write(0x01FF, 0x00)
 	if _, _, ok := detectStackFrame(ram, 0x01FE); ok {
 		t.Fatalf("stored=$0001 has no opcode-2 byte; should be rejected")
+	}
+}
+
+// TestDetectStackFrame_StoredInZeroPage exercises the codeMinAddr gate. A
+// stored value of $00FE has byte $20 placed at $00FC (so signal 1 passes),
+// but the return falls in zero-page so the heuristic rejects it.
+func TestDetectStackFrame_StoredInZeroPage(t *testing.T) {
+	ram := cpu.NewRAM()
+	ram.Write(0x00FC, 0x20) // looks like a JSR in zero-page
+	ram.Write(0x01FE, 0xFE) // lo
+	ram.Write(0x01FF, 0x00) // hi -> stored = $00FE (< $0200)
+	if _, _, ok := detectStackFrame(ram, 0x01FE); ok {
+		t.Fatalf("stored in zero-page should be rejected by codeMinAddr gate")
+	}
+}
+
+// TestDetectStackFrame_TargetInStackPage covers the third gate: stored
+// looks fine, opcode is $20, but the JSR operand points at $01XX which is
+// the stack page itself. Reject — real code doesn't JSR into the stack.
+func TestDetectStackFrame_TargetInStackPage(t *testing.T) {
+	ram := cpu.NewRAM()
+	// JSR opcode at $7FFE, operand $00 $01 -> target $0100 (stack page).
+	ram.Write(0x7FFE, 0x20)
+	ram.Write(0x7FFF, 0x00)
+	ram.Write(0x8000, 0x01)
+	// stored value $8000 (signals 1+2 pass).
+	ram.Write(0x01FE, 0x00)
+	ram.Write(0x01FF, 0x80)
+	if _, _, ok := detectStackFrame(ram, 0x01FE); ok {
+		t.Fatalf("JSR target in stack-page should be rejected")
 	}
 }
 


### PR DESCRIPTION
Closes #45.

## Summary
Adds two address-range checks to `detectStackFrame`:

1. Stored return-address must be ≥ `codeMinAddr` ($0200) — not zero-page or stack-page.
2. JSR target read from the operand bytes must also be ≥ $0200.

The original signal-1 check (byte at `stored-2` is `$20`) remains. False positives where a random stack byte pair satisfies all three signals are exceedingly rare.

## Why
Random stack bytes pointing one past a $20 in RAM previously registered as false-positive frames. The new gates reject the noisy majority because real programs put neither JSR opcodes nor JSR targets in zero / stack pages.

## Trade-off
A pathological program that genuinely uses $0000-$01FF as executable code loses annotation in that range. The panel still renders the bytes and `T` reveals them; degenerate enough that the v1 trade-off is correct.

## Test plan
- [x] `go build ./...` — green.
- [x] `go test -race ./...` — 2 new negative tests (stored-in-zero-page, target-in-stack-page) plus existing 4 `DetectStackFrame_*` tests still pass.
- [x] `golangci-lint run` — 0 issues.

## Docs (per CLAUDE.md \"docs in every PR\")
- docs/context.md: #45 moves to Merged-PRs-of-note; backlog refreshed.