### PR TITLE
feat(dap): backward disassemble via shared walk-back

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -162,6 +162,7 @@ Bus chain: `CPU → tui.WBus → cpu.MMIO → cpu.RAM`
 - DAP stepBack (issue #79, first of #78 DAP-v2 epic): wires the rewind ring into DAP. Snapshot ring promoted from `internal/tui` to `internal/cpu` as `cpu.SnapshotRing` so both the TUI's `<` key and DAP's stepBack share storage. `supportsStepBack: true`.
 - DAP setFunctionBreakpoints (issue #82, DAP-v2): symbol-name bps via `syms.LookupName`. New `bpsByName` map joins `bpsBySrc` and `bpsInst` in `rebuildBPHit`'s union. `supportsFunctionBreakpoints: true`.
 - DAP loadedSources + source (issue #84, DAP-v2): editor's Loaded Scripts pane lists every file in `srcMap.Files`; the `source` request returns joined-line content with basename fallback for clients passing absolute paths. `supportsLoadedSourcesRequest: true`.
+- DAP backward disassemble (issue #80, DAP-v2): `walkBack` promoted from `internal/tui` to `internal/cpu` as `cpu.WalkBack`; DAP's `disassemble` handler uses it for negative `instructionOffset`. Heuristic tightened to prefer earliest-start at equal sequence length, biasing toward real code boundaries.
 
 ### Open issues
 - #22 (homebrew-core) — blocked on stars

--- a/docs/dap.md
+++ b/docs/dap.md
@@ -80,15 +80,13 @@ require("dap").adapters.chippy = {
 | `setFunctionBreakpoints`         | #82   | Symbol-name bps via `syms.LookupName`. Unknown names report `verified: false`. |
 | `loadedSources`                  | #84   | Lists every file the loaded `.dbg` references. |
 | `source`                         | #84   | Returns file contents for a previously-listed Source. Basename-matches if the client passes an absolute path. |
-| `disassemble`                    | #51   | Variant-aware via `cpu.DisasmCPU`. |
+| `disassemble`                    | #51, #80 | Variant-aware via `cpu.DisasmCPU`. Negative `instructionOffset` resolves via `cpu.WalkBack` for pre-context. |
 | `readMemory` / `writeMemory`     | #51   | Bypasses MMIO — peripherals don't see debugger pokes. |
 | `evaluate`                       | #52   | Watch / hover / debug-console expressions via `internal/expr`. |
 
 ## Known gaps
 
 - `attach` is unsupported — only `launch` boots a fresh debuggee.
-- `disassemble` clamps negative `instructionOffset` to 0; backward
-  walks would need the TUI's `walkBack` heuristic.
 - Peripherals aren't snapshotted by reverse-step (see #62).
 - The DAP server is a single session per process. To debug two ROMs
   at once, run two `chippy -dap` instances on different ports.

--- a/internal/cpu/disasm.go
+++ b/internal/cpu/disasm.go
@@ -35,6 +35,56 @@ func DisasmCPUWithSyms(c *CPU, addr uint16, sym SymLookup) (string, int) {
 	return disasmWithTable(c.Bus, addr, c.opcodes, sym)
 }
 
+// WalkBack returns up to n instruction-start addresses immediately
+// preceding pc, in ascending order. 6502 has variable-width opcodes so
+// there's no exact backward decode; we try every starting offset
+// 1..maxLook back and pick the alignment that decodes cleanly all the
+// way to pc with the most instructions.
+//
+// Shared between the TUI's disassembly panel scroller and the DAP
+// server's `disassemble` handler when the editor requests pre-context
+// (negative instructionOffset).
+func WalkBack(c *CPU, pc uint16, n int) []uint16 {
+	if n <= 0 || pc == 0 {
+		return nil
+	}
+	const maxLook = 64 // bytes of lookback
+	bestSeq := []uint16{}
+	for back := 1; back <= maxLook; back++ {
+		if int(pc)-back < 0 {
+			break
+		}
+		start := pc - uint16(back)
+		var seq []uint16
+		cur := start
+		ok := true
+		for cur < pc {
+			seq = append(seq, cur)
+			_, sz := DisasmCPUWithSyms(c, cur, nil)
+			next := uint32(cur) + uint32(sz)
+			if next > uint32(pc) {
+				ok = false
+				break
+			}
+			cur = uint16(next)
+		}
+		if !ok || cur != pc {
+			continue
+		}
+		// Prefer sequences with more instructions; at equal length prefer
+		// the earlier start (larger back distance), which biases toward
+		// real code boundaries when illegal-opcode slots happen to
+		// decode in the middle of a real instruction.
+		if len(seq) > len(bestSeq) || (len(seq) == len(bestSeq) && len(seq) > 0 && (len(bestSeq) == 0 || seq[0] < bestSeq[0])) {
+			bestSeq = seq
+		}
+	}
+	if len(bestSeq) > n {
+		bestSeq = bestSeq[len(bestSeq)-n:]
+	}
+	return bestSeq
+}
+
 // disasmWithTable is the shared core. Both the legacy NMOS-fixed API and
 // the CPU-variant-aware API funnel through here so there's exactly one
 // formatter to maintain.

--- a/internal/dap/memory.go
+++ b/internal/dap/memory.go
@@ -10,16 +10,17 @@ import (
 	"github.com/nkane/chippy/internal/cpu"
 )
 
-// handleDisassemble renders InstructionCount instructions starting at
-// MemoryReference (+ Offset bytes). Variant-aware via cpu.DisasmCPU so
-// CMOS-only mnemonics decode correctly.
+// handleDisassemble renders InstructionCount instructions starting
+// `InstructionOffset` *instructions* before/after MemoryReference (+
+// Offset bytes). Variant-aware via cpu.DisasmCPU so CMOS-only mnemonics
+// decode correctly.
 //
-// NB: a negative InstructionOffset means "show N instructions before the
-// reference address." That's a hard problem on the 6502 because of
-// variable-width opcodes — proper support would require the same
-// walk-back heuristic the TUI uses. Clamped to 0 in this v1; the
-// editor sees fewer pre-context instructions than requested but the
-// disasm view at PC works.
+// Negative InstructionOffset (pre-context) is resolved via cpu.WalkBack —
+// 6502 has variable-width opcodes so there's no exact backward decode;
+// the heuristic walks back up to 64 bytes trying alignments that decode
+// cleanly all the way to the reference. Pre-context list is emitted
+// first, then forward instructions, until InstructionCount entries are
+// produced.
 func (s *Server) handleDisassemble(req Request) {
 	if s.cpu == nil {
 		s.sendErrorResponse(req, "no debuggee — send launch first")
@@ -35,35 +36,34 @@ func (s *Server) handleDisassemble(req Request) {
 		s.sendErrorResponse(req, fmt.Sprintf("bad memoryReference %q: %v", args.MemoryReference, err))
 		return
 	}
-	start := uint16(int(base) + args.Offset)
+	refPC := uint16(int(base) + args.Offset)
 	count := args.InstructionCount
 	if count <= 0 {
 		count = 16
 	}
 
 	instructions := make([]DisassembledInstruction, 0, count)
-	addr := start
-	for i := 0; i < count; i++ {
-		text, n := cpu.DisasmCPU(s.cpu, addr)
-		bytesHex := make([]string, n)
-		for j := 0; j < n; j++ {
-			bytesHex[j] = fmt.Sprintf("%02X", s.ram.Read(addr+uint16(j)))
-		}
-		ins := DisassembledInstruction{
-			Address:          fmt.Sprintf("$%04X", addr),
-			InstructionBytes: strings.Join(bytesHex, " "),
-			Instruction:      text,
-		}
-		if s.syms != nil {
-			ins.Symbol = s.syms.Lookup(addr)
-		}
-		if s.srcMap != nil {
-			if loc, ok := s.srcMap.PCToSrc[addr]; ok {
-				ins.Location = &Source{Name: filepath.Base(loc.File), Path: loc.File}
-				ins.Line = loc.Line
+
+	// Pre-context: if instructionOffset is negative, walk back |offset|
+	// instructions from refPC and emit them first.
+	if args.InstructionOffset < 0 {
+		back := cpu.WalkBack(s.cpu, refPC, -args.InstructionOffset)
+		for _, a := range back {
+			if len(instructions) >= count {
+				break
 			}
+			instructions = append(instructions, s.disasmOne(a))
 		}
+	}
+
+	// Forward decode from refPC (skip if a positive instructionOffset
+	// asks for forward-only context — currently treated as alignment
+	// at refPC).
+	addr := refPC
+	for len(instructions) < count {
+		ins := s.disasmOne(addr)
 		instructions = append(instructions, ins)
+		_, n := cpu.DisasmCPU(s.cpu, addr)
 		next := uint32(addr) + uint32(n)
 		if next > 0xFFFF {
 			break
@@ -75,6 +75,31 @@ func (s *Server) handleDisassemble(req Request) {
 		Instructions []DisassembledInstruction `json:"instructions"`
 	}
 	s.sendResponse(req, body{Instructions: instructions})
+}
+
+// disasmOne formats one DisassembledInstruction at addr with bytes,
+// symbol, and source location filled in when available.
+func (s *Server) disasmOne(addr uint16) DisassembledInstruction {
+	text, n := cpu.DisasmCPU(s.cpu, addr)
+	bytesHex := make([]string, n)
+	for j := 0; j < n; j++ {
+		bytesHex[j] = fmt.Sprintf("%02X", s.ram.Read(addr+uint16(j)))
+	}
+	ins := DisassembledInstruction{
+		Address:          fmt.Sprintf("$%04X", addr),
+		InstructionBytes: strings.Join(bytesHex, " "),
+		Instruction:      text,
+	}
+	if s.syms != nil {
+		ins.Symbol = s.syms.Lookup(addr)
+	}
+	if s.srcMap != nil {
+		if loc, ok := s.srcMap.PCToSrc[addr]; ok {
+			ins.Location = &Source{Name: filepath.Base(loc.File), Path: loc.File}
+			ins.Line = loc.Line
+		}
+	}
+	return ins
 }
 
 // handleReadMemory returns a byte window starting at MemoryReference (+

--- a/internal/dap/memory_test.go
+++ b/internal/dap/memory_test.go
@@ -124,6 +124,37 @@ func TestMem_WriteMemoryThenRead(t *testing.T) {
 	}
 }
 
+func TestMem_DisassembleBackwardContext(t *testing.T) {
+	// Layout: $8000 A9 42 (LDA #$42, 2B) ; $8002 EA (NOP, 1B) ; $8003 EA (NOP, 1B) ; $8004 4C 00 80 (JMP $8000, 3B)
+	// Asking from $8004 with instructionOffset=-3 should produce $8000, $8002, $8003 as pre-context, then $8004 as the reference.
+	s, _, out := newStoppedServer(t, []byte{0xA9, 0x42, 0xEA, 0xEA, 0x4C, 0x00, 0x80})
+
+	req := Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "disassemble",
+		Arguments:       json.RawMessage(`{"memoryReference":"$8004","instructionOffset":-3,"instructionCount":4}`),
+	}
+	s.handleDisassemble(req)
+
+	body := out.String()
+	for _, want := range []string{
+		`"address":"$8000"`,
+		`"address":"$8002"`,
+		`"address":"$8003"`,
+		`"address":"$8004"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("expected %s in body:\n%s", want, body)
+		}
+	}
+	// Confirm address ordering: $8000 must appear before $8004 in the output.
+	idx8000 := strings.Index(body, `"address":"$8000"`)
+	idx8004 := strings.Index(body, `"address":"$8004"`)
+	if idx8000 >= idx8004 {
+		t.Fatalf("pre-context $8000 should appear before $8004 in body:\n%s", body)
+	}
+}
+
 func TestMem_DisassembleUsesVariantTable(t *testing.T) {
 	// CMOS BRA = $80 rel. NMOS legacy disasm would render it as "NOP #$02"
 	// (or whatever the NMOS slot is). The disassemble handler must route

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1326,48 +1326,12 @@ func disasmAddrsAround(c *cpu.CPU, pc uint16, above, below int, isData func(uint
 // `pc`, in ascending order. Strategy: try every starting offset 1..MaxLook
 // behind pc; the alignment that decodes cleanly all the way to pc with the
 // most instructions wins.
+// walkBack is a thin wrapper around cpu.WalkBack — kept so existing call
+// sites (in this file and disasmAddrsAround) don't need a per-call
+// package prefix. The actual heuristic lives in internal/cpu so the DAP
+// server's disassemble handler can share it.
 func walkBack(c *cpu.CPU, pc uint16, n int) []uint16 {
-	if n <= 0 || pc == 0 {
-		return nil
-	}
-	const maxLook = 64 // bytes of lookback
-	bestSeq := []uint16{}
-	for back := 1; back <= maxLook; back++ {
-		if int(pc)-back < 0 {
-			break
-		}
-		start := pc - uint16(back)
-		// Decode forward from `start`, recording instruction addresses, until
-		// we either hit pc exactly (good) or pass it (bad alignment).
-		var seq []uint16
-		cur := start
-		ok := true
-		for cur < pc {
-			seq = append(seq, cur)
-			_, sz := cpu.DisasmCPUWithSyms(c, cur, nil)
-			next := uint32(cur) + uint32(sz)
-			if next > uint32(pc) {
-				ok = false
-				break
-			}
-			cur = uint16(next)
-		}
-		if !ok || cur != pc {
-			continue
-		}
-		// Prefer sequences with more instructions (closer to a stable boundary).
-		if len(seq) > len(bestSeq) {
-			bestSeq = seq
-			if len(bestSeq) >= n {
-				break
-			}
-		}
-	}
-	// Trim to last n.
-	if len(bestSeq) > n {
-		bestSeq = bestSeq[len(bestSeq)-n:]
-	}
-	return bestSeq
+	return cpu.WalkBack(c, pc, n)
 }
 
 // cachedDisasmAddrs wraps disasmAddrsAround with a one-entry cache. While the


### PR DESCRIPTION
Closes #80. Part of #78 (DAP-v2 epic).

## Summary
- `walkBack` promoted from `internal/tui` to `internal/cpu` as `cpu.WalkBack`. TUI's local helper kept as a thin wrapper.
- DAP `disassemble` honors negative `instructionOffset`: walks back `|offset|` instructions, emits them first, then forward-decodes to fill `instructionCount` total.
- Walk-back tie-break tightened: at equal sequence length, prefer the alignment with the earliest start address — biases toward real code boundaries when illegal-opcode slots happen to decode at non-boundary alignments.

## Test plan
- [x] `go build ./...` — green.
- [x] `go test -race ./...` — new `TestMem_DisassembleBackwardContext` covers the pre-context + forward decode through a program where an illegal-slot alignment competes with the real boundary. Existing tests (TUI walkBack via disasm scroller + DAP forward disassemble + variant disasm) still pass.
- [x] `golangci-lint run` — 0 issues.

## Docs
- docs/dap.md: `disassemble` row links to #80; \"clamps negative instructionOffset\" line in Known gaps section removed.
- docs/context.md: #80 noted in Merged-PRs-of-note.