### PR TITLE
feat(dap): DAP transport + initialize/launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Flags:
 | `--cpu`  | `nmos`  | CPU variant: `nmos` (MOS 6502) or `65c02` (WDC/Rockwell CMOS) |
 | `-trace` | —       | Write per-instruction execution trace to this file. Also toggleable at runtime via `:trace PATH \| :trace on \| :trace off`. |
 | `-run-on-start` | `false` | Start the CPU running instead of paused. Pair with `-trace` for non-interactive capture (`chippy -rom prog.bin -trace t.log -run-on-start`). |
+| `-dap`  | —       | Run as a [Debug Adapter Protocol](https://microsoft.github.io/debug-adapter-protocol/) server instead of the TUI. Accepts `stdio` (editor pipes stdin/stdout) or `tcp:PORT` (server listens, editor connects out). Supported requests grow incrementally — see issue #46 epic. |
 
 Examples:
 

--- a/cmd/chippy/dap.go
+++ b/cmd/chippy/dap.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strings"
+
+	"github.com/nkane/chippy/internal/dap"
+)
+
+// runDAP starts a Debug Adapter Protocol server in the requested transport
+// mode and blocks until the session ends. Supported modes:
+//
+//	stdio       — read requests from os.Stdin, write responses to os.Stdout.
+//	             VS Code default; editor spawns chippy and pipes.
+//	tcp:PORT    — listen on TCP, accept exactly one connection. nvim-dap
+//	             default; editor connects out.
+//
+// On exit, normal CLI errors print to stderr. The dap package itself logs
+// to stderr too — never stdout, which is the protocol channel.
+func runDAP(mode string) {
+	switch {
+	case mode == "stdio":
+		srv := dap.NewServer(os.Stdin, os.Stdout)
+		if err := srv.Serve(); err != nil {
+			fmt.Fprintln(os.Stderr, "dap:", err)
+			os.Exit(1)
+		}
+	case strings.HasPrefix(mode, "tcp:"):
+		port := mode[len("tcp:"):]
+		ln, err := net.Listen("tcp", ":"+port)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "dap: listen:", err)
+			os.Exit(1)
+		}
+		defer func() { _ = ln.Close() }()
+		fmt.Fprintf(os.Stderr, "chippy dap: listening on :%s\n", port)
+		conn, err := ln.Accept()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "dap: accept:", err)
+			os.Exit(1)
+		}
+		defer func() { _ = conn.Close() }()
+		srv := dap.NewServer(conn, conn)
+		if err := srv.Serve(); err != nil {
+			fmt.Fprintln(os.Stderr, "dap:", err)
+			os.Exit(1)
+		}
+	default:
+		fmt.Fprintf(os.Stderr, "unknown -dap mode %q (want stdio or tcp:PORT)\n", mode)
+		os.Exit(2)
+	}
+}

--- a/cmd/chippy/main.go
+++ b/cmd/chippy/main.go
@@ -25,8 +25,14 @@ func main() {
 		cpuFlag    = flag.String("cpu", "nmos", "CPU variant: nmos | 65c02")
 		tracePath  = flag.String("trace", "", "write per-instruction execution trace to this file")
 		runOnStart = flag.Bool("run-on-start", false, "start the CPU running instead of paused (pair with -trace for non-interactive capture)")
+		dapMode    = flag.String("dap", "", "run as a Debug Adapter Protocol server instead of the TUI: 'stdio' or 'tcp:PORT'")
 	)
 	flag.Parse()
