### PR TITLE
feat(dap): setFunctionBreakpoints

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -160,6 +160,7 @@ Bus chain: `CPU → tui.WBus → cpu.MMIO → cpu.RAM`
 - DAP example configs + onboarding docs (issue #53): `docs/dap.md` walkthrough, `examples/dap/launch.json` (VS Code) and `examples/dap/nvim-dap.lua` (nvim-dap). DAP-v1 epic complete.
 - v0.2.0 — release cut after #77 / DAP-v1 epic.
 - DAP stepBack (issue #79, first of #78 DAP-v2 epic): wires the rewind ring into DAP. Snapshot ring promoted from `internal/tui` to `internal/cpu` as `cpu.SnapshotRing` so both the TUI's `<` key and DAP's stepBack share storage. `supportsStepBack: true`.
+- DAP setFunctionBreakpoints (issue #82, DAP-v2): symbol-name bps via `syms.LookupName`. New `bpsByName` map joins `bpsBySrc` and `bpsInst` in `rebuildBPHit`'s union. `supportsFunctionBreakpoints: true`.
 
 ### Open issues
 - #22 (homebrew-core) — blocked on stars

--- a/docs/dap.md
+++ b/docs/dap.md
@@ -77,6 +77,7 @@ require("dap").adapters.chippy = {
 | `setVariable`                    | #48   | Writes hex / decimal to a register or flag bit. |
 | `setBreakpoints`                 | #49   | Source-line bps resolved through the `.dbg` source map. |
 | `setInstructionBreakpoints`      | #49   | Address bps (`$XX`, `0xXX`, decimal). |
+| `setFunctionBreakpoints`         | #82   | Symbol-name bps via `syms.LookupName`. Unknown names report `verified: false`. |
 | `disassemble`                    | #51   | Variant-aware via `cpu.DisasmCPU`. |
 | `readMemory` / `writeMemory`     | #51   | Bypasses MMIO — peripherals don't see debugger pokes. |
 | `evaluate`                       | #52   | Watch / hover / debug-console expressions via `internal/expr`. |

--- a/internal/dap/breakpoints.go
+++ b/internal/dap/breakpoints.go
@@ -107,8 +107,8 @@ func (s *Server) handleSetInstructionBreakpoints(req Request) {
 	s.sendResponse(req, body{Breakpoints: results})
 }
 
-// rebuildBPHit flattens bpsBySrc + bpsInst into the single PC set the run
-// loop checks. Call under bpMu.
+// rebuildBPHit flattens bpsBySrc + bpsInst + bpsByName into the single PC
+// set the run loop checks. Call under bpMu.
 func (s *Server) rebuildBPHit() {
 	hit := make(map[uint16]bool, len(s.bpsInst))
 	for pc := range s.bpsInst {
@@ -119,7 +119,60 @@ func (s *Server) rebuildBPHit() {
 			hit[pc] = true
 		}
 	}
+	for _, pc := range s.bpsByName {
+		hit[pc] = true
+	}
 	s.bpHit = hit
+}
+
+// handleSetFunctionBreakpoints replaces all symbol-name breakpoints in
+// one call. Each entry resolves through the loaded .dbg symbol table —
+// unresolved names report verified=false with a descriptive message.
+func (s *Server) handleSetFunctionBreakpoints(req Request) {
+	if s.cpu == nil {
+		s.sendErrorResponse(req, "no debuggee — send launch first")
+		return
+	}
+	var args SetFunctionBreakpointsArguments
+	if err := json.Unmarshal(req.Arguments, &args); err != nil {
+		s.sendErrorResponse(req, fmt.Sprintf("bad setFunctionBreakpoints args: %v", err))
+		return
+	}
+
+	newByName := map[string]uint16{}
+	results := make([]Breakpoint, 0, len(args.Breakpoints))
+	for _, bp := range args.Breakpoints {
+		if s.syms == nil {
+			results = append(results, Breakpoint{
+				Verified: false,
+				Message:  "no symbol table loaded (-dbg / dbgPath not set)",
+			})
+			continue
+		}
+		addr, ok := s.syms.LookupName(bp.Name)
+		if !ok {
+			results = append(results, Breakpoint{
+				Verified: false,
+				Message:  fmt.Sprintf("unknown symbol: %s", bp.Name),
+			})
+			continue
+		}
+		newByName[bp.Name] = addr
+		results = append(results, Breakpoint{
+			Verified:                    true,
+			InstructionPointerReference: fmt.Sprintf("$%04X", addr),
+		})
+	}
+
+	s.bpMu.Lock()
+	s.bpsByName = newByName
+	s.rebuildBPHit()
+	s.bpMu.Unlock()
+
+	type body struct {
+		Breakpoints []Breakpoint `json:"breakpoints"`
+	}
+	s.sendResponse(req, body{Breakpoints: results})
 }
 
 // isBreakpoint reports whether pc has a breakpoint pending. Run loop hot

--- a/internal/dap/funcbp_test.go
+++ b/internal/dap/funcbp_test.go
@@ -1,0 +1,163 @@
+package dap
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/nkane/chippy/internal/symbols"
+)
+
+// buildSyms writes a minimal cc65-style .dbg file and loads it. Same
+// pattern as the tui complete_test helper; duplicated here to keep
+// internal/dap free of cross-package test deps.
+func buildSyms(t *testing.T, nameAddr ...interface{}) *symbols.Table {
+	t.Helper()
+	if len(nameAddr)%2 != 0 {
+		t.Fatalf("buildSyms: odd number of name/addr args")
+	}
+	path := filepath.Join(t.TempDir(), "x.dbg")
+	var body []byte
+	for i := 0; i < len(nameAddr); i += 2 {
+		name := nameAddr[i].(string)
+		addr := nameAddr[i+1].(int)
+		body = append(body, fmt.Appendf(nil, "sym\tname=\"%s\",val=0x%04X\n", name, addr)...)
+	}
+	if err := os.WriteFile(path, body, 0o644); err != nil {
+		t.Fatalf("write dbg: %v", err)
+	}
+	tbl, err := symbols.LoadDbg(path)
+	if err != nil {
+		t.Fatalf("LoadDbg: %v", err)
+	}
+	return tbl
+}
+
+func TestFuncBP_ResolveAndSet(t *testing.T) {
+	s, _, out := newStoppedServer(t, []byte{0xEA})
+	s.syms = buildSyms(t, "main", 0x8042, "render", 0x9000)
+
+	req := Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "setFunctionBreakpoints",
+		Arguments:       json.RawMessage(`{"breakpoints":[{"name":"main"},{"name":"render"}]}`),
+	}
+	s.handleSetFunctionBreakpoints(req)
+
+	body := out.String()
+	if !strings.Contains(body, `"$8042"`) {
+		t.Fatalf("expected resolved IP $8042 in body:\n%s", body)
+	}
+	if !strings.Contains(body, `"$9000"`) {
+		t.Fatalf("expected resolved IP $9000 in body:\n%s", body)
+	}
+	if !s.isBreakpoint(0x8042) || !s.isBreakpoint(0x9000) {
+		t.Fatalf("after resolution, both PCs should be in bpHit")
+	}
+}
+
+func TestFuncBP_UnknownSymbolUnverified(t *testing.T) {
+	s, _, out := newStoppedServer(t, []byte{0xEA})
+	s.syms = buildSyms(t, "main", 0x8042)
+
+	req := Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "setFunctionBreakpoints",
+		Arguments:       json.RawMessage(`{"breakpoints":[{"name":"main"},{"name":"nope"}]}`),
+	}
+	s.handleSetFunctionBreakpoints(req)
+
+	body := out.String()
+	if !strings.Contains(body, `"verified":false`) {
+		t.Fatalf("unknown symbol should be verified=false, got: %s", body)
+	}
+	if !s.isBreakpoint(0x8042) {
+		t.Fatalf("known symbol should still resolve even when another in the set fails")
+	}
+}
+
+func TestFuncBP_NoSymsLoaded(t *testing.T) {
+	s, _, out := newStoppedServer(t, []byte{0xEA})
+	// s.syms intentionally nil — no .dbg loaded.
+
+	req := Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "setFunctionBreakpoints",
+		Arguments:       json.RawMessage(`{"breakpoints":[{"name":"main"}]}`),
+	}
+	s.handleSetFunctionBreakpoints(req)
+
+	body := out.String()
+	if !strings.Contains(body, `"verified":false`) {
+		t.Fatalf("no-syms-loaded should be verified=false, got: %s", body)
+	}
+	if !strings.Contains(body, "no symbol table loaded") {
+		t.Fatalf("error message should explain the cause, got: %s", body)
+	}
+}
+
+func TestFuncBP_ReplacesAllForCall(t *testing.T) {
+	s, _, _ := newStoppedServer(t, []byte{0xEA})
+	s.syms = buildSyms(t, "a", 0x8001, "b", 0x8002, "c", 0x8003)
+
+	first := Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "setFunctionBreakpoints",
+		Arguments:       json.RawMessage(`{"breakpoints":[{"name":"a"},{"name":"b"}]}`),
+	}
+	s.handleSetFunctionBreakpoints(first)
+	if !s.isBreakpoint(0x8001) || !s.isBreakpoint(0x8002) {
+		t.Fatalf("first set should install a and b")
+	}
+
+	// Replace with just c. a and b should drop.
+	second := Request{
+		ProtocolMessage: ProtocolMessage{Seq: 2, Type: "request"},
+		Command:         "setFunctionBreakpoints",
+		Arguments:       json.RawMessage(`{"breakpoints":[{"name":"c"}]}`),
+	}
+	s.handleSetFunctionBreakpoints(second)
+	if s.isBreakpoint(0x8001) || s.isBreakpoint(0x8002) {
+		t.Fatalf("second set should clear prior function bps")
+	}
+	if !s.isBreakpoint(0x8003) {
+		t.Fatalf("second set should install c")
+	}
+}
+
+func TestFuncBP_RunStopsAtFunction(t *testing.T) {
+	// LDA #$00 (2B) ; LDA #$11 (2B) ; JMP $8000 (3B) — sym `target` at $8002.
+	s, _, _ := newStoppedServer(t, []byte{0xA9, 0x00, 0xA9, 0x11, 0x4C, 0x00, 0x80})
+	s.syms = buildSyms(t, "target", 0x8002)
+
+	s.handleSetFunctionBreakpoints(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "setFunctionBreakpoints",
+		Arguments:       json.RawMessage(`{"breakpoints":[{"name":"target"}]}`),
+	})
+
+	s.handleContinue(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 2, Type: "request"},
+		Command:         "continue",
+	})
+	<-s.runDone
+
+	if s.cpu.PC != 0x8002 {
+		t.Fatalf("continue+function-bp: want stop at $8002, got $%04X", s.cpu.PC)
+	}
+}
+
+func TestFuncBP_CapabilityAdvertised(t *testing.T) {
+	s, _, out := newStoppedServer(t, nil)
+	s.handleInitialize(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "initialize",
+		Arguments:       json.RawMessage(`{"adapterID":"chippy"}`),
+	})
+	if !strings.Contains(out.String(), `"supportsFunctionBreakpoints":true`) {
+		t.Fatalf("initialize should advertise supportsFunctionBreakpoints:true, got: %s", out.String())
+	}
+}

