### PR TITLE
feat(dap): step controls (continue/next/stepIn/stepOut/pause)

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -151,10 +151,12 @@ Bus chain: `CPU → tui.WBus → cpu.MMIO → cpu.RAM`
 - #58 — Stack heuristic tightening (issue #45): `detectStackFrame` now also rejects frames whose stored return-address or JSR target falls below `codeMinAddr = $0200` (zero-page + stack-page). Cuts most false positives without losing real frames.
 - #68 — Help modal paging: 4 pages, space/→ next, p/← prev, any other key closes. Splits the 10-section keybinding reference so the modal fits on small terminals.
 - #69 — DAP transport + initialize/launch/disconnect (issue #47): `internal/dap` package with Content-Length framing, request/response/event types, server dispatch loop; `-dap stdio | tcp:PORT` CLI flag. Launches construct CPU+RAM+MMIO from `LaunchArguments` matching the CLI flag shape; capabilities advertise everything #48–#53 will eventually wire (conditional bp / instruction bp / disassemble / readMemory / writeMemory etc.).
+- v0.1.0 — release cut after #69. Minor bump signals new DAP subsystem.
+- DAP step controls (issue #50): `continue` / `next` / `stepIn` / `stepOut` / `pause` / `threads`. `continue` spins a background goroutine that calls `cpu.Step` until pauseRequested flips true or the CPU halts; emits `stopped` event on exit. Single-step variants refuse while running and emit `stopped` after the synchronous step.
 
 ### Open issues
 - #22 (homebrew-core) — blocked on stars
-- #46 DAP epic; remaining sub-issues #48–#53
+- #46 DAP epic; remaining sub-issues #48 (variables), #49 (breakpoints), #51 (disasm/memory), #52 (evaluate), #53 (example configs + docs)
 - Post-DAP follow-ups: #59 Klaus 65C02, #60 BCD test, #61 CMOS e2e in CI, #62 peripheral snapshots, #63 VIA 6522, #64 trace replay, #65 mem-watch conditional expressions, #66 CoW RAM snapshots, #67 WebAssembly playground
 
 ---

--- a/internal/dap/server.go
+++ b/internal/dap/server.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log"
 	"sync"
+	"sync/atomic"
 
 	"github.com/nkane/chippy/internal/cpu"
 	"github.com/nkane/chippy/internal/loader"
@@ -43,6 +44,15 @@ type Server struct {
 	// terminated flips true on disconnect / terminate. Serve returns when
 	// either the wire closes or this flag goes true.
 	terminated bool
+
+	// Step-control state. `running` is set by `continue`; the run loop
+	// goroutine spins Step() in the background until it observes
+	// `pauseRequested` (set by `pause` or by another step request) or
+	// the CPU halts. `runDone` is closed by the run loop on exit so
+	// other handlers can wait for it before mutating CPU state.
+	running        atomic.Bool
+	pauseRequested atomic.Bool
+	runDone        chan struct{}
 }
 
 // NewServer wires the transport to a fresh Server. r/w must point at the
@@ -97,6 +107,18 @@ func (s *Server) dispatch(req Request) {
 		s.sendErrorResponse(req, "attach is not supported in this build; use launch")
 	case "configurationDone":
 		s.sendResponse(req, nil)
+	case "continue":
+		s.handleContinue(req)
+	case "next":
+		s.handleNext(req)
+	case "stepIn":
+		s.handleStepIn(req)
+	case "stepOut":
+		s.handleStepOut(req)
+	case "pause":
+		s.handlePause(req)
+	case "threads":
+		s.handleThreads(req)
 	case "disconnect":
 		s.handleDisconnect(req)
 	case "terminate":
@@ -239,6 +261,7 @@ func (s *Server) bootDebuggee(args LaunchArguments) error {
 }
 
 func (s *Server) handleDisconnect(req Request) {
+	s.stopRunLoop()
 	s.sendResponse(req, nil)
 	if s.tracer != nil {
 		_ = s.tracer.Close()
@@ -247,12 +270,24 @@ func (s *Server) handleDisconnect(req Request) {
 }
 
 func (s *Server) handleTerminate(req Request) {
+	s.stopRunLoop()
 	s.sendResponse(req, nil)
 	s.sendEvent("terminated", TerminatedEventBody{})
 	if s.tracer != nil {
 		_ = s.tracer.Close()
 	}
 	s.terminated = true
+}
+
+// stopRunLoop signals the run-loop goroutine (if any) to exit and waits
+// for it to finish so callers can safely tear down CPU state. No-op when
+// the CPU is already stopped.
+func (s *Server) stopRunLoop() {
+	if !s.running.Load() {
+		return
+	}
+	s.pauseRequested.Store(true)
+	<-s.runDone
 }
 
 // sendResponse marshals a successful response for req. body may be nil.

--- a/internal/dap/steps.go
+++ b/internal/dap/steps.go
@@ -1,0 +1,157 @@
+package dap
+
+// Step controls — continue / next / stepIn / stepOut / pause — plus the
+// thin `threads` handler that 6502 needs (always one virtual thread).
+//
+// Free-run vs. step:
+//   - `continue` spawns a goroutine that calls cpu.Step in a tight loop
+//     until pauseRequested flips true or the CPU halts. The handler
+//     responds immediately; the goroutine emits the `stopped` event when
+//     it exits.
+//   - Single-step requests (next/stepIn/stepOut) refuse if a continue is
+//     in flight. They execute synchronously and emit `stopped` right
+//     after responding.
+//   - `pause` flips pauseRequested; the run goroutine notices on its
+//     next loop iteration. The stopped event comes from the goroutine,
+//     not the pause handler.
+
+// guardSteps caps stepOut / next loops at this many instructions so a
+// runaway program doesn't pin the goroutine.
+const guardSteps = 2_000_000
+
+func (s *Server) handleThreads(req Request) {
+	type thread struct {
+		ID   int    `json:"id"`
+		Name string `json:"name"`
+	}
+	type body struct {
+		Threads []thread `json:"threads"`
+	}
+	s.sendResponse(req, body{
+		Threads: []thread{{ID: 1, Name: "cpu"}},
+	})
+}
+
+func (s *Server) handleContinue(req Request) {
+	if s.cpu == nil {
+		s.sendErrorResponse(req, "no debuggee — send launch first")
+		return
+	}
+	if s.running.Load() {
+		s.sendErrorResponse(req, "already running")
+		return
+	}
+	s.pauseRequested.Store(false)
+	s.runDone = make(chan struct{})
+	s.running.Store(true)
+
+	type body struct {
+		AllThreadsContinued bool `json:"allThreadsContinued"`
+	}
+	s.sendResponse(req, body{AllThreadsContinued: true})
+
+	go s.runLoop()
+}
+
+// runLoop free-runs the CPU until pauseRequested is set or the CPU halts.
+// Emits the `stopped` event before signaling runDone. Single goroutine —
+// safe to mutate cpu state without locks because no other handler runs
+// while running=true (single-step handlers refuse, and disconnect waits
+// for runDone).
+func (s *Server) runLoop() {
+	defer func() {
+		s.running.Store(false)
+		close(s.runDone)
+	}()
+	reason := "pause"
+	for {
+		if s.pauseRequested.Load() {
+			reason = "pause"
+			break
+		}
+		s.cpu.Step()
+		if s.cpu.Halted {
+			reason = "exception"
+			break
+		}
+	}
+	s.sendEvent("stopped", StoppedEventBody{
+		Reason:            reason,
+		ThreadID:          1,
+		AllThreadsStopped: true,
+	})
+}
+
+func (s *Server) handlePause(req Request) {
+	if !s.running.Load() {
+		s.sendErrorResponse(req, "not running")
+		return
+	}
+	s.pauseRequested.Store(true)
+	s.sendResponse(req, nil)
+}
+
+func (s *Server) handleStepIn(req Request) {
+	if !s.requireStopped(req) {
+		return
+	}
+	s.cpu.Step()
+	s.sendResponse(req, nil)
+	s.sendEvent("stopped", StoppedEventBody{Reason: "step", ThreadID: 1, AllThreadsStopped: true})
+}
+
+// handleNext = step-over. If the current opcode is a JSR ($20), run until
+// PC reaches the address just past the call. Otherwise single-step.
+func (s *Server) handleNext(req Request) {
+	if !s.requireStopped(req) {
+		return
+	}
+	op := s.ram.Read(s.cpu.PC)
+	if op != 0x20 {
+		s.cpu.Step()
+	} else {
+		retPC := s.cpu.PC + 3
+		for i := 0; i < guardSteps; i++ {
+			s.cpu.Step()
+			if s.cpu.Halted || s.cpu.PC == retPC {
+				break
+			}
+		}
+	}
+	s.sendResponse(req, nil)
+	s.sendEvent("stopped", StoppedEventBody{Reason: "step", ThreadID: 1, AllThreadsStopped: true})
+}
+
+// handleStepOut runs until SP rises above the current frame's SP — i.e.
+// the current routine has popped its return address and RTS'd back.
+func (s *Server) handleStepOut(req Request) {
+	if !s.requireStopped(req) {
+		return
+	}
+	startSP := s.cpu.SP
+	for i := 0; i < guardSteps; i++ {
+		s.cpu.Step()
+		if s.cpu.Halted {
+			break
+		}
+		if s.cpu.SP > startSP {
+			break
+		}
+	}
+	s.sendResponse(req, nil)
+	s.sendEvent("stopped", StoppedEventBody{Reason: "step", ThreadID: 1, AllThreadsStopped: true})
+}
+
+// requireStopped checks that a debuggee exists and isn't in continue mode.
+// Sends an error response when either check fails and returns false.
+func (s *Server) requireStopped(req Request) bool {
+	if s.cpu == nil {
+		s.sendErrorResponse(req, "no debuggee — send launch first")
+		return false
+	}
+	if s.running.Load() {
+		s.sendErrorResponse(req, "CPU is running; pause first")
+		return false
+	}
+	return true
+}

--- a/internal/dap/steps_test.go
+++ b/internal/dap/steps_test.go
@@ -1,0 +1,216 @@
+package dap
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nkane/chippy/internal/cpu"
+	"github.com/nkane/chippy/internal/peripheral"
+)
+
+// newStoppedServer constructs a Server with a debuggee pre-wired to
+// match what bootDebuggee builds, then returns it ready for step
+// requests. Skipping the launch round-trip lets tests focus on the
+// step semantics. The caller supplies the program bytes; entry point
+// is $8000 with reset vector pointing at it.
+func newStoppedServer(t *testing.T, prog []byte) (*Server, *bytes.Buffer, *bytes.Buffer) {
+	t.Helper()
+	ram := cpu.NewRAM()
+	ram.Load(0x8000, prog)
+	ram.Write(cpu.VecReset, 0x00)
+	ram.Write(cpu.VecReset+1, 0x80)
+	mmio := cpu.NewMMIO(ram)
+	textOut := peripheral.NewTextOutput(0xF001)
+	keyIn := peripheral.NewKeyboardInput(0xF004, 0xF005)
+	_ = mmio.Register(textOut)
+	_ = mmio.Register(keyIn)
+	c := cpu.New(mmio)
+
+	var in, out bytes.Buffer
+	s := NewServer(&in, &out)
+	s.cpu = c
+	s.ram = ram
+	s.mmio = mmio
+	s.textOut = textOut
+	s.keyIn = keyIn
+	return s, &in, &out
+}
+
+func TestSteps_StepInAdvancesOneInstruction(t *testing.T) {
+	// LDA #$42 (2 bytes) ; LDA #$77 (2 bytes)
+	s, _, _ := newStoppedServer(t, []byte{0xA9, 0x42, 0xA9, 0x77})
+	startPC := s.cpu.PC
+
+	req := Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "stepIn",
+	}
+	s.handleStepIn(req)
+
+	if s.cpu.PC != startPC+2 {
+		t.Fatalf("stepIn should advance one instruction; PC went $%04X -> $%04X", startPC, s.cpu.PC)
+	}
+	if s.cpu.A != 0x42 {
+		t.Fatalf("LDA #$42 should set A=$42, got $%02X", s.cpu.A)
+	}
+}
+
+func TestSteps_NextOverJSRRunsToReturn(t *testing.T) {
+	// JSR $8010 ; NOP ; ... ; @$8010: RTS
+	// Layout: $8000 JSR $8010 (3 bytes) -> next-pc = $8003
+	//         $8003 EA NOP
+	//         $8010 60 RTS
+	s, _, _ := newStoppedServer(t, []byte{0x20, 0x10, 0x80, 0xEA})
+	s.ram.Write(0x8010, 0x60) // RTS
+
+	req := Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "next",
+	}
+	s.handleNext(req)
+
+	if s.cpu.PC != 0x8003 {
+		t.Fatalf("next over JSR should land at $8003 (post-call), got $%04X", s.cpu.PC)
+	}
+}
+
+func TestSteps_NextOverNonJSRSingleSteps(t *testing.T) {
+	// Two NOPs.
+	s, _, _ := newStoppedServer(t, []byte{0xEA, 0xEA})
+	startPC := s.cpu.PC
+
+	req := Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "next",
+	}
+	s.handleNext(req)
+
+	if s.cpu.PC != startPC+1 {
+		t.Fatalf("next over NOP should single-step, got PC $%04X (started $%04X)", s.cpu.PC, startPC)
+	}
+}
+
+func TestSteps_StepOutRunsUntilSPRises(t *testing.T) {
+	// JSR $8010 ; @$8010: RTS
+	s, _, _ := newStoppedServer(t, []byte{0x20, 0x10, 0x80})
+	s.ram.Write(0x8010, 0x60) // RTS
+
+	// First step the JSR so we're inside the routine.
+	stepReq := Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "stepIn",
+	}
+	s.handleStepIn(stepReq)
+	if s.cpu.PC != 0x8010 {
+		t.Fatalf("setup: stepIn should land in callee at $8010, got $%04X", s.cpu.PC)
+	}
+
+	// Now stepOut should run the RTS and return us past the JSR.
+	outReq := Request{
+		ProtocolMessage: ProtocolMessage{Seq: 2, Type: "request"},
+		Command:         "stepOut",
+	}
+	s.handleStepOut(outReq)
+
+	if s.cpu.PC != 0x8003 {
+		t.Fatalf("stepOut should return to $8003, got $%04X", s.cpu.PC)
+	}
+}
+
+func TestSteps_ContinuePauseRoundTrip(t *testing.T) {
+	// Tight loop: LDA #$00 (2 bytes) ; JMP $8000 — runs forever until
+	// pause. A bare `JMP $8000` at $8000 would trip Step()'s self-jump
+	// halt detection (PC == startPC -> Halted=true).
+	s, _, out := newStoppedServer(t, []byte{0xA9, 0x00, 0x4C, 0x00, 0x80})
+
+	contReq := Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "continue",
+	}
+	s.handleContinue(contReq)
+	if !s.running.Load() {
+		t.Fatalf("continue should mark server as running")
+	}
+	// Let the run loop spin briefly so we know it's actually executing.
+	time.Sleep(20 * time.Millisecond)
+
+	pauseReq := Request{
+		ProtocolMessage: ProtocolMessage{Seq: 2, Type: "request"},
+		Command:         "pause",
+	}
+	s.handlePause(pauseReq)
+
+	// Wait for the run loop to observe pauseRequested and shut down.
+	<-s.runDone
+	if s.running.Load() {
+		t.Fatalf("running should be false after run loop exits")
+	}
+
+	// Two responses (continue, pause) + one stopped event should be in
+	// the output buffer.
+	got := out.String()
+	for _, want := range []string{
+		`"command":"continue"`,
+		`"command":"pause"`,
+		`"event":"stopped"`,
+		`"reason":"pause"`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("output missing %q\nfull output:\n%s", want, got)
+		}
+	}
+}
+
+func TestSteps_PauseWhenNotRunningErrors(t *testing.T) {
+	s, _, out := newStoppedServer(t, []byte{0xEA})
+
+	req := Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "pause",
+	}
+	s.handlePause(req)
+
+	if !strings.Contains(out.String(), `"success":false`) {
+		t.Fatalf("pause-when-not-running should produce error response")
+	}
+}
+
+func TestSteps_StepInWhileRunningErrors(t *testing.T) {
+	// LDA #$00 ; JMP $8000 — non-degenerate infinite loop.
+	s, _, out := newStoppedServer(t, []byte{0xA9, 0x00, 0x4C, 0x00, 0x80})
+
+	s.handleContinue(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "continue",
+	})
+
+	// While running=true, stepIn must refuse.
+	s.handleStepIn(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 2, Type: "request"},
+		Command:         "stepIn",
+	})
+
+	// Stop the run loop before reading out — avoids racing with the
+	// stopped event the runLoop emits when it exits.
+	s.pauseRequested.Store(true)
+	<-s.runDone
+
+	if !strings.Contains(out.String(), `"command":"stepIn"`) ||
+		!strings.Contains(out.String(), `"success":false`) {
+		t.Fatalf("stepIn while running should produce error response, got:\n%s", out.String())
+	}
+}
+
+func TestSteps_ThreadsReturnsSingleVirtualThread(t *testing.T) {
+	s, _, out := newStoppedServer(t, []byte{0xEA})
+	s.handleThreads(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "threads",
+	})
+	body := out.String()
+	if !strings.Contains(body, `"id":1`) || !strings.Contains(body, `"name":"cpu"`) {
+		t.Fatalf("threads response should list a single cpu thread, got: %s", body)
+	}
+}


