### PR TITLE
feat(dap): stackTrace / scopes / variables / setVariable

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -153,10 +153,11 @@ Bus chain: `CPU → tui.WBus → cpu.MMIO → cpu.RAM`
 - #69 — DAP transport + initialize/launch/disconnect (issue #47): `internal/dap` package with Content-Length framing, request/response/event types, server dispatch loop; `-dap stdio | tcp:PORT` CLI flag. Launches construct CPU+RAM+MMIO from `LaunchArguments` matching the CLI flag shape; capabilities advertise everything #48–#53 will eventually wire (conditional bp / instruction bp / disassemble / readMemory / writeMemory etc.).
 - v0.1.0 — release cut after #69. Minor bump signals new DAP subsystem.
 - DAP step controls (issue #50): `continue` / `next` / `stepIn` / `stepOut` / `pause` / `threads`. `continue` spins a background goroutine that calls `cpu.Step` until pauseRequested flips true or the CPU halts; emits `stopped` event on exit. Single-step variants refuse while running and emit `stopped` after the synchronous step.
+- DAP stackTrace / scopes / variables / setVariable (issue #48): `stackTrace` walks JSR frames via `cpu.DetectStackFrame` (moved from tui/stack.go); scopes returns `Registers` + `Flags`; variables emits A/X/Y/SP/PC/P/Cycles for ref=1 and N/V/U/B/D/I/Z/C for ref=2; setVariable writes registers or toggles flags. Stack-frame detection moved from tui to cpu package as `cpu.DetectStackFrame`/`StackCodeMinAddr`.
 
 ### Open issues
 - #22 (homebrew-core) — blocked on stars
-- #46 DAP epic; remaining sub-issues #48 (variables), #49 (breakpoints), #51 (disasm/memory), #52 (evaluate), #53 (example configs + docs)
+- #46 DAP epic; remaining sub-issues #49 (breakpoints), #51 (disasm/memory), #52 (evaluate), #53 (example configs + docs)
 - Post-DAP follow-ups: #59 Klaus 65C02, #60 BCD test, #61 CMOS e2e in CI, #62 peripheral snapshots, #63 VIA 6522, #64 trace replay, #65 mem-watch conditional expressions, #66 CoW RAM snapshots, #67 WebAssembly playground
 
 ---

--- a/internal/cpu/stackframe.go
+++ b/internal/cpu/stackframe.go
@@ -1,0 +1,45 @@
+package cpu
+
+// StackCodeMinAddr is the lowest address treated as plausibly executable
+// code by DetectStackFrame. Real programs don't put JSR opcodes or JSR
+// targets in the zero page ($0000-$00FF) or stack page ($0100-$01FF), so
+// any candidate frame whose stored return-address or call target falls
+// below this bar is rejected.
+const StackCodeMinAddr uint16 = 0x0200
+
+// DetectStackFrame reports whether the byte pair at $01XX (spLo, spLo+1)
+// in RAM looks like a JSR-pushed return address. Used by the TUI's
+// annotated stack panel and the DAP `stackTrace` request to walk the
+// 6502 call chain. The heuristic checks three signals; all must hold:
+//
+//  1. The byte two below the stored 16-bit value is the JSR opcode ($20).
+//  2. The stored return address points at executable space
+//     (≥ StackCodeMinAddr).
+//  3. The JSR's call target (read from the two operand bytes that follow
+//     the opcode) also points at executable space.
+//
+// retAddr is `stored + 1` (the address RTS will jump to); target is the
+// JSR's call target. False positives are still possible (misleading
+// annotation, never a crash) — random stack bytes that happen to point
+// one past a $20 in real code can register as frames.
+func DetectStackFrame(ram *RAM, spLo uint16) (retAddr, target uint16, ok bool) {
+	if (spLo & 0xFF) == 0xFF {
+		return 0, 0, false
+	}
+	lo := ram.Read(spLo)
+	hi := ram.Read(spLo + 1)
+	stored := uint16(hi)<<8 | uint16(lo)
+	if stored < StackCodeMinAddr {
+		return 0, 0, false
+	}
+	if ram.Read(stored-2) != 0x20 {
+		return 0, 0, false
+	}
+	targetLo := ram.Read(stored - 1)
+	targetHi := ram.Read(stored)
+	target = uint16(targetHi)<<8 | uint16(targetLo)
+	if target < StackCodeMinAddr {
+		return 0, 0, false
+	}
+	return stored + 1, target, true
+}

--- a/internal/dap/protocol.go
+++ b/internal/dap/protocol.go
@@ -116,3 +116,63 @@ type StoppedEventBody struct {
 type TerminatedEventBody struct {
 	Restart bool `json:"restart,omitempty"`
 }
+
+// Source identifies a source file in stack-frame / breakpoint requests.
+type Source struct {
+	Name string `json:"name,omitempty"`
+	Path string `json:"path,omitempty"`
+}
+
+// StackFrame is one entry in a `stackTrace` response. ID must be unique
+// per stopped point so the client can correlate frames with subsequent
+// `scopes` and `variables` requests.
+type StackFrame struct {
+	ID                          int     `json:"id"`
+	Name                        string  `json:"name"`
+	Source                      *Source `json:"source,omitempty"`
+	Line                        int     `json:"line,omitempty"`
+	Column                      int     `json:"column,omitempty"`
+	InstructionPointerReference string  `json:"instructionPointerReference,omitempty"`
+}
+
+// Scope groups variables under a named heading in the editor's Variables
+// pane. VariablesReference is the handle the client passes to a follow-up
+// `variables` request.
+type Scope struct {
+	Name               string `json:"name"`
+	VariablesReference int    `json:"variablesReference"`
+	Expensive          bool   `json:"expensive"`
+}
+
+// Variable is one row in the Variables pane. VariablesReference > 0 means
+// the entry has children; the client expands it via `variables` again.
+type Variable struct {
+	Name               string `json:"name"`
+	Value              string `json:"value"`
+	Type               string `json:"type,omitempty"`
+	VariablesReference int    `json:"variablesReference,omitempty"`
+}
+
+// StackTraceArguments is the request body for `stackTrace`.
+type StackTraceArguments struct {
+	ThreadID   int `json:"threadId"`
+	StartFrame int `json:"startFrame,omitempty"`
+	Levels     int `json:"levels,omitempty"`
+}
+
+// ScopesArguments is the request body for `scopes`.
+type ScopesArguments struct {
+	FrameID int `json:"frameId"`
+}
+
+// VariablesArguments is the request body for `variables`.
+type VariablesArguments struct {
+	VariablesReference int `json:"variablesReference"`
+}
+
+// SetVariableArguments is the request body for `setVariable`.
+type SetVariableArguments struct {
+	VariablesReference int    `json:"variablesReference"`
+	Name               string `json:"name"`
+	Value              string `json:"value"`
+}

--- a/internal/dap/server.go
+++ b/internal/dap/server.go
@@ -119,6 +119,14 @@ func (s *Server) dispatch(req Request) {
 		s.handlePause(req)
 	case "threads":
 		s.handleThreads(req)
+	case "stackTrace":
+		s.handleStackTrace(req)
+	case "scopes":
+		s.handleScopes(req)
+	case "variables":
+		s.handleVariables(req)
+	case "setVariable":
+		s.handleSetVariable(req)
 	case "disconnect":
 		s.handleDisconnect(req)
 	case "terminate":
@@ -146,6 +154,7 @@ func (s *Server) handleInitialize(req Request) {
 		SupportsFunctionBreakpoints:        false,
 		SupportsRestartRequest:             false,
 		SupportsCompletionsRequest:         false,
+		SupportsSetVariable:                true,
 	}
 	s.sendResponse(req, caps)
 	s.sendEvent("initialized", nil)

--- a/internal/dap/vars.go
+++ b/internal/dap/vars.go
@@ -1,0 +1,272 @@
+package dap
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/nkane/chippy/internal/cpu"
+)
+
+// Variable-reference IDs. Static / well-known because the 6502 has a
+// single fixed set of registers and flags; no per-frame variation. Real
+// debug targets typically allocate these dynamically, but for 6502 a
+// constant map is plain and lets `setVariable` switch on the ref ID
+// instead of carrying a generation counter.
+const (
+	refRegisters = 1
+	refFlags     = 2
+)
+
+func (s *Server) handleStackTrace(req Request) {
+	if s.cpu == nil {
+		s.sendErrorResponse(req, "no debuggee — send launch first")
+		return
+	}
+	type body struct {
+		StackFrames []StackFrame `json:"stackFrames"`
+		TotalFrames int          `json:"totalFrames"`
+	}
+	frames := make([]StackFrame, 0, 8)
+	frames = append(frames, s.frameForPC(0, s.cpu.PC))
+
+	// Walk upward from SP+1; each detected JSR pair becomes another frame.
+	// Cap at 64 frames to bound a runaway stack.
+	const frameCap = 64
+	a := uint16(s.cpu.SP) + 1
+	for a <= 0xFF && len(frames) < frameCap {
+		sp := uint16(0x0100) | a
+		retAddr, _, ok := cpu.DetectStackFrame(s.ram, sp)
+		if !ok {
+			a++
+			continue
+		}
+		// retAddr is the address RTS will jump to. The caller's PC at the
+		// JSR site is retAddr - 1 (the operand byte of the JSR). For the
+		// stack-trace `Name` we still report retAddr so the user sees
+		// where the routine will resume.
+		frames = append(frames, s.frameForPC(len(frames), retAddr))
+		a += 2
+	}
+	s.sendResponse(req, body{StackFrames: frames, TotalFrames: len(frames)})
+}
+
+// frameForPC builds a StackFrame at the given ID for the given PC. Source
+// info is filled from the loaded .dbg when available; otherwise the
+// caller sees a bare `$XXXX` name.
+func (s *Server) frameForPC(id int, pc uint16) StackFrame {
+	f := StackFrame{
+		ID:                          id,
+		Name:                        s.nameForPC(pc),
+		InstructionPointerReference: fmt.Sprintf("$%04X", pc),
+	}
+	if s.srcMap != nil {
+		if loc, ok := s.srcMap.PCToSrc[pc]; ok {
+			name := filepath.Base(loc.File)
+			f.Source = &Source{Name: name, Path: loc.File}
+			f.Line = loc.Line
+			f.Column = 1
+		}
+	}
+	return f
+}
+
+func (s *Server) nameForPC(pc uint16) string {
+	if s.syms != nil {
+		if n := s.syms.Lookup(pc); n != "" {
+			return n
+		}
+	}
+	return fmt.Sprintf("$%04X", pc)
+}
+
+func (s *Server) handleScopes(req Request) {
+	if s.cpu == nil {
+		s.sendErrorResponse(req, "no debuggee")
+		return
+	}
+	type body struct {
+		Scopes []Scope `json:"scopes"`
+	}
+	s.sendResponse(req, body{Scopes: []Scope{
+		{Name: "Registers", VariablesReference: refRegisters, Expensive: false},
+		{Name: "Flags", VariablesReference: refFlags, Expensive: false},
+	}})
+}
+
+func (s *Server) handleVariables(req Request) {
+	if s.cpu == nil {
+		s.sendErrorResponse(req, "no debuggee")
+		return
+	}
+	var args VariablesArguments
+	if err := json.Unmarshal(req.Arguments, &args); err != nil {
+		s.sendErrorResponse(req, fmt.Sprintf("bad variables args: %v", err))
+		return
+	}
+	type body struct {
+		Variables []Variable `json:"variables"`
+	}
+	switch args.VariablesReference {
+	case refRegisters:
+		s.sendResponse(req, body{Variables: s.regsVariables()})
+	case refFlags:
+		s.sendResponse(req, body{Variables: s.flagsVariables()})
+	default:
+		s.sendErrorResponse(req, fmt.Sprintf("unknown variablesReference: %d", args.VariablesReference))
+	}
+}
+
+func (s *Server) regsVariables() []Variable {
+	return []Variable{
+		{Name: "A", Value: fmt.Sprintf("$%02X", s.cpu.A), Type: "byte"},
+		{Name: "X", Value: fmt.Sprintf("$%02X", s.cpu.X), Type: "byte"},
+		{Name: "Y", Value: fmt.Sprintf("$%02X", s.cpu.Y), Type: "byte"},
+		{Name: "SP", Value: fmt.Sprintf("$%02X", s.cpu.SP), Type: "byte"},
+		{Name: "PC", Value: fmt.Sprintf("$%04X", s.cpu.PC), Type: "word"},
+		{Name: "P", Value: fmt.Sprintf("$%02X", s.cpu.P), Type: "byte"},
+		{Name: "Cycles", Value: strconv.FormatUint(s.cpu.Cycles, 10), Type: "uint64"},
+	}
+}
+
+func (s *Server) flagsVariables() []Variable {
+	one := func(name string, bit byte) Variable {
+		v := "0"
+		if s.cpu.P&bit != 0 {
+			v = "1"
+		}
+		return Variable{Name: name, Value: v, Type: "bit"}
+	}
+	return []Variable{
+		one("N", cpu.FlagN),
+		one("V", cpu.FlagV),
+		one("U", cpu.FlagU),
+		one("B", cpu.FlagB),
+		one("D", cpu.FlagD),
+		one("I", cpu.FlagI),
+		one("Z", cpu.FlagZ),
+		one("C", cpu.FlagC),
+	}
+}
+
+func (s *Server) handleSetVariable(req Request) {
+	if s.cpu == nil {
+		s.sendErrorResponse(req, "no debuggee")
+		return
+	}
+	if s.running.Load() {
+		s.sendErrorResponse(req, "CPU is running; pause first")
+		return
+	}
+	var args SetVariableArguments
+	if err := json.Unmarshal(req.Arguments, &args); err != nil {
+		s.sendErrorResponse(req, fmt.Sprintf("bad setVariable args: %v", err))
+		return
+	}
+	n, err := parseDAPNumber(args.Value)
+	if err != nil {
+		s.sendErrorResponse(req, fmt.Sprintf("bad value %q: %v", args.Value, err))
+		return
+	}
+	type body struct {
+		Value string `json:"value"`
+		Type  string `json:"type,omitempty"`
+	}
+	switch args.VariablesReference {
+	case refRegisters:
+		newVal, t, err := s.setRegister(args.Name, n)
+		if err != nil {
+			s.sendErrorResponse(req, err.Error())
+			return
+		}
+		s.sendResponse(req, body{Value: newVal, Type: t})
+	case refFlags:
+		newVal, err := s.setFlag(args.Name, n)
+		if err != nil {
+			s.sendErrorResponse(req, err.Error())
+			return
+		}
+		s.sendResponse(req, body{Value: newVal, Type: "bit"})
+	default:
+		s.sendErrorResponse(req, fmt.Sprintf("unknown variablesReference: %d", args.VariablesReference))
+	}
+}
+
+func (s *Server) setRegister(name string, v uint64) (string, string, error) {
+	switch strings.ToUpper(name) {
+	case "A":
+		s.cpu.A = byte(v)
+		return fmt.Sprintf("$%02X", s.cpu.A), "byte", nil
+	case "X":
+		s.cpu.X = byte(v)
+		return fmt.Sprintf("$%02X", s.cpu.X), "byte", nil
+	case "Y":
+		s.cpu.Y = byte(v)
+		return fmt.Sprintf("$%02X", s.cpu.Y), "byte", nil
+	case "SP":
+		s.cpu.SP = byte(v)
+		return fmt.Sprintf("$%02X", s.cpu.SP), "byte", nil
+	case "PC":
+		s.cpu.PC = uint16(v)
+		return fmt.Sprintf("$%04X", s.cpu.PC), "word", nil
+	case "P":
+		s.cpu.P = byte(v)
+		return fmt.Sprintf("$%02X", s.cpu.P), "byte", nil
+	}
+	return "", "", fmt.Errorf("unknown register: %s", name)
+}
+
+func (s *Server) setFlag(name string, v uint64) (string, error) {
+	var bit byte
+	switch strings.ToUpper(name) {
+	case "N":
+		bit = cpu.FlagN
+	case "V":
+		bit = cpu.FlagV
+	case "U":
+		bit = cpu.FlagU
+	case "B":
+		bit = cpu.FlagB
+	case "D":
+		bit = cpu.FlagD
+	case "I":
+		bit = cpu.FlagI
+	case "Z":
+		bit = cpu.FlagZ
+	case "C":
+		bit = cpu.FlagC
+	default:
+		return "", fmt.Errorf("unknown flag: %s", name)
+	}
+	if v != 0 {
+		s.cpu.P |= bit
+	} else {
+		s.cpu.P &^= bit
+	}
+	if s.cpu.P&bit != 0 {
+		return "1", nil
+	}
+	return "0", nil
+}
+
+// parseDAPNumber accepts `$XX`, `0xXX`, decimal, or bare hex. DAP doesn't
+// fix the format for setVariable values — clients (VS Code, nvim-dap)
+// echo back whatever the user typed in the Variables pane.
+func parseDAPNumber(s string) (uint64, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, fmt.Errorf("empty value")
+	}
+	switch {
+	case strings.HasPrefix(s, "$"):
+		return strconv.ParseUint(s[1:], 16, 32)
+	case strings.HasPrefix(s, "0x"), strings.HasPrefix(s, "0X"):
+		return strconv.ParseUint(s[2:], 16, 32)
+	}
+	if v, err := strconv.ParseUint(s, 10, 32); err == nil {
+		return v, nil
+	}
+	return strconv.ParseUint(s, 16, 32)
+}

--- a/internal/dap/vars_test.go
+++ b/internal/dap/vars_test.go
@@ -1,0 +1,187 @@
+package dap
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestVars_StackTraceTopFrame(t *testing.T) {
+	s, _, out := newStoppedServer(t, []byte{0xEA, 0xEA})
+	req := Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "stackTrace",
+		Arguments:       json.RawMessage(`{"threadId":1}`),
+	}
+	s.handleStackTrace(req)
+
+	body := out.String()
+	if !strings.Contains(body, `"id":0`) {
+		t.Fatalf("expected frame id 0, got: %s", body)
+	}
+	if !strings.Contains(body, `"instructionPointerReference":"$8000"`) {
+		t.Fatalf("expected IP $8000 for top frame, got: %s", body)
+	}
+}
+
+func TestVars_StackTraceWalksJSRFrames(t *testing.T) {
+	// JSR $9000 at $8000 ; @$9000: JSR $A000 ; @$A000: NOP
+	s, _, out := newStoppedServer(t, []byte{0x20, 0x00, 0x90}) // $8000-$8002
+	s.ram.Write(0x9000, 0x20)                                  // JSR
+	s.ram.Write(0x9001, 0x00)                                  // $A000 lo
+	s.ram.Write(0x9002, 0xA0)                                  // $A000 hi
+	s.ram.Write(0xA000, 0xEA)                                  // NOP
+
+	// Step through both JSRs so we're at $A000 with two frames on the stack.
+	s.cpu.Step() // JSR $9000 -> PC=$9000
+	s.cpu.Step() // JSR $A000 -> PC=$A000
+	if s.cpu.PC != 0xA000 {
+		t.Fatalf("setup: want PC=$A000, got $%04X", s.cpu.PC)
+	}
+
+	req := Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "stackTrace",
+		Arguments:       json.RawMessage(`{"threadId":1}`),
+	}
+	s.handleStackTrace(req)
+
+	body := out.String()
+	// Expect 3 frames: $A000 (current), $9003 (return from inner), $8003.
+	for _, want := range []string{`"$A000"`, `"$9003"`, `"$8003"`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("expected frame ref %s in body:\n%s", want, body)
+		}
+	}
+}
+
+func TestVars_Scopes(t *testing.T) {
+	s, _, out := newStoppedServer(t, []byte{0xEA})
+	s.handleScopes(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "scopes",
+		Arguments:       json.RawMessage(`{"frameId":0}`),
+	})
+	body := out.String()
+	if !strings.Contains(body, `"name":"Registers"`) {
+		t.Fatalf("missing Registers scope: %s", body)
+	}
+	if !strings.Contains(body, `"name":"Flags"`) {
+		t.Fatalf("missing Flags scope: %s", body)
+	}
+}
+
+func TestVars_VariablesRegisters(t *testing.T) {
+	s, _, out := newStoppedServer(t, []byte{0xA9, 0x42}) // LDA #$42
+	s.cpu.Step()                                         // A=$42
+
+	s.handleVariables(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "variables",
+		Arguments:       json.RawMessage(`{"variablesReference":1}`),
+	})
+	body := out.String()
+	if !strings.Contains(body, `"name":"A"`) || !strings.Contains(body, `"value":"$42"`) {
+		t.Fatalf("expected A=$42 in body:\n%s", body)
+	}
+}
+
+func TestVars_VariablesFlags(t *testing.T) {
+	s, _, out := newStoppedServer(t, []byte{0xEA})
+	s.cpu.P = 0x24 // FlagU | FlagI
+
+	s.handleVariables(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "variables",
+		Arguments:       json.RawMessage(`{"variablesReference":2}`),
+	})
+	body := out.String()
+	// U bit (0x20) and I bit (0x04) should read 1; others 0.
+	for _, want := range []string{
+		`"name":"U","value":"1"`,
+		`"name":"I","value":"1"`,
+		`"name":"N","value":"0"`,
+		`"name":"C","value":"0"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("expected %s in body:\n%s", want, body)
+		}
+	}
+}
+
+func TestVars_SetVariableRegister(t *testing.T) {
+	s, _, _ := newStoppedServer(t, []byte{0xEA})
+	s.handleSetVariable(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "setVariable",
+		Arguments:       json.RawMessage(`{"variablesReference":1,"name":"A","value":"$AA"}`),
+	})
+	if s.cpu.A != 0xAA {
+		t.Fatalf("setVariable A=$AA should write the register; got $%02X", s.cpu.A)
+	}
+}
+
+func TestVars_SetVariableFlag(t *testing.T) {
+	s, _, _ := newStoppedServer(t, []byte{0xEA})
+	s.cpu.P = 0
+	s.handleSetVariable(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "setVariable",
+		Arguments:       json.RawMessage(`{"variablesReference":2,"name":"C","value":"1"}`),
+	})
+	if s.cpu.P&0x01 == 0 {
+		t.Fatalf("setVariable C=1 should set carry; P=$%02X", s.cpu.P)
+	}
+	s.handleSetVariable(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 2, Type: "request"},
+		Command:         "setVariable",
+		Arguments:       json.RawMessage(`{"variablesReference":2,"name":"C","value":"0"}`),
+	})
+	if s.cpu.P&0x01 != 0 {
+		t.Fatalf("setVariable C=0 should clear carry; P=$%02X", s.cpu.P)
+	}
+}
+
+func TestVars_SetVariableUnknownReg(t *testing.T) {
+	s, _, out := newStoppedServer(t, []byte{0xEA})
+	s.handleSetVariable(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "setVariable",
+		Arguments:       json.RawMessage(`{"variablesReference":1,"name":"BOGUS","value":"$01"}`),
+	})
+	if !strings.Contains(out.String(), `"success":false`) {
+		t.Fatalf("unknown reg name should error")
+	}
+}
+
+func TestParseDAPNumber(t *testing.T) {
+	cases := []struct {
+		in   string
+		want uint64
+		err  bool
+	}{
+		{"$42", 0x42, false},
+		{"$FFFF", 0xFFFF, false},
+		{"0x80", 0x80, false},
+		{"42", 42, false},
+		{"FF", 0xFF, false}, // bare hex fallback
+		{"", 0, true},
+		{"xyz", 0, true},
+	}
+	for _, c := range cases {
+		got, err := parseDAPNumber(c.in)
+		if c.err {
+			if err == nil {
+				t.Errorf("parseDAPNumber(%q): want err, got %d", c.in, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("parseDAPNumber(%q): unexpected err %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("parseDAPNumber(%q): want %d, got %d", c.in, c.want, got)
+		}
+	}
+}

--- a/internal/tui/stack.go
+++ b/internal/tui/stack.go
@@ -22,52 +22,12 @@ type stackEntry struct {
 	src     string // frame only — "file.s:NN" if a source map covers retAddr
 }
 
-// codeMinAddr is the lowest address we accept as plausibly executable code.
-// $0000-$00FF is the zero page, $0100-$01FF is the stack page. Real programs
-// don't put JSR opcodes or JSR targets in those regions, so requiring the
-// stored return address AND the JSR target to be ≥ $0200 cuts most of the
-// false-positive frames the bare opcode check produces. (Programs that DO
-// abuse zero-page as code will lose frame annotation in the affected range
-// but are degenerate cases — the panel still renders the bytes.)
-const codeMinAddr uint16 = 0x0200
-
-// detectStackFrame reports whether the byte pair at $01XX (spLo, spLo+1)
-// looks like a JSR-pushed return address. The heuristic checks three
-// signals; all must hold:
-//
-//  1. The byte two below the stored 16-bit value is the JSR opcode ($20).
-//  2. The stored return address points at executable space (≥ codeMinAddr).
-//  3. The JSR's call target (read from the two operand bytes that follow
-//     the opcode) also points at executable space.
-//
-// retAddr is `stored + 1` (what RTS will jump to); target is the JSR's
-// call target. Random byte pairs satisfying signal 1 alone get filtered
-// out by 2 and 3 unless the noise happens to look like a real call into
-// a real code region — exceedingly rare.
-//
-// False positives are still possible (misleading annotation, never a
-// crash); `T` toggles the panel back to raw bytes when the heuristic
-// misfires.
+// detectStackFrame is the TUI-side alias for cpu.DetectStackFrame; thin
+// wrapper kept so existing call sites (and tests) don't grow extra import
+// noise. The actual heuristic lives in the cpu package so the DAP server
+// can share it without depending on tui.
 func detectStackFrame(ram *cpu.RAM, spLo uint16) (retAddr, target uint16, ok bool) {
-	if (spLo & 0xFF) == 0xFF {
-		return 0, 0, false
-	}
-	lo := ram.Read(spLo)
-	hi := ram.Read(spLo + 1)
-	stored := uint16(hi)<<8 | uint16(lo)
-	if stored < codeMinAddr {
-		return 0, 0, false
-	}
-	if ram.Read(stored-2) != 0x20 {
-		return 0, 0, false
-	}
-	targetLo := ram.Read(stored - 1)
-	targetHi := ram.Read(stored)
-	target = uint16(targetHi)<<8 | uint16(targetLo)
-	if target < codeMinAddr {
-		return 0, 0, false
-	}
-	return stored + 1, target, true
+	return cpu.DetectStackFrame(ram, spLo)
 }
 
 // stackEntries walks upward from SP+1 building rendered rows for the stack


### PR DESCRIPTION
Closes #48.

## Summary
- `stackTrace` walks JSR frames using `cpu.DetectStackFrame` (moved from `tui/stack.go` so DAP can share); top frame = current PC, older frames = stored return addresses.
- `scopes` returns \"Registers\" + \"Flags\" with constant `variablesReference` IDs (1 and 2).
- `variables` ref=1 -> {A, X, Y, SP, PC, P, Cycles}; ref=2 -> the 8 P-flag bits.
- `setVariable` writes hex/decimal back to registers and flags. Refuses while CPU is running.
- Capabilities now advertise `supportsSetVariable: true`.

## Refactor
`DetectStackFrame` + `StackCodeMinAddr` moved from `internal/tui` to `internal/cpu`. The TUI's stack panel keeps a thin private alias so existing call sites compile without churn.

## Test plan
- [x] `go build ./...` — green.
- [x] `go test -race ./...` — 8 new tests cover stackTrace top frame, stackTrace walks JSR chain (3 frames after JSR ; JSR), scopes returns Registers + Flags, variables registers, variables flags, setVariable register, setVariable flag, setVariable unknown name error. Plus parseDAPNumber parser test.
- [x] `golangci-lint run` — 0 issues.

## Docs (per CLAUDE.md \"docs in every PR\")
- docs/context.md: stackTrace/scopes/variables work moved to Merged-PRs-of-note; remaining DAP backlog refreshed.