+
+	if *dapMode != "" {
+		runDAP(*dapMode)
+		return
+	}
 
 	variant := cpu.VariantNMOS
 	switch strings.ToLower(*cpuFlag) {

--- a/docs/context.md
+++ b/docs/context.md
@@ -150,10 +150,11 @@ Bus chain: `CPU → tui.WBus → cpu.MMIO → cpu.RAM`
 - #57 — Trace interrupt-entry lines (issue #43): `Tracer.LogInterrupt` hook + `FileTracer` emits `---- NMI -> $FFFA (PC=... P=... SP=... CYC:...)` markers at the service boundary, so trace readers can spot the PC jump in the next instruction.
 - #58 — Stack heuristic tightening (issue #45): `detectStackFrame` now also rejects frames whose stored return-address or JSR target falls below `codeMinAddr = $0200` (zero-page + stack-page). Cuts most false positives without losing real frames.
 - #68 — Help modal paging: 4 pages, space/→ next, p/← prev, any other key closes. Splits the 10-section keybinding reference so the modal fits on small terminals.
+- #69 — DAP transport + initialize/launch/disconnect (issue #47): `internal/dap` package with Content-Length framing, request/response/event types, server dispatch loop; `-dap stdio | tcp:PORT` CLI flag. Launches construct CPU+RAM+MMIO from `LaunchArguments` matching the CLI flag shape; capabilities advertise everything #48–#53 will eventually wire (conditional bp / instruction bp / disassemble / readMemory / writeMemory etc.).
 
 ### Open issues
 - #22 (homebrew-core) — blocked on stars
-- #46 DAP epic + #47–#53 sub-issues
+- #46 DAP epic; remaining sub-issues #48–#53
 - Post-DAP follow-ups: #59 Klaus 65C02, #60 BCD test, #61 CMOS e2e in CI, #62 peripheral snapshots, #63 VIA 6522, #64 trace replay, #65 mem-watch conditional expressions, #66 CoW RAM snapshots, #67 WebAssembly playground
 
 ---

--- a/internal/dap/frame.go
+++ b/internal/dap/frame.go
@@ -1,0 +1,57 @@
+package dap
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+// ReadMessage reads one Content-Length-framed JSON payload from r. The
+// header section is ASCII lines terminated by \r\n, followed by an empty
+// \r\n, then exactly the byte count declared by `Content-Length`.
+//
+// Any header other than `Content-Length` is ignored (DAP doesn't currently
+// define extra ones but the spec leaves room for it).
+func ReadMessage(r *bufio.Reader) ([]byte, error) {
+	var contentLength int
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			return nil, fmt.Errorf("read header: %w", err)
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			break
+		}
+		if !strings.HasPrefix(strings.ToLower(line), "content-length:") {
+			continue
+		}
+		v := strings.TrimSpace(line[len("Content-Length:"):])
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return nil, fmt.Errorf("bad Content-Length %q: %w", v, err)
+		}
+		contentLength = n
+	}
+	if contentLength <= 0 {
+		return nil, fmt.Errorf("missing or zero Content-Length")
+	}
+	body := make([]byte, contentLength)
+	if _, err := io.ReadFull(r, body); err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+	return body, nil
+}
+
+// WriteMessage frames body with a Content-Length header and writes it to w
+// as one logical message.
+func WriteMessage(w io.Writer, body []byte) error {
+	hdr := fmt.Sprintf("Content-Length: %d\r\n\r\n", len(body))
+	if _, err := io.WriteString(w, hdr); err != nil {
+		return err
+	}
+	_, err := w.Write(body)
+	return err
+}

--- a/internal/dap/frame_test.go
+++ b/internal/dap/frame_test.go
@@ -1,0 +1,76 @@
+package dap
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestFrame_WriteReadRoundTrip(t *testing.T) {
+	want := []byte(`{"seq":1,"type":"request","command":"initialize"}`)
+	var buf bytes.Buffer
+	if err := WriteMessage(&buf, want); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := ReadMessage(bufio.NewReader(&buf))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("roundtrip mismatch:\n want %s\n got  %s", want, got)
+	}
+}
+
+func TestFrame_ReadIgnoresExtraHeaders(t *testing.T) {
+	raw := "Content-Type: application/vscode-jsonrpc\r\n" +
+		"Content-Length: 14\r\n" +
+		"X-Custom: yes\r\n" +
+		"\r\n" +
+		"hello, world!\n"
+	got, err := ReadMessage(bufio.NewReader(strings.NewReader(raw)))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != "hello, world!\n" {
+		t.Fatalf("body mismatch: got %q", got)
+	}
+}
+
+func TestFrame_ReadMissingLength(t *testing.T) {
+	raw := "X-Whatever: yes\r\n\r\nbody"
+	if _, err := ReadMessage(bufio.NewReader(strings.NewReader(raw))); err == nil {
+		t.Fatalf("expected error on missing Content-Length")
+	}
+}
+
+func TestFrame_ReadBadLength(t *testing.T) {
+	raw := "Content-Length: not-a-number\r\n\r\n"
+	if _, err := ReadMessage(bufio.NewReader(strings.NewReader(raw))); err == nil {
+		t.Fatalf("expected error on bad Content-Length value")
+	}
+}
+
+func TestFrame_ReadMultipleMessages(t *testing.T) {
+	// Two back-to-back messages share one stream — header parser must not
+	// over-read past the declared body.
+	var buf bytes.Buffer
+	if err := WriteMessage(&buf, []byte("first")); err != nil {
+		t.Fatalf("write 1: %v", err)
+	}
+	if err := WriteMessage(&buf, []byte("second")); err != nil {
+		t.Fatalf("write 2: %v", err)
+	}
+	r := bufio.NewReader(&buf)
+	m1, err := ReadMessage(r)
+	if err != nil {
+		t.Fatalf("read 1: %v", err)
+	}
+	m2, err := ReadMessage(r)
+	if err != nil {
+		t.Fatalf("read 2: %v", err)
+	}
+	if string(m1) != "first" || string(m2) != "second" {
+		t.Fatalf("messages: got %q %q", m1, m2)
+	}
+}

