### PR TITLE
feat(dap): source-line + instruction breakpoints

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -154,10 +154,11 @@ Bus chain: `CPU → tui.WBus → cpu.MMIO → cpu.RAM`
 - v0.1.0 — release cut after #69. Minor bump signals new DAP subsystem.
 - DAP step controls (issue #50): `continue` / `next` / `stepIn` / `stepOut` / `pause` / `threads`. `continue` spins a background goroutine that calls `cpu.Step` until pauseRequested flips true or the CPU halts; emits `stopped` event on exit. Single-step variants refuse while running and emit `stopped` after the synchronous step.
 - DAP stackTrace / scopes / variables / setVariable (issue #48): `stackTrace` walks JSR frames via `cpu.DetectStackFrame` (moved from tui/stack.go); scopes returns `Registers` + `Flags`; variables emits A/X/Y/SP/PC/P/Cycles for ref=1 and N/V/U/B/D/I/Z/C for ref=2; setVariable writes registers or toggles flags. Stack-frame detection moved from tui to cpu package as `cpu.DetectStackFrame`/`StackCodeMinAddr`.
+- DAP breakpoints (issue #49): `setBreakpoints` (source-line, resolved via `srcMap.PCToSrc` reverse-lookup) and `setInstructionBreakpoints` (address). Both are destructive against their respective namespace per DAP spec. Run loop checks `bpHit` (flattened union) at each Step and emits `stopped` with reason=breakpoint.
 
 ### Open issues
 - #22 (homebrew-core) — blocked on stars
-- #46 DAP epic; remaining sub-issues #49 (breakpoints), #51 (disasm/memory), #52 (evaluate), #53 (example configs + docs)
+- #46 DAP epic; remaining sub-issues #51 (disasm/memory), #52 (evaluate), #53 (example configs + docs)
 - Post-DAP follow-ups: #59 Klaus 65C02, #60 BCD test, #61 CMOS e2e in CI, #62 peripheral snapshots, #63 VIA 6522, #64 trace replay, #65 mem-watch conditional expressions, #66 CoW RAM snapshots, #67 WebAssembly playground
 
 ---

--- a/internal/dap/breakpoints.go
+++ b/internal/dap/breakpoints.go
@@ -1,0 +1,178 @@
+package dap
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// handleSetBreakpoints replaces all source-line breakpoints for the named
+// source file. Per DAP semantics this is destructive against any prior
+// bps for the same source; bps in other sources are unaffected.
+//
+// Resolution walks the loaded source map (the .dbg file's PC -> file:line
+// table, reversed). Matching is on basename so editors that pass an
+// absolute project-root path resolve against a .dbg that records bare
+// filenames. A bp is reported `verified: false` when no PC matches.
+func (s *Server) handleSetBreakpoints(req Request) {
+	if s.cpu == nil {
+		s.sendErrorResponse(req, "no debuggee — send launch first")
+		return
+	}
+	var args SetBreakpointsArguments
+	if err := json.Unmarshal(req.Arguments, &args); err != nil {
+		s.sendErrorResponse(req, fmt.Sprintf("bad setBreakpoints args: %v", err))
+		return
+	}
+
+	srcKey := canonicalSourcePath(args.Source)
+	resolved := make(map[int]uint16)
+	results := make([]Breakpoint, 0, len(args.Breakpoints))
+	for _, bp := range args.Breakpoints {
+		pc, ok := s.lookupSourceLine(args.Source, bp.Line)
+		if !ok {
+			results = append(results, Breakpoint{
+				Verified: false,
+				Line:     bp.Line,
+				Message:  fmt.Sprintf("no PC for %s:%d", srcKey, bp.Line),
+			})
+			continue
+		}
+		resolved[bp.Line] = pc
+		results = append(results, Breakpoint{
+			Verified:                    true,
+			Line:                        bp.Line,
+			Source:                      &args.Source,
+			InstructionPointerReference: fmt.Sprintf("$%04X", pc),
+		})
+	}
+
+	s.bpMu.Lock()
+	if len(resolved) == 0 {
+		delete(s.bpsBySrc, srcKey)
+	} else {
+		s.bpsBySrc[srcKey] = resolved
+	}
+	s.rebuildBPHit()
+	s.bpMu.Unlock()
+
+	type body struct {
+		Breakpoints []Breakpoint `json:"breakpoints"`
+	}
+	s.sendResponse(req, body{Breakpoints: results})
+}
+
+// handleSetInstructionBreakpoints replaces all address breakpoints in one
+// call. The instructionReference field is parsed as a hex address — $XX,
+// 0xXX, or bare hex — matching parseDAPNumber's grammar.
+func (s *Server) handleSetInstructionBreakpoints(req Request) {
+	if s.cpu == nil {
+		s.sendErrorResponse(req, "no debuggee — send launch first")
+		return
+	}
+	var args SetInstructionBreakpointsArguments
+	if err := json.Unmarshal(req.Arguments, &args); err != nil {
+		s.sendErrorResponse(req, fmt.Sprintf("bad setInstructionBreakpoints args: %v", err))
+		return
+	}
+
+	newInst := map[uint16]bool{}
+	results := make([]Breakpoint, 0, len(args.Breakpoints))
+	for _, bp := range args.Breakpoints {
+		n, err := parseDAPNumber(bp.InstructionReference)
+		if err != nil {
+			results = append(results, Breakpoint{
+				Verified: false,
+				Message:  fmt.Sprintf("bad instructionReference %q: %v", bp.InstructionReference, err),
+			})
+			continue
+		}
+		pc := uint16(int(n) + bp.Offset)
+		newInst[pc] = true
+		results = append(results, Breakpoint{
+			Verified:                    true,
+			InstructionPointerReference: fmt.Sprintf("$%04X", pc),
+		})
+	}
+
+	s.bpMu.Lock()
+	s.bpsInst = newInst
+	s.rebuildBPHit()
+	s.bpMu.Unlock()
+
+	type body struct {
+		Breakpoints []Breakpoint `json:"breakpoints"`
+	}
+	s.sendResponse(req, body{Breakpoints: results})
+}
+
+// rebuildBPHit flattens bpsBySrc + bpsInst into the single PC set the run
+// loop checks. Call under bpMu.
+func (s *Server) rebuildBPHit() {
+	hit := make(map[uint16]bool, len(s.bpsInst))
+	for pc := range s.bpsInst {
+		hit[pc] = true
+	}
+	for _, lineMap := range s.bpsBySrc {
+		for _, pc := range lineMap {
+			hit[pc] = true
+		}
+	}
+	s.bpHit = hit
+}
+
+// isBreakpoint reports whether pc has a breakpoint pending. Run loop hot
+// path; takes bpMu only long enough to read the map.
+func (s *Server) isBreakpoint(pc uint16) bool {
+	s.bpMu.Lock()
+	defer s.bpMu.Unlock()
+	return s.bpHit[pc]
+}
+
+// lookupSourceLine maps (source, line) -> PC using the loaded .dbg source
+// map. Returns (0, false) when the source map is absent or the line has
+// no recorded PC.
+func (s *Server) lookupSourceLine(src Source, line int) (uint16, bool) {
+	if s.srcMap == nil {
+		return 0, false
+	}
+	want := canonicalSourcePath(src)
+	for pc, loc := range s.srcMap.PCToSrc {
+		if loc.Line != line {
+			continue
+		}
+		if matchesSource(loc.File, src.Path, want) {
+			return pc, true
+		}
+	}
+	return 0, false
+}
+
+// canonicalSourcePath returns the form we key bpsBySrc under. Prefer the
+// full path when the client sent one; otherwise fall back to the name.
+func canonicalSourcePath(src Source) string {
+	if src.Path != "" {
+		return src.Path
+	}
+	return src.Name
+}
+
+// matchesSource decides whether a .dbg-recorded file equals the source
+// the client is asking about. We're permissive: equal path, equal
+// basename, or basename of the .dbg entry matches the canonical key.
+func matchesSource(dbgFile, clientPath, canonicalKey string) bool {
+	if dbgFile == clientPath {
+		return true
+	}
+	if filepath.Base(dbgFile) == filepath.Base(clientPath) {
+		return true
+	}
+	if filepath.Base(dbgFile) == filepath.Base(canonicalKey) {
+		return true
+	}
+	if strings.EqualFold(filepath.Base(dbgFile), filepath.Base(clientPath)) {
+		return true
+	}
+	return false
+}

--- a/internal/dap/breakpoints_test.go
+++ b/internal/dap/breakpoints_test.go
@@ -1,0 +1,192 @@
+package dap
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/nkane/chippy/internal/symbols"
+)
+
+func TestBP_SetInstructionBreakpoints(t *testing.T) {
+	s, _, out := newStoppedServer(t, []byte{0xEA, 0xEA, 0xEA})
+
+	req := Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "setInstructionBreakpoints",
+		Arguments:       json.RawMessage(`{"breakpoints":[{"instructionReference":"$8002"}]}`),
+	}
+	s.handleSetInstructionBreakpoints(req)
+
+	if !strings.Contains(out.String(), `"verified":true`) {
+		t.Fatalf("expected verified=true, got: %s", out.String())
+	}
+	if !s.isBreakpoint(0x8002) {
+		t.Fatalf("isBreakpoint($8002) should be true after set")
+	}
+}
+
+func TestBP_SetInstructionBreakpointsReplacesAll(t *testing.T) {
+	s, _, _ := newStoppedServer(t, []byte{0xEA})
+	first := Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "setInstructionBreakpoints",
+		Arguments:       json.RawMessage(`{"breakpoints":[{"instructionReference":"$8002"},{"instructionReference":"$8004"}]}`),
+	}
+	s.handleSetInstructionBreakpoints(first)
+	if !s.isBreakpoint(0x8002) || !s.isBreakpoint(0x8004) {
+		t.Fatalf("first set should install both bps")
+	}
+	second := Request{
+		ProtocolMessage: ProtocolMessage{Seq: 2, Type: "request"},
+		Command:         "setInstructionBreakpoints",
+		Arguments:       json.RawMessage(`{"breakpoints":[{"instructionReference":"$9000"}]}`),
+	}
+	s.handleSetInstructionBreakpoints(second)
+	if s.isBreakpoint(0x8002) || s.isBreakpoint(0x8004) {
+		t.Fatalf("second set should clear prior instruction bps")
+	}
+	if !s.isBreakpoint(0x9000) {
+		t.Fatalf("second set should install $9000")
+	}
+}
+
+func TestBP_RunStopsOnBreakpoint(t *testing.T) {
+	// LDA #$00 ; LDA #$11 ; JMP $8000 — non-degenerate loop.
+	s, _, _ := newStoppedServer(t, []byte{0xA9, 0x00, 0xA9, 0x11, 0x4C, 0x00, 0x80})
+	// Breakpoint at $8002 (the second LDA).
+	s.handleSetInstructionBreakpoints(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "setInstructionBreakpoints",
+		Arguments:       json.RawMessage(`{"breakpoints":[{"instructionReference":"$8002"}]}`),
+	})
+
+	s.handleContinue(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 2, Type: "request"},
+		Command:         "continue",
+	})
+
+	<-s.runDone
+	if s.cpu.PC != 0x8002 {
+		t.Fatalf("run should stop with PC=$8002, got $%04X", s.cpu.PC)
+	}
+}
+
+func TestBP_SourceLineResolvesViaSrcMap(t *testing.T) {
+	// Build a tiny fake source map: $8002 -> main.s:5.
+	s, _, out := newStoppedServer(t, []byte{0xEA, 0xEA, 0xEA})
+	s.srcMap = &symbols.SourceMap{
+		PCToSrc: map[uint16]symbols.SrcLoc{
+			0x8002: {File: "main.s", Line: 5},
+		},
+		Files: map[string][]string{"main.s": {"line1", "line2", "line3", "line4", "line5"}},
+	}
+
+	req := Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "setBreakpoints",
+		Arguments: json.RawMessage(`{
+			"source":{"name":"main.s","path":"main.s"},
+			"breakpoints":[{"line":5}]
+		}`),
+	}
+	s.handleSetBreakpoints(req)
+
+	body := out.String()
+	if !strings.Contains(body, `"verified":true`) {
+		t.Fatalf("expected verified=true, got: %s", body)
+	}
+	if !strings.Contains(body, `"$8002"`) {
+		t.Fatalf("expected resolved IP=$8002, got: %s", body)
+	}
+	if !s.isBreakpoint(0x8002) {
+		t.Fatalf("bp set should activate $8002")
+	}
+}
+
+func TestBP_SourceLineUnresolved(t *testing.T) {
+	s, _, out := newStoppedServer(t, []byte{0xEA})
+	s.srcMap = &symbols.SourceMap{
+		PCToSrc: map[uint16]symbols.SrcLoc{},
+	}
+	req := Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "setBreakpoints",
+		Arguments: json.RawMessage(`{
+			"source":{"name":"main.s","path":"main.s"},
+			"breakpoints":[{"line":99}]
+		}`),
+	}
+	s.handleSetBreakpoints(req)
+	if !strings.Contains(out.String(), `"verified":false`) {
+		t.Fatalf("unresolved bp should report verified=false, got: %s", out.String())
+	}
+}
+
+func TestBP_SetBreakpointsReplacesAllForSource(t *testing.T) {
+	s, _, _ := newStoppedServer(t, []byte{0xEA})
+	s.srcMap = &symbols.SourceMap{
+		PCToSrc: map[uint16]symbols.SrcLoc{
+			0x8001: {File: "a.s", Line: 1},
+			0x8002: {File: "a.s", Line: 2},
+			0x8003: {File: "b.s", Line: 1},
+		},
+	}
+
+	// Two bps in a.s.
+	s.handleSetBreakpoints(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "setBreakpoints",
+		Arguments: json.RawMessage(`{
+			"source":{"name":"a.s","path":"a.s"},
+			"breakpoints":[{"line":1},{"line":2}]
+		}`),
+	})
+	// One bp in b.s.
+	s.handleSetBreakpoints(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 2, Type: "request"},
+		Command:         "setBreakpoints",
+		Arguments: json.RawMessage(`{
+			"source":{"name":"b.s","path":"b.s"},
+			"breakpoints":[{"line":1}]
+		}`),
+	})
+	if !s.isBreakpoint(0x8001) || !s.isBreakpoint(0x8002) || !s.isBreakpoint(0x8003) {
+		t.Fatalf("after independent sources are set, all bps should be live")
+	}
+
+	// Replace a.s with a single bp at line 2 only — a.s:1 should drop.
+	s.handleSetBreakpoints(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 3, Type: "request"},
+		Command:         "setBreakpoints",
+		Arguments: json.RawMessage(`{
+			"source":{"name":"a.s","path":"a.s"},
+			"breakpoints":[{"line":2}]
+		}`),
+	})
+	if s.isBreakpoint(0x8001) {
+		t.Fatalf("a.s:1 should have been cleared")
+	}
+	if !s.isBreakpoint(0x8002) {
+		t.Fatalf("a.s:2 should still be set")
+	}
+	if !s.isBreakpoint(0x8003) {
+		t.Fatalf("b.s bp should be unaffected by a.s rewrite")
+	}
+
+	// Empty breakpoints array for a.s -> all a.s bps drop.
+	s.handleSetBreakpoints(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 4, Type: "request"},
+		Command:         "setBreakpoints",
+		Arguments: json.RawMessage(`{
+			"source":{"name":"a.s","path":"a.s"},
+			"breakpoints":[]
+		}`),
+	})
+	if s.isBreakpoint(0x8002) {
+		t.Fatalf("empty a.s set should clear $8002")
+	}
+	if !s.isBreakpoint(0x8003) {
+		t.Fatalf("b.s bp should still be set")
+	}
+}