### PR DESCRIPTION
Closes #50.

## Summary
- `continue` — spawns a background run-loop goroutine; responds immediately; the goroutine emits the `stopped` event when it exits.
- `pause` — flips `pauseRequested`, the run loop drops out on the next iteration.
- `next` (step-over) — runs to `PC+3` past a JSR opcode, else single-step.
- `stepIn` — single `cpu.Step()`.
- `stepOut` — steps until SP > startSP (current routine's RTS fires).
- `threads` — returns a single virtual thread `{id: 1, name: \"cpu\"}`.
- Disconnect / terminate now wait for the run goroutine to exit before tearing down CPU state.

## Concurrency
The dispatch loop is single-goroutine. Continue is the only handler that spawns a second goroutine; while it's alive, every other step handler refuses via `requireStopped`. The shared write mutex from #69 keeps the `stopped` event ordered with respect to the request that triggered it.

## Test plan
- [x] `go build ./...` — green.
- [x] `go test -race ./...` — 8 new tests cover stepIn advance, next over JSR, next over NOP, stepOut frame return, continue+pause roundtrip with timing barrier, pause-when-not-running error, stepIn-while-running error, threads single virtual thread.
- [x] `golangci-lint run` — 0 issues.

## Docs (per CLAUDE.md \"docs in every PR\")
- docs/context.md: DAP step controls moves to Merged-PRs-of-note; remaining DAP backlog refreshed.