--- a/internal/dap/protocol.go
+++ b/internal/dap/protocol.go
@@ -1,0 +1,118 @@
+// Package dap implements a Debug Adapter Protocol server for chippy. The
+// DAP wire format is JSON-RPC-flavored: each message is a JSON object framed
+// by an HTTP-style `Content-Length` header. Servers consume requests + emit
+// responses or events; events are unprompted notifications.
+//
+// This package handles the wire layer plus a request-dispatch loop. Real
+// debugger functionality lives in the request handlers (launch, breakpoints,
+// step controls, etc.) and is added one issue at a time per the #46 epic.
+//
+// Spec: https://microsoft.github.io/debug-adapter-protocol/
+package dap
+
+import "encoding/json"
+
+// ProtocolMessage is the base envelope for every DAP message.
+type ProtocolMessage struct {
+	Seq  int    `json:"seq"`
+	Type string `json:"type"` // "request" | "response" | "event"
+}
+
+// Request is a client-initiated call expecting a Response back.
+type Request struct {
+	ProtocolMessage
+	Command   string          `json:"command"`
+	Arguments json.RawMessage `json:"arguments,omitempty"`
+}
+
+// Response carries the result of a Request. Success=false + Message set when
+// the server can't fulfill the request.
+type Response struct {
+	ProtocolMessage
+	RequestSeq int         `json:"request_seq"`
+	Success    bool        `json:"success"`
+	Command    string      `json:"command"`
+	Message    string      `json:"message,omitempty"`
+	Body       interface{} `json:"body,omitempty"`
+}
+
+// Event is an unprompted server-to-client notification.
+type Event struct {
+	ProtocolMessage
+	Event string      `json:"event"`
+	Body  interface{} `json:"body,omitempty"`
+}
+
+// InitializeArguments is the subset of `initialize` request args we use.
+// The full DAP spec has many more capability negotiation fields; clients
+// degrade gracefully on missing values.
+type InitializeArguments struct {
+	ClientID                     string `json:"clientID,omitempty"`
+	ClientName                   string `json:"clientName,omitempty"`
+	AdapterID                    string `json:"adapterID,omitempty"`
+	Locale                       string `json:"locale,omitempty"`
+	LinesStartAt1                bool   `json:"linesStartAt1,omitempty"`
+	ColumnsStartAt1              bool   `json:"columnsStartAt1,omitempty"`
+	PathFormat                   string `json:"pathFormat,omitempty"`
+	SupportsVariableType         bool   `json:"supportsVariableType,omitempty"`
+	SupportsRunInTerminalRequest bool   `json:"supportsRunInTerminalRequest,omitempty"`
+}
+
+// Capabilities is the server's declaration of what requests it honors. The
+// shape mirrors `Capabilities` in the DAP spec; only the fields we actually
+// advertise are populated for now — future issues add to this set as new
+// requests are wired up.
+type Capabilities struct {
+	SupportsConfigurationDoneRequest   bool `json:"supportsConfigurationDoneRequest"`
+	SupportsFunctionBreakpoints        bool `json:"supportsFunctionBreakpoints"`
+	SupportsConditionalBreakpoints     bool `json:"supportsConditionalBreakpoints"`
+	SupportsHitConditionalBreakpoints  bool `json:"supportsHitConditionalBreakpoints"`
+	SupportsEvaluateForHovers          bool `json:"supportsEvaluateForHovers"`
+	SupportsStepBack                   bool `json:"supportsStepBack"`
+	SupportsSetVariable                bool `json:"supportsSetVariable"`
+	SupportsRestartFrame               bool `json:"supportsRestartFrame"`
+	SupportsRestartRequest             bool `json:"supportsRestartRequest"`
+	SupportsExceptionInfoRequest       bool `json:"supportsExceptionInfoRequest"`
+	SupportsTerminateRequest           bool `json:"supportsTerminateRequest"`
+	SupportsDisassembleRequest         bool `json:"supportsDisassembleRequest"`
+	SupportsReadMemoryRequest          bool `json:"supportsReadMemoryRequest"`
+	SupportsWriteMemoryRequest         bool `json:"supportsWriteMemoryRequest"`
+	SupportsInstructionBreakpoints     bool `json:"supportsInstructionBreakpoints"`
+	SupportsSteppingGranularity        bool `json:"supportsSteppingGranularity"`
+	SupportsLogPoints                  bool `json:"supportsLogPoints"`
+	SupportsDelayedStackTraceLoading   bool `json:"supportsDelayedStackTraceLoading"`
+	SupportsLoadedSourcesRequest       bool `json:"supportsLoadedSourcesRequest"`
+	SupportsCompletionsRequest         bool `json:"supportsCompletionsRequest"`
+	SupportsBreakpointLocationsRequest bool `json:"supportsBreakpointLocationsRequest"`
+}
+
+// LaunchArguments is the chippy-specific subset of a `launch` request body.
+// Matches the CLI flags (rom, addr, reset, cpu, dbg, trace) so a launch
+// config in the editor looks like the chippy CLI invocation.
+type LaunchArguments struct {
+	NoDebug     bool   `json:"noDebug,omitempty"`
+	StopOnEntry bool   `json:"stopOnEntry,omitempty"`
+	Rom         string `json:"rom,omitempty"`
+	LoadAddr    uint16 `json:"loadAddr,omitempty"`
+	ResetVec    uint16 `json:"resetVec,omitempty"`
+	LinkerCfg   string `json:"linkerCfg,omitempty"`
+	DbgPath     string `json:"dbgPath,omitempty"`
+	CPUVariant  string `json:"cpuVariant,omitempty"` // "nmos" | "65c02"
+	TracePath   string `json:"tracePath,omitempty"`
+}
+
+// StoppedEventBody is the body of a `stopped` event. Reason values include
+// "entry", "step", "breakpoint", "pause", "exception".
+type StoppedEventBody struct {
+	Reason            string `json:"reason"`
+	Description       string `json:"description,omitempty"`
+	ThreadID          int    `json:"threadId,omitempty"`
+	PreserveFocusHint bool   `json:"preserveFocusHint,omitempty"`
+	Text              string `json:"text,omitempty"`
+	AllThreadsStopped bool   `json:"allThreadsStopped,omitempty"`
+}
+
+// TerminatedEventBody is the body of a `terminated` event.
+type TerminatedEventBody struct {
+	Restart bool `json:"restart,omitempty"`
+}