--- a/internal/dap/protocol.go
+++ b/internal/dap/protocol.go
@@ -176,3 +176,46 @@ type SetVariableArguments struct {
 	Name               string `json:"name"`
 	Value              string `json:"value"`
 }
+
+// SourceBreakpoint is one entry in a `setBreakpoints` request body.
+type SourceBreakpoint struct {
+	Line         int    `json:"line"`
+	Column       int    `json:"column,omitempty"`
+	Condition    string `json:"condition,omitempty"`
+	HitCondition string `json:"hitCondition,omitempty"`
+	LogMessage   string `json:"logMessage,omitempty"`
+}
+
+// SetBreakpointsArguments — replace ALL source-line breakpoints for the
+// given source. Each call is destructive against prior bps for the same
+// path; bps in other sources are unaffected.
+type SetBreakpointsArguments struct {
+	Source      Source             `json:"source"`
+	Breakpoints []SourceBreakpoint `json:"breakpoints"`
+}
+
+// InstructionBreakpoint is one entry in a `setInstructionBreakpoints`
+// request body. InstructionReference is typically the hex address string
+// `stackTrace` returned for a frame's IP.
+type InstructionBreakpoint struct {
+	InstructionReference string `json:"instructionReference"`
+	Offset               int    `json:"offset,omitempty"`
+	Condition            string `json:"condition,omitempty"`
+	HitCondition         string `json:"hitCondition,omitempty"`
+}
+
+// SetInstructionBreakpointsArguments — replace ALL address breakpoints.
+type SetInstructionBreakpointsArguments struct {
+	Breakpoints []InstructionBreakpoint `json:"breakpoints"`
+}
+
+// Breakpoint is what `setBreakpoints` / `setInstructionBreakpoints`
+// return: per-entry resolution status plus the resolved location.
+type Breakpoint struct {
+	ID                          int     `json:"id,omitempty"`
+	Verified                    bool    `json:"verified"`
+	Message                     string  `json:"message,omitempty"`
+	Source                      *Source `json:"source,omitempty"`
+	Line                        int     `json:"line,omitempty"`
+	InstructionPointerReference string  `json:"instructionPointerReference,omitempty"`
+}