--- a/internal/dap/protocol.go
+++ b/internal/dap/protocol.go
@@ -209,6 +209,19 @@ type SetInstructionBreakpointsArguments struct {
 	Breakpoints []InstructionBreakpoint `json:"breakpoints"`
 }
 
+// FunctionBreakpoint identifies a breakpoint by symbol name. Resolution
+// happens at set time via the loaded .dbg symbol table.
+type FunctionBreakpoint struct {
+	Name         string `json:"name"`
+	Condition    string `json:"condition,omitempty"`
+	HitCondition string `json:"hitCondition,omitempty"`
+}
+
+// SetFunctionBreakpointsArguments — replace ALL symbol-name breakpoints.
+type SetFunctionBreakpointsArguments struct {
+	Breakpoints []FunctionBreakpoint `json:"breakpoints"`
+}
+
 // Breakpoint is what `setBreakpoints` / `setInstructionBreakpoints`
 // return: per-entry resolution status plus the resolved location.
 type Breakpoint struct {

--- a/internal/dap/server.go
+++ b/internal/dap/server.go
@@ -59,10 +59,11 @@ type Server struct {
 	// PC-set the run loop checks each iteration (recomputed on every
 	// set request). All three are guarded by bpMu since setBreakpoints
 	// may arrive while the run loop is reading bpHit.
-	bpMu     sync.Mutex
-	bpsBySrc map[string]map[int]uint16
-	bpsInst  map[uint16]bool
-	bpHit    map[uint16]bool
+	bpMu      sync.Mutex
+	bpsBySrc  map[string]map[int]uint16
+	bpsInst   map[uint16]bool
+	bpsByName map[string]uint16
+	bpHit     map[uint16]bool
 
 	// Reverse-step ring. Populated on every explicit-step request
 	// (stepIn/next/stepOut) and on continue→bp stops. stepBack pops one
@@ -75,12 +76,13 @@ type Server struct {
 // in tcp mode.
 func NewServer(r io.Reader, w io.Writer) *Server {
 	return &Server{
-		in:       bufio.NewReader(r),
-		out:      w,
-		bpsBySrc: map[string]map[int]uint16{},
-		bpsInst:  map[uint16]bool{},
-		bpHit:    map[uint16]bool{},
-		rewind:   cpu.NewSnapshotRing(cpu.DefaultSnapshotRingCap),
+		in:        bufio.NewReader(r),
+		out:       w,
+		bpsBySrc:  map[string]map[int]uint16{},
+		bpsInst:   map[uint16]bool{},
+		bpsByName: map[string]uint16{},
+		bpHit:     map[uint16]bool{},
+		rewind:    cpu.NewSnapshotRing(cpu.DefaultSnapshotRingCap),
 	}
 }
 
@@ -152,6 +154,8 @@ func (s *Server) dispatch(req Request) {
 		s.handleSetBreakpoints(req)
 	case "setInstructionBreakpoints":
 		s.handleSetInstructionBreakpoints(req)
+	case "setFunctionBreakpoints":
+		s.handleSetFunctionBreakpoints(req)
 	case "disassemble":
 		s.handleDisassemble(req)
 	case "readMemory":
@@ -184,7 +188,7 @@ func (s *Server) handleInitialize(req Request) {
 		SupportsBreakpointLocationsRequest: true,
 		SupportsLoadedSourcesRequest:       false,
 		SupportsStepBack:                   true,
-		SupportsFunctionBreakpoints:        false,
+		SupportsFunctionBreakpoints:        true,
 		SupportsRestartRequest:             false,
 		SupportsCompletionsRequest:         false,
 		SupportsSetVariable:                true,


### PR DESCRIPTION
Closes #82. Part of #78 (DAP-v2 epic).

## Summary
- New `setFunctionBreakpoints` handler. Each entry's `name` resolves via `s.syms.LookupName`.
- New `bpsByName` map; `rebuildBPHit` unions over source-line + instruction + name maps.
- Unresolved names come back `verified: false` with a useful message (unknown symbol vs. no symbol table loaded). Known symbols return their resolved `$XXXX` instruction pointer reference.
- `supportsFunctionBreakpoints: true` advertised in initialize.

## Test plan
- [x] `go build ./...` — green.
- [x] `go test -race ./...` — 6 new tests: resolve and set, unknown symbol unverified, no-syms-loaded message, set replaces all prior name bps, run+continue stops at a resolved function bp, capability advertised.
- [x] `golangci-lint run` — 0 issues.

## Docs
- docs/dap.md: `setFunctionBreakpoints` row added.
- docs/context.md: #82 noted in Merged-PRs-of-note.