--- a/internal/dap/server.go
+++ b/internal/dap/server.go
@@ -1,0 +1,308 @@
+package dap
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"sync"
+
+	"github.com/nkane/chippy/internal/cpu"
+	"github.com/nkane/chippy/internal/loader"
+	"github.com/nkane/chippy/internal/peripheral"
+	"github.com/nkane/chippy/internal/symbols"
+)
+
+// Server is a single DAP session. It owns the transport, the message-frame
+// dispatch loop, and the debuggee state created on `launch`.
+//
+// Concurrency: the dispatch loop is single-goroutine. Writes go through
+// `writeMu` so future async events emitted from background goroutines
+// (e.g. the CPU run loop the step issue will add) don't tangle with
+// in-progress responses.
+type Server struct {
+	in  *bufio.Reader
+	out io.Writer
+
+	writeMu sync.Mutex
+	seq     int
+
+	// Debuggee state — populated by `launch`. Nil before launch / after
+	// disconnect. Each request handler checks for nil and reports a
+	// useful error rather than panicking.
+	cpu     *cpu.CPU
+	ram     *cpu.RAM
+	mmio    *cpu.MMIO
+	tracer  *cpu.FileTracer
+	syms    *symbols.Table
+	srcMap  *symbols.SourceMap
+	textOut *peripheral.TextOutput
+	keyIn   *peripheral.KeyboardInput
+
+	// terminated flips true on disconnect / terminate. Serve returns when
+	// either the wire closes or this flag goes true.
+	terminated bool
+}
+
+// NewServer wires the transport to a fresh Server. r/w must point at the
+// negotiated DAP channel — stdio in stdio mode, the accepted TCP socket
+// in tcp mode.
+func NewServer(r io.Reader, w io.Writer) *Server {
+	return &Server{
+		in:  bufio.NewReader(r),
+		out: w,
+	}
+}
+
+// Serve runs the dispatch loop until EOF, write failure, or a successful
+// disconnect/terminate. Returns nil on a clean shutdown.
+func (s *Server) Serve() error {
+	for {
+		if s.terminated {
+			return nil
+		}
+		body, err := ReadMessage(s.in)
+		if err != nil {
+			if err == io.EOF {
+				return nil
+			}
+			return fmt.Errorf("read: %w", err)
+		}
+		var msg ProtocolMessage
+		if err := json.Unmarshal(body, &msg); err != nil {
+			log.Printf("dap: drop unparseable message: %v", err)
+			continue
+		}
+		if msg.Type != "request" {
+			log.Printf("dap: ignore non-request type %q", msg.Type)
+			continue
+		}
+		var req Request
+		if err := json.Unmarshal(body, &req); err != nil {
+			log.Printf("dap: drop unparseable request: %v", err)
+			continue
+		}
+		s.dispatch(req)
+	}
+}
+
+func (s *Server) dispatch(req Request) {
+	switch req.Command {
+	case "initialize":
+		s.handleInitialize(req)
+	case "launch":
+		s.handleLaunch(req)
+	case "attach":
+		s.sendErrorResponse(req, "attach is not supported in this build; use launch")
+	case "configurationDone":
+		s.sendResponse(req, nil)
+	case "disconnect":
+		s.handleDisconnect(req)
+	case "terminate":
+		s.handleTerminate(req)
+	default:
+		s.sendErrorResponse(req, fmt.Sprintf("not implemented: %s", req.Command))
+	}
+}
+
+func (s *Server) handleInitialize(req Request) {
+	caps := Capabilities{
+		SupportsConfigurationDoneRequest:   true,
+		SupportsConditionalBreakpoints:     true,
+		SupportsHitConditionalBreakpoints:  true,
+		SupportsEvaluateForHovers:          true,
+		SupportsTerminateRequest:           true,
+		SupportsDisassembleRequest:         true,
+		SupportsReadMemoryRequest:          true,
+		SupportsWriteMemoryRequest:         true,
+		SupportsInstructionBreakpoints:     true,
+		SupportsLogPoints:                  true,
+		SupportsBreakpointLocationsRequest: true,
+		SupportsLoadedSourcesRequest:       false,
+		SupportsStepBack:                   false,
+		SupportsFunctionBreakpoints:        false,
+		SupportsRestartRequest:             false,
+		SupportsCompletionsRequest:         false,
+	}
+	s.sendResponse(req, caps)
+	s.sendEvent("initialized", nil)
+}
+
+func (s *Server) handleLaunch(req Request) {
+	var args LaunchArguments
+	if err := json.Unmarshal(req.Arguments, &args); err != nil {
+		s.sendErrorResponse(req, fmt.Sprintf("bad launch args: %v", err))
+		return
+	}
+	if err := s.bootDebuggee(args); err != nil {
+		s.sendErrorResponse(req, err.Error())
+		return
+	}
+	s.sendResponse(req, nil)
+	// CPU is paused at the reset vector; report it stopped on entry so
+	// the client immediately renders state. stopOnEntry defaults true —
+	// noDebug + stopOnEntry=false will eventually allow auto-run.
+	if !args.NoDebug {
+		s.sendEvent("stopped", StoppedEventBody{
+			Reason:            "entry",
+			ThreadID:          1,
+			AllThreadsStopped: true,
+		})
+	}
+}
+
+// bootDebuggee constructs the CPU+RAM+MMIO chain the same way
+// cmd/chippy/main.go does for the TUI. Returns a launch-shaped error
+// message on any wiring failure so it can be relayed to the client.
+func (s *Server) bootDebuggee(args LaunchArguments) error {
+	if s.cpu != nil {
+		return fmt.Errorf("a launch is already active; disconnect first")
+	}
+	var variant cpu.Variant
+	switch args.CPUVariant {
+	case "", "nmos", "6502":
+		variant = cpu.VariantNMOS
+	case "65c02", "cmos", "cmos65c02":
+		variant = cpu.VariantCMOS65C02
+	default:
+		return fmt.Errorf("unknown cpuVariant %q", args.CPUVariant)
+	}
+	ram := cpu.NewRAM()
+	var loaded *loader.Result
+	if args.Rom != "" {
+		var err error
+		loaded, err = loader.Load(ram, args.Rom, loader.Options{
+			Addr:      args.LoadAddr,
+			LinkerCfg: args.LinkerCfg,
+		})
+		if err != nil {
+			return fmt.Errorf("load rom: %w", err)
+		}
+	} else {
+		return fmt.Errorf("launch requires a `rom` argument")
+	}
+	switch {
+	case args.ResetVec != 0:
+		ram.Write(cpu.VecReset, byte(args.ResetVec))
+		ram.Write(cpu.VecReset+1, byte(args.ResetVec>>8))
+	case ram.Read(cpu.VecReset) == 0 && ram.Read(cpu.VecReset+1) == 0:
+		ram.Write(cpu.VecReset, byte(loaded.LoadAddr))
+		ram.Write(cpu.VecReset+1, byte(loaded.LoadAddr>>8))
+	}
+
+	dbg := args.DbgPath
+	if dbg == "" {
+		if loaded.LinkedBin != "" {
+			dbg = symbols.SiblingDbg(loaded.LinkedBin)
+		}
+		if dbg == "" {
+			dbg = symbols.SiblingDbg(args.Rom)
+		}
+	}
+	if dbg != "" {
+		if t, err := symbols.LoadDbg(dbg); err == nil {
+			s.syms = t
+		}
+		if sm, err := symbols.LoadSourceMap(dbg); err == nil {
+			s.srcMap = sm
+		}
+	}
+
+	mmio := cpu.NewMMIO(ram)
+	textOut := peripheral.NewTextOutput(0xF001)
+	keyIn := peripheral.NewKeyboardInput(0xF004, 0xF005)
+	if err := mmio.Register(textOut); err != nil {
+		return fmt.Errorf("register text output: %w", err)
+	}
+	if err := mmio.Register(keyIn); err != nil {
+		return fmt.Errorf("register keyboard: %w", err)
+	}
+
+	c := cpu.NewVariant(mmio, variant)
+	tracer := cpu.NewFileTracer()
+	c.Tracer = tracer
+	if args.TracePath != "" {
+		if err := tracer.SetPath(args.TracePath); err != nil {
+			return fmt.Errorf("trace: %w", err)
+		}
+		tracer.Enable()
+	}
+
+	s.cpu = c
+	s.ram = ram
+	s.mmio = mmio
+	s.tracer = tracer
+	s.textOut = textOut
+	s.keyIn = keyIn
+	return nil
+}
+
+func (s *Server) handleDisconnect(req Request) {
+	s.sendResponse(req, nil)
+	if s.tracer != nil {
+		_ = s.tracer.Close()
+	}
+	s.terminated = true
+}
+
+func (s *Server) handleTerminate(req Request) {
+	s.sendResponse(req, nil)
+	s.sendEvent("terminated", TerminatedEventBody{})
+	if s.tracer != nil {
+		_ = s.tracer.Close()
+	}
+	s.terminated = true
+}
+
+// sendResponse marshals a successful response for req. body may be nil.
+func (s *Server) sendResponse(req Request, body interface{}) {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	s.seq++
+	resp := Response{
+		ProtocolMessage: ProtocolMessage{Seq: s.seq, Type: "response"},
+		RequestSeq:      req.Seq,
+		Success:         true,
+		Command:         req.Command,
+		Body:            body,
+	}
+	s.writeJSON(resp)
+}
+
+func (s *Server) sendErrorResponse(req Request, message string) {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	s.seq++
+	resp := Response{
+		ProtocolMessage: ProtocolMessage{Seq: s.seq, Type: "response"},
+		RequestSeq:      req.Seq,
+		Success:         false,
+		Command:         req.Command,
+		Message:         message,
+	}
+	s.writeJSON(resp)
+}
+
+func (s *Server) sendEvent(name string, body interface{}) {
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	s.seq++
+	ev := Event{
+		ProtocolMessage: ProtocolMessage{Seq: s.seq, Type: "event"},
+		Event:           name,
+		Body:            body,
+	}
+	s.writeJSON(ev)
+}
+
+func (s *Server) writeJSON(v interface{}) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		log.Printf("dap: marshal failed: %v", err)
+		return
+	}
+	if err := WriteMessage(s.out, data); err != nil {
+		log.Printf("dap: write failed: %v", err)
+	}
+}