--- a/internal/dap/server.go
+++ b/internal/dap/server.go
@@ -53,6 +53,16 @@ type Server struct {
 	running        atomic.Bool
 	pauseRequested atomic.Bool
 	runDone        chan struct{}
+
+	// Breakpoint state. bpsBySrc maps source path -> line -> resolved PC;
+	// bpsInst is the address-breakpoint set. bpHit is the flattened
+	// PC-set the run loop checks each iteration (recomputed on every
+	// set request). All three are guarded by bpMu since setBreakpoints
+	// may arrive while the run loop is reading bpHit.
+	bpMu     sync.Mutex
+	bpsBySrc map[string]map[int]uint16
+	bpsInst  map[uint16]bool
+	bpHit    map[uint16]bool
 }
 
 // NewServer wires the transport to a fresh Server. r/w must point at the
@@ -60,8 +70,11 @@ type Server struct {
 // in tcp mode.
 func NewServer(r io.Reader, w io.Writer) *Server {
 	return &Server{
-		in:  bufio.NewReader(r),
-		out: w,
+		in:       bufio.NewReader(r),
+		out:      w,
+		bpsBySrc: map[string]map[int]uint16{},
+		bpsInst:  map[uint16]bool{},
+		bpHit:    map[uint16]bool{},
 	}
 }
 
@@ -127,6 +140,10 @@ func (s *Server) dispatch(req Request) {
 		s.handleVariables(req)
 	case "setVariable":
 		s.handleSetVariable(req)
+	case "setBreakpoints":
+		s.handleSetBreakpoints(req)
+	case "setInstructionBreakpoints":
+		s.handleSetInstructionBreakpoints(req)
 	case "disconnect":
 		s.handleDisconnect(req)
 	case "terminate":

--- a/internal/dap/steps.go
+++ b/internal/dap/steps.go
@@ -53,11 +53,13 @@ func (s *Server) handleContinue(req Request) {
 	go s.runLoop()
 }
 
-// runLoop free-runs the CPU until pauseRequested is set or the CPU halts.
-// Emits the `stopped` event before signaling runDone. Single goroutine —
-// safe to mutate cpu state without locks because no other handler runs
-// while running=true (single-step handlers refuse, and disconnect waits
-// for runDone).
+// runLoop free-runs the CPU until pauseRequested is set, the CPU halts,
+// or PC lands on a breakpoint. Emits the `stopped` event before
+// signaling runDone. Single goroutine — safe to mutate cpu state
+// without locks because no other handler runs while running=true
+// (single-step handlers refuse, and disconnect waits for runDone).
+// Breakpoint reads are guarded by bpMu inside isBreakpoint so concurrent
+// setBreakpoints requests stay safe.
 func (s *Server) runLoop() {
 	defer func() {
 		s.running.Store(false)
@@ -72,6 +74,10 @@ func (s *Server) runLoop() {
 		s.cpu.Step()
 		if s.cpu.Halted {
 			reason = "exception"
+			break
+		}
+		if s.isBreakpoint(s.cpu.PC) {
+			reason = "breakpoint"
 			break
 		}
 	}


### PR DESCRIPTION
Closes #49.

## Summary
- `setBreakpoints` — replaces all source-line bps for the given source. Resolution via the loaded `.dbg` (`srcMap.PCToSrc` reverse lookup). Matching is path-or-basename-tolerant so editors sending absolute paths resolve against .dbgs with bare filenames.
- `setInstructionBreakpoints` — replaces all address bps. Accepts `$XX`, `0xXX`, decimal, or bare hex via the shared `parseDAPNumber`. Honors per-bp `offset`.
- Run loop checks the flattened `bpHit` set at each step and emits `stopped` with `reason=\"breakpoint\"` on hit.
- `bpMu` guards bp state — concurrent setBreakpoints calls + run-loop reads are race-free.

## Test plan
- [x] `go build ./...` — green.
- [x] `go test -race ./...` — 6 new tests cover address bp set, address bp set-replaces-all, run-stops-on-bp (end-to-end with continue+breakpoint hit), source-line resolves via srcMap, source-line unresolved -> verified=false, setBreakpoints replaces per-source while leaving other sources alone.
- [x] `golangci-lint run` — 0 issues.

## Docs
- docs/context.md: #49 moves to Merged-PRs-of-note; remaining DAP backlog refreshed.