### PR TITLE
docs(dap): VS Code + nvim-dap configs + walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Flags:
 | `--cpu`  | `nmos`  | CPU variant: `nmos` (MOS 6502) or `65c02` (WDC/Rockwell CMOS) |
 | `-trace` | —       | Write per-instruction execution trace to this file. Also toggleable at runtime via `:trace PATH \| :trace on \| :trace off`. |
 | `-run-on-start` | `false` | Start the CPU running instead of paused. Pair with `-trace` for non-interactive capture (`chippy -rom prog.bin -trace t.log -run-on-start`). |
-| `-dap`  | —       | Run as a [Debug Adapter Protocol](https://microsoft.github.io/debug-adapter-protocol/) server instead of the TUI. Accepts `stdio` (editor pipes stdin/stdout) or `tcp:PORT` (server listens, editor connects out). Supported requests grow incrementally — see issue #46 epic. |
+| `-dap`  | —       | Run as a [Debug Adapter Protocol](https://microsoft.github.io/debug-adapter-protocol/) server instead of the TUI. Accepts `stdio` (editor pipes stdin/stdout) or `tcp:PORT` (server listens, editor connects out). See [`docs/dap.md`](docs/dap.md) for the request list, supported launch arguments, and VS Code / nvim-dap onboarding. |
 
 Examples:
 

--- a/docs/context.md
+++ b/docs/context.md
@@ -157,10 +157,10 @@ Bus chain: `CPU → tui.WBus → cpu.MMIO → cpu.RAM`
 - DAP breakpoints (issue #49): `setBreakpoints` (source-line, resolved via `srcMap.PCToSrc` reverse-lookup) and `setInstructionBreakpoints` (address). Both are destructive against their respective namespace per DAP spec. Run loop checks `bpHit` (flattened union) at each Step and emits `stopped` with reason=breakpoint.
 - DAP disassemble / readMemory / writeMemory (issue #51): `disassemble` routes through `cpu.DisasmCPU` (variant-aware), reports `address`, `instructionBytes`, `instruction`, `symbol`, `location`/`line`; `readMemory`/`writeMemory` bypass MMIO so peripheral side-effects don't fire on debugger pokes. Base64 envelope per spec.
 - DAP evaluate (issue #52): `evaluate` request compiles + runs the same expression grammar used by `:bp X if E`. Expression compiler moved from `internal/tui/cond.go` to a new `internal/expr` package so DAP and TUI share semantics (`expr.Compile`, `expr.EvalFn`); `tui.compileCondition` is now a thin wrapper.
+- DAP example configs + onboarding docs (issue #53): `docs/dap.md` walkthrough, `examples/dap/launch.json` (VS Code) and `examples/dap/nvim-dap.lua` (nvim-dap). DAP epic complete.
 
 ### Open issues
 - #22 (homebrew-core) — blocked on stars
-- #46 DAP epic; remaining sub-issue #53 (example configs + docs)
 - Post-DAP follow-ups: #59 Klaus 65C02, #60 BCD test, #61 CMOS e2e in CI, #62 peripheral snapshots, #63 VIA 6522, #64 trace replay, #65 mem-watch conditional expressions, #66 CoW RAM snapshots, #67 WebAssembly playground
 
 ---

--- a/docs/dap.md
+++ b/docs/dap.md
@@ -1,0 +1,120 @@
+# Debugging chippy programs from your editor
+
+`chippy` ships with a [Debug Adapter Protocol](https://microsoft.github.io/debug-adapter-protocol/)
+server so any DAP-aware editor can drive the emulator. The TUI is still
+the default; DAP mode is a separate process you start with the `-dap`
+flag.
+
+## Launching the adapter
+
+Two transports:
+
+```sh
+# stdio — editor spawns the binary and pipes stdin/stdout.
+# Used by VS Code's default DebugAdapterExecutable.
+chippy -dap stdio
+
+# TCP — adapter listens, editor connects out.
+# Used by nvim-dap's default `executable` block.
+chippy -dap tcp:14785
+```
+
+`-dap` is mutually exclusive with the TUI: when set, chippy never opens
+the alt-screen and instead speaks JSON-RPC over the chosen channel.
+
+## VS Code
+
+Copy `examples/dap/launch.json` into your project's `.vscode/launch.json`
+and adjust paths. The launch config maps 1:1 to the CLI flags:
+
+```jsonc
+{
+  "type": "chippy",
+  "request": "launch",
+  "name": "Run chippy",
+  "rom": "${workspaceFolder}/build/program.bin",
+  "cpuVariant": "65c02",
+  "dbgPath": "${workspaceFolder}/build/program.dbg",
+  "stopOnEntry": true
+}
+```
+
+`stopOnEntry` defaults to true so the debugger pauses at the reset
+vector. Press F5 again (or **Continue**) to start running.
+
+## nvim-dap
+
+Copy `examples/dap/nvim-dap.lua` into your config. It registers the
+`chippy` adapter (TCP transport on 14785) and a default configuration
+that launches a program from `cwd/build/program.bin`.
+
+```lua
+require("dap").adapters.chippy = {
+  type = "server",
+  port = 14785,
+  executable = { command = "chippy", args = { "-dap", "tcp:14785" } },
+}
+```
+
+`<F5>` to launch, `<F10>` step over, `<F11>` step into,
+`<Shift-F11>` step out.
+
+## Supported requests
+
+| Request                          | Issue | Notes |
+|----------------------------------|-------|-------|
+| `initialize`                     | #47   | Negotiates capabilities; reports the full subset below in one shot. |
+| `launch`                         | #47   | Takes `rom`, `loadAddr`, `resetVec`, `linkerCfg`, `dbgPath`, `cpuVariant`, `tracePath`, `stopOnEntry`. |
+| `attach`                         | —     | Not supported. Returns an error. |
+| `disconnect` / `terminate`       | #47   | Tears down the run goroutine, closes the trace file, exits. |
+| `continue` / `pause`             | #50   | Continue spawns a CPU run goroutine; pause flips a signal. |
+| `next` / `stepIn` / `stepOut`    | #50   | Step-over runs to PC+3 past a JSR; step-out runs until SP rises. |
+| `threads`                        | #50   | One virtual thread (`id=1`, name=`cpu`). |
+| `stackTrace`                     | #48   | Walks JSR frames via `cpu.DetectStackFrame`. |
+| `scopes`                         | #48   | Two scopes per frame: Registers, Flags. |
+| `variables`                      | #48   | ref=1 → A/X/Y/SP/PC/P/Cycles; ref=2 → 8 P-flag bits. |
+| `setVariable`                    | #48   | Writes hex / decimal to a register or flag bit. |
+| `setBreakpoints`                 | #49   | Source-line bps resolved through the `.dbg` source map. |
+| `setInstructionBreakpoints`      | #49   | Address bps (`$XX`, `0xXX`, decimal). |
+| `disassemble`                    | #51   | Variant-aware via `cpu.DisasmCPU`. |
+| `readMemory` / `writeMemory`     | #51   | Bypasses MMIO — peripherals don't see debugger pokes. |
+| `evaluate`                       | #52   | Watch / hover / debug-console expressions via `internal/expr`. |
+
+## Known gaps
+
+- `stepBack` is unsupported in DAP. The TUI's `<` rewind ring (#54)
+  isn't yet wired to the adapter; reverse-step over DAP is filed as a
+  follow-up.
+- `attach` is unsupported — only `launch` boots a fresh debuggee.
+- `disassemble` clamps negative `instructionOffset` to 0; backward
+  walks would need the TUI's `walkBack` heuristic.
+- Peripherals aren't snapshotted by reverse-step (see #62).
+- The DAP server is a single session per process. To debug two ROMs
+  at once, run two `chippy -dap` instances on different ports.
+
+## Expression grammar (`evaluate`, conditional breakpoints)
+
+Same compiler as the TUI:
+
+```
+A == $42
+X > 10 && Y != 0
+(A & $80) != 0
+[$0042] == X
+C && !Z
+PC >= main
+```
+
+See `internal/expr/expr.go` for the full operator table.
+
+## Troubleshooting
+
+- **No output from a trace launched via DAP.** Same as the TUI: pass
+  `"tracePath"` AND set `"stopOnEntry": false` (or send `continue`
+  after launch). The CPU doesn't auto-run on launch.
+- **`launch` returns `launch requires a 'rom' argument`.** Your config
+  is missing the `rom` field. Path can be absolute or relative to the
+  cwd of the chippy process.
+- **Breakpoints come back `verified: false`.** The .dbg source map
+  doesn't cover the requested (file, line). Confirm `dbgPath` resolves
+  and that the file matches a `sym` entry's `file=` field in the .dbg.

--- a/examples/dap/launch.json
+++ b/examples/dap/launch.json
@@ -1,0 +1,31 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "chippy",
+      "request": "launch",
+      "name": "Run chippy (NMOS)",
+      "rom": "${workspaceFolder}/build/program.bin",
+      "cpuVariant": "nmos",
+      "dbgPath": "${workspaceFolder}/build/program.dbg",
+      "stopOnEntry": true
+    },
+    {
+      "type": "chippy",
+      "request": "launch",
+      "name": "Run chippy (CMOS 65C02)",
+      "rom": "${workspaceFolder}/build/program.bin",
+      "cpuVariant": "65c02",
+      "dbgPath": "${workspaceFolder}/build/program.dbg",
+      "stopOnEntry": true
+    },
+    {
+      "type": "chippy",
+      "request": "launch",
+      "name": "Run chippy + trace capture",
+      "rom": "${workspaceFolder}/build/program.bin",
+      "tracePath": "${workspaceFolder}/build/trace.log",
+      "stopOnEntry": false
+    }
+  ]
+}

--- a/examples/dap/nvim-dap.lua
+++ b/examples/dap/nvim-dap.lua
@@ -1,0 +1,53 @@
+-- nvim-dap adapter + sample configuration for chippy.
+--
+-- Drop this into your nvim config (e.g. ~/.config/nvim/lua/dap-chippy.lua)
+-- and `require("dap-chippy")` somewhere your dap setup runs. Adjust the
+-- `command` if `chippy` isn't on $PATH.
+
+local dap = require("dap")
+
+dap.adapters.chippy = {
+  type = "server",
+  port = "${port}",
+  executable = {
+    command = "chippy",
+    args = { "-dap", "tcp:${port}" },
+  },
+}
+
+dap.configurations["asm_ca65"] = {
+  {
+    type = "chippy",
+    request = "launch",
+    name = "Run chippy (NMOS)",
+    rom = "${workspaceFolder}/build/program.bin",
+    cpuVariant = "nmos",
+    dbgPath = "${workspaceFolder}/build/program.dbg",
+    stopOnEntry = true,
+  },
+  {
+    type = "chippy",
+    request = "launch",
+    name = "Run chippy (CMOS 65C02)",
+    rom = "${workspaceFolder}/build/program.bin",
+    cpuVariant = "65c02",
+    dbgPath = "${workspaceFolder}/build/program.dbg",
+    stopOnEntry = true,
+  },
+}
+
+-- ca65 source files are typically `.s` with no dedicated filetype. Map them
+-- onto the chippy configurations under whichever filetype your editor
+-- assigns. The block below is conservative — drop or extend to taste.
+dap.configurations.asm = dap.configurations["asm_ca65"]
+dap.configurations.ca65 = dap.configurations["asm_ca65"]
+
+-- Suggested keymaps (no leader required so they work in any setup).
+-- Drop these into your own keybinding init if you don't want them
+-- defined globally.
+local map = vim.keymap.set
+map("n", "<F5>", function() dap.continue() end, { desc = "DAP continue" })
+map("n", "<F10>", function() dap.step_over() end, { desc = "DAP step over" })
+map("n", "<F11>", function() dap.step_into() end, { desc = "DAP step into" })
+map("n", "<S-F11>", function() dap.step_out() end, { desc = "DAP step out" })
+map("n", "<F9>", function() dap.toggle_breakpoint() end, { desc = "DAP toggle bp" })


### PR DESCRIPTION
Closes #53. Also closes the #46 DAP epic — every sub-issue is now merged.

## Summary
- `docs/dap.md` — transports, capability matrix (one row per request, linked back to its merging issue), known gaps, expression grammar quick-reference, troubleshooting.
- `examples/dap/launch.json` — three VS Code configs: NMOS launch, CMOS launch, trace-capture run with `stopOnEntry: false`.
- `examples/dap/nvim-dap.lua` — adapter block (TCP transport with auto-port), default launch configs, suggested F5/F10/F11/Shift-F11 keymaps.
- README flag-table cell points at `docs/dap.md`.

## DAP epic recap (#46)
| Sub | PR | Lands |
|-----|----|-------|
| #47 | #69 | Transport + initialize + launch + disconnect |
| #50 | #72 | continue / next / stepIn / stepOut / pause + threads |
| #48 | #73 | stackTrace / scopes / variables / setVariable |
| #49 | #74 | setBreakpoints + setInstructionBreakpoints |
| #51 | #75 | disassemble + readMemory + writeMemory |
| #52 | #76 | evaluate (via shared internal/expr) |
| #53 | this | Example configs + onboarding docs |

## Test plan
- [x] `go build ./...` — green (docs-only diff).
- [x] `go test -race ./...` — full suite still passes.
- [x] `golangci-lint run` — 0 issues.
- [ ] Manual: drop launch.json into a ca65 project's `.vscode/` and verify hit-a-breakpoint flow. (Skipped because v1's editor pieces are example-only — VS Code needs a published extension to teach it the `chippy` type; that's a separate distribution task.)