--- a/internal/dap/server_test.go
+++ b/internal/dap/server_test.go
@@ -1,0 +1,160 @@
+package dap
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+// frameRequest writes a DAP-framed request into buf with the given command,
+// seq, and JSON-encoded arguments string. Helper for table-driven server
+// tests below.
+func frameRequest(t *testing.T, buf *bytes.Buffer, seq int, command, argsJSON string) {
+	t.Helper()
+	req := Request{
+		ProtocolMessage: ProtocolMessage{Seq: seq, Type: "request"},
+		Command:         command,
+		Arguments:       json.RawMessage(argsJSON),
+	}
+	body, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	if err := WriteMessage(buf, body); err != nil {
+		t.Fatalf("write framed request: %v", err)
+	}
+}
+
+// drainMessages reads every framed JSON message remaining in buf and
+// returns them parsed into a generic map shape so assertions can poke at
+// specific fields without re-declaring every protocol struct. Reads until
+// the underlying buffer reports EOF (bufio.Reader may pre-buffer so we
+// can't rely on buf.Len() to detect end-of-stream).
+func drainMessages(t *testing.T, buf *bytes.Buffer) []map[string]any {
+	t.Helper()
+	r := bufio.NewReader(buf)
+	var out []map[string]any
+	for {
+		if _, err := r.Peek(1); err != nil {
+			return out
+		}
+		body, err := ReadMessage(r)
+		if err != nil {
+			t.Fatalf("read framed response: %v", err)
+		}
+		var m map[string]any
+		if err := json.Unmarshal(body, &m); err != nil {
+			t.Fatalf("unmarshal response: %v", err)
+		}
+		out = append(out, m)
+	}
+}
+
+func TestServer_InitializeHandshake(t *testing.T) {
+	// Sequence: initialize → disconnect → EOF. Server should:
+	//   1. respond to initialize with success + Capabilities body.
+	//   2. emit an "initialized" event.
+	//   3. respond to disconnect.
+	//   4. exit cleanly (terminated=true).
+	var in bytes.Buffer
+	frameRequest(t, &in, 1, "initialize", `{"adapterID":"chippy"}`)
+	frameRequest(t, &in, 2, "disconnect", `{}`)
+
+	var out bytes.Buffer
+	s := NewServer(&in, &out)
+	if err := s.Serve(); err != nil {
+		t.Fatalf("Serve: %v", err)
+	}
+	msgs := drainMessages(t, &out)
+	if len(msgs) != 3 {
+		t.Fatalf("want 3 outbound messages (init resp, init event, disconnect resp), got %d:\n%v", len(msgs), msgs)
+	}
+
+	// Message 0 — initialize response.
+	m := msgs[0]
+	if m["type"] != "response" || m["command"] != "initialize" {
+		t.Fatalf("msg 0 want type=response cmd=initialize, got %v", m)
+	}
+	if m["success"] != true {
+		t.Fatalf("initialize should succeed: %v", m)
+	}
+	if int(m["request_seq"].(float64)) != 1 {
+		t.Fatalf("response request_seq should match request seq: %v", m)
+	}
+	body, _ := m["body"].(map[string]any)
+	if body == nil {
+		t.Fatalf("initialize response should carry a Capabilities body")
+	}
+	if body["supportsConfigurationDoneRequest"] != true {
+		t.Fatalf("expected supportsConfigurationDoneRequest=true in capabilities")
+	}
+
+	// Message 1 — initialized event.
+	if msgs[1]["type"] != "event" || msgs[1]["event"] != "initialized" {
+		t.Fatalf("msg 1 want event=initialized, got %v", msgs[1])
+	}
+
+	// Message 2 — disconnect response.
+	if msgs[2]["type"] != "response" || msgs[2]["command"] != "disconnect" {
+		t.Fatalf("msg 2 want type=response cmd=disconnect, got %v", msgs[2])
+	}
+}
+
+func TestServer_AttachUnsupported(t *testing.T) {
+	var in bytes.Buffer
+	frameRequest(t, &in, 1, "attach", `{}`)
+	frameRequest(t, &in, 2, "disconnect", `{}`)
+
+	var out bytes.Buffer
+	s := NewServer(&in, &out)
+	if err := s.Serve(); err != nil {
+		t.Fatalf("Serve: %v", err)
+	}
+	msgs := drainMessages(t, &out)
+	if len(msgs) < 1 {
+		t.Fatalf("no response captured")
+	}
+	if msgs[0]["success"] != false {
+		t.Fatalf("attach should fail with error response: %v", msgs[0])
+	}
+	if msgs[0]["message"] == nil {
+		t.Fatalf("error response should include a message: %v", msgs[0])
+	}
+}
+
+func TestServer_LaunchRequiresRom(t *testing.T) {
+	// Launch with no rom field — bootDebuggee should refuse, error response.
+	var in bytes.Buffer
+	frameRequest(t, &in, 1, "launch", `{}`)
+	frameRequest(t, &in, 2, "disconnect", `{}`)
+
+	var out bytes.Buffer
+	s := NewServer(&in, &out)
+	if err := s.Serve(); err != nil {
+		t.Fatalf("Serve: %v", err)
+	}
+	msgs := drainMessages(t, &out)
+	if len(msgs) < 1 {
+		t.Fatalf("no response captured")
+	}
+	if msgs[0]["success"] != false {
+		t.Fatalf("launch without rom should fail: %v", msgs[0])
+	}
+}
+
+func TestServer_UnknownCommand(t *testing.T) {
+	var in bytes.Buffer
+	frameRequest(t, &in, 1, "bogusCommand", `{}`)
+	frameRequest(t, &in, 2, "disconnect", `{}`)
+
+	var out bytes.Buffer
+	s := NewServer(&in, &out)
+	if err := s.Serve(); err != nil {
+		t.Fatalf("Serve: %v", err)
+	}
+	msgs := drainMessages(t, &out)
+	if msgs[0]["success"] != false {
+		t.Fatalf("unknown command should produce error response: %v", msgs[0])
+	}
+}


