### PR TITLE
feat(dap): loadedSources + source content

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -161,6 +161,7 @@ Bus chain: `CPU → tui.WBus → cpu.MMIO → cpu.RAM`
 - v0.2.0 — release cut after #77 / DAP-v1 epic.
 - DAP stepBack (issue #79, first of #78 DAP-v2 epic): wires the rewind ring into DAP. Snapshot ring promoted from `internal/tui` to `internal/cpu` as `cpu.SnapshotRing` so both the TUI's `<` key and DAP's stepBack share storage. `supportsStepBack: true`.
 - DAP setFunctionBreakpoints (issue #82, DAP-v2): symbol-name bps via `syms.LookupName`. New `bpsByName` map joins `bpsBySrc` and `bpsInst` in `rebuildBPHit`'s union. `supportsFunctionBreakpoints: true`.
+- DAP loadedSources + source (issue #84, DAP-v2): editor's Loaded Scripts pane lists every file in `srcMap.Files`; the `source` request returns joined-line content with basename fallback for clients passing absolute paths. `supportsLoadedSourcesRequest: true`.
 
 ### Open issues
 - #22 (homebrew-core) — blocked on stars

--- a/docs/dap.md
+++ b/docs/dap.md
@@ -78,6 +78,8 @@ require("dap").adapters.chippy = {
 | `setBreakpoints`                 | #49   | Source-line bps resolved through the `.dbg` source map. |
 | `setInstructionBreakpoints`      | #49   | Address bps (`$XX`, `0xXX`, decimal). |
 | `setFunctionBreakpoints`         | #82   | Symbol-name bps via `syms.LookupName`. Unknown names report `verified: false`. |
+| `loadedSources`                  | #84   | Lists every file the loaded `.dbg` references. |
+| `source`                         | #84   | Returns file contents for a previously-listed Source. Basename-matches if the client passes an absolute path. |
 | `disassemble`                    | #51   | Variant-aware via `cpu.DisasmCPU`. |
 | `readMemory` / `writeMemory`     | #51   | Bypasses MMIO — peripherals don't see debugger pokes. |
 | `evaluate`                       | #52   | Watch / hover / debug-console expressions via `internal/expr`. |

--- a/internal/dap/protocol.go
+++ b/internal/dap/protocol.go
@@ -278,3 +278,10 @@ type EvaluateArguments struct {
 		Hex bool `json:"hex,omitempty"`
 	} `json:"format,omitempty"`
 }
+
+// SourceArguments is the request body for `source` — return file contents
+// for a previously-listed Source.
+type SourceArguments struct {
+	Source          Source `json:"source"`
+	SourceReference int    `json:"sourceReference,omitempty"`
+}

--- a/internal/dap/server.go
+++ b/internal/dap/server.go
@@ -164,6 +164,10 @@ func (s *Server) dispatch(req Request) {
 		s.handleWriteMemory(req)
 	case "evaluate":
 		s.handleEvaluate(req)
+	case "loadedSources":
+		s.handleLoadedSources(req)
+	case "source":
+		s.handleSource(req)
 	case "disconnect":
 		s.handleDisconnect(req)
 	case "terminate":
@@ -186,7 +190,7 @@ func (s *Server) handleInitialize(req Request) {
 		SupportsInstructionBreakpoints:     true,
 		SupportsLogPoints:                  true,
 		SupportsBreakpointLocationsRequest: true,
-		SupportsLoadedSourcesRequest:       false,
+		SupportsLoadedSourcesRequest:       true,
 		SupportsStepBack:                   true,
 		SupportsFunctionBreakpoints:        true,
 		SupportsRestartRequest:             false,

--- a/internal/dap/sources.go
+++ b/internal/dap/sources.go
@@ -1,0 +1,70 @@
+package dap
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// handleLoadedSources returns one Source entry per file the loaded .dbg
+// references. Lights up the editor's Loaded Scripts pane so the user can
+// open files chippy knows about even when they aren't in the workspace.
+func (s *Server) handleLoadedSources(req Request) {
+	if s.cpu == nil {
+		s.sendErrorResponse(req, "no debuggee — send launch first")
+		return
+	}
+	type body struct {
+		Sources []Source `json:"sources"`
+	}
+	if s.srcMap == nil {
+		s.sendResponse(req, body{Sources: []Source{}})
+		return
+	}
+	out := make([]Source, 0, len(s.srcMap.Files))
+	for path := range s.srcMap.Files {
+		out = append(out, Source{
+			Name: filepath.Base(path),
+			Path: path,
+		})
+	}
+	// Stable ordering so the editor displays the same list each refresh.
+	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
+	s.sendResponse(req, body{Sources: out})
+}
+
+// handleSource returns the cached file contents for a previously-listed
+// source. Used by editors that want to display a source file chippy
+// loaded (via .dbg) but the user doesn't have open in their workspace.
+func (s *Server) handleSource(req Request) {
+	if s.cpu == nil {
+		s.sendErrorResponse(req, "no debuggee — send launch first")
+		return
+	}
+	if s.srcMap == nil {
+		s.sendErrorResponse(req, "no source map loaded")
+		return
+	}
+	var args SourceArguments
+	if err := json.Unmarshal(req.Arguments, &args); err != nil {
+		s.sendErrorResponse(req, fmt.Sprintf("bad source args: %v", err))
+		return
+	}
+	want := canonicalSourcePath(args.Source)
+	for path, lines := range s.srcMap.Files {
+		if path == want || filepath.Base(path) == filepath.Base(want) {
+			type body struct {
+				Content  string `json:"content"`
+				MimeType string `json:"mimeType,omitempty"`
+			}
+			s.sendResponse(req, body{
+				Content:  strings.Join(lines, "\n"),
+				MimeType: "text/plain",
+			})
+			return
+		}
+	}
+	s.sendErrorResponse(req, fmt.Sprintf("source not loaded: %s", want))
+}

--- a/internal/dap/sources_test.go
+++ b/internal/dap/sources_test.go
@@ -1,0 +1,121 @@
+package dap
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/nkane/chippy/internal/symbols"
+)
+
+func srcMapWithFiles(files map[string][]string) *symbols.SourceMap {
+	return &symbols.SourceMap{
+		PCToSrc: map[uint16]symbols.SrcLoc{},
+		Files:   files,
+	}
+}
+
+func TestSources_LoadedSourcesEmpty(t *testing.T) {
+	s, _, out := newStoppedServer(t, []byte{0xEA})
+	// s.srcMap nil — no .dbg loaded.
+
+	s.handleLoadedSources(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "loadedSources",
+	})
+
+	body := out.String()
+	if !strings.Contains(body, `"sources":[]`) {
+		t.Fatalf("nil srcMap should yield empty sources, got: %s", body)
+	}
+}
+
+func TestSources_LoadedSourcesLists(t *testing.T) {
+	s, _, out := newStoppedServer(t, []byte{0xEA})
+	s.srcMap = srcMapWithFiles(map[string][]string{
+		"main.s":  {"line1", "line2"},
+		"util.s":  {"x"},
+		"start.s": {"y"},
+	})
+
+	s.handleLoadedSources(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "loadedSources",
+	})
+
+	body := out.String()
+	for _, want := range []string{`"name":"main.s"`, `"name":"util.s"`, `"name":"start.s"`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("expected %s in body:\n%s", want, body)
+		}
+	}
+	// Sorted by path.
+	if !strings.Contains(body, `"path":"main.s"`) {
+		t.Fatalf("expected path field populated: %s", body)
+	}
+}
+
+func TestSources_SourceReturnsContent(t *testing.T) {
+	s, _, out := newStoppedServer(t, []byte{0xEA})
+	s.srcMap = srcMapWithFiles(map[string][]string{
+		"main.s": {"  lda #$42", "  rts"},
+	})
+
+	s.handleSource(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "source",
+		Arguments:       json.RawMessage(`{"source":{"name":"main.s","path":"main.s"}}`),
+	})
+
+	body := out.String()
+	if !strings.Contains(body, `"content":"  lda #$42\n  rts"`) {
+		t.Fatalf("expected joined content, got: %s", body)
+	}
+}
+
+func TestSources_SourceBasenameFallback(t *testing.T) {
+	// .dbg recorded a bare filename; client passes an absolute path.
+	s, _, out := newStoppedServer(t, []byte{0xEA})
+	s.srcMap = srcMapWithFiles(map[string][]string{
+		"main.s": {"  lda"},
+	})
+
+	s.handleSource(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "source",
+		Arguments:       json.RawMessage(`{"source":{"name":"main.s","path":"/abs/project/main.s"}}`),
+	})
+
+	if !strings.Contains(out.String(), `"content":"  lda"`) {
+		t.Fatalf("basename match should succeed: %s", out.String())
+	}
+}
+
+func TestSources_SourceUnknown(t *testing.T) {
+	s, _, out := newStoppedServer(t, []byte{0xEA})
+	s.srcMap = srcMapWithFiles(map[string][]string{
+		"main.s": {"x"},
+	})
+
+	s.handleSource(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "source",
+		Arguments:       json.RawMessage(`{"source":{"name":"missing.s","path":"missing.s"}}`),
+	})
+
+	if !strings.Contains(out.String(), `"success":false`) {
+		t.Fatalf("unknown source should error, got: %s", out.String())
+	}
+}
+
+func TestSources_CapabilityAdvertised(t *testing.T) {
+	s, _, out := newStoppedServer(t, nil)
+	s.handleInitialize(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "initialize",
+		Arguments:       json.RawMessage(`{"adapterID":"chippy"}`),
+	})
+	if !strings.Contains(out.String(), `"supportsLoadedSourcesRequest":true`) {
+		t.Fatalf("initialize should advertise supportsLoadedSourcesRequest:true, got: %s", out.String())
+	}
+}


### PR DESCRIPTION
Closes #84. Part of #78 (DAP-v2 epic).

## Summary
- `loadedSources` returns one `Source` per filename in `srcMap.Files`. Sorted for stable display.
- `source` returns joined-line content for a previously-listed Source. Exact-path match first, then basename fallback (so clients sending absolute project-root paths still resolve).
- `supportsLoadedSourcesRequest: true` advertised in initialize.

## Test plan
- [x] `go build ./...` — green.
- [x] `go test -race ./...` — 6 new tests: empty srcMap returns `[]`, lists files when present, source returns joined content, basename fallback works, unknown source errors, capability advertised.
- [x] `golangci-lint run` — 0 issues.

## Docs
- docs/dap.md: `loadedSources` + `source` rows added to capability matrix.
- docs/context.md: #84 noted in Merged-PRs-of-note.