### PR DESCRIPTION
Closes #47. Foundation for the #46 epic.

## Summary
- New `internal/dap` package with Content-Length wire framing, JSON protocol types, single-goroutine dispatch loop guarded by a `writeMu` so async events from later issues won't tangle with in-flight responses.
- Requests handled in this PR: `initialize`, `launch`, `attach` (returns \"unsupported\"), `configurationDone`, `disconnect`, `terminate`.
- `initialize` already advertises every capability the subsequent issues will wire (conditional + instruction breakpoints, disassemble, readMemory / writeMemory, logPoints, evaluate-for-hovers, etc.) so editors don't have to revisit negotiation each time a new request lands.
- `launch` reuses the exact CPU + RAM + MMIO + tracer wiring `cmd/chippy/main.go` uses for the TUI. `LaunchArguments` mirrors the CLI flag shape: `rom`, `loadAddr`, `resetVec`, `linkerCfg`, `dbgPath`, `cpuVariant`, `tracePath`, `stopOnEntry`, `noDebug`.
- CLI: `-dap stdio` (VS Code default) and `-dap tcp:PORT` (nvim-dap default).

## Deferred to follow-up issues
- #48 threads/stackTrace/scopes/variables
- #49 setBreakpoints / setInstructionBreakpoints
- #50 continue / next / stepIn / stepOut / pause
- #51 disassemble / readMemory / writeMemory
- #52 evaluate
- #53 VS Code + nvim-dap example configs

## Test plan
- [x] `go build ./...` — green.
- [x] `go test -race ./...` — 9 new tests cover framing roundtrip, multi-header parsing, missing/bad Content-Length, multiple-messages-per-stream, initialize handshake (response + initialized event), attach error, launch-without-rom error, unknown-command error.
- [x] `golangci-lint run` — 0 issues.
- [x] Live TCP smoke: `chippy -dap tcp:14786` + a small Go DAP client sends initialize and disconnect, receives capabilities response, `initialized` event, and disconnect response in order.

## Docs (per CLAUDE.md \"docs in every PR\")
- README: `-dap` flag row.
- docs/context.md: #47 moves to Merged-PRs-of-note; DAP epic backlog refreshed.