### PR TITLE
feat(dap): completions request

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -163,6 +163,7 @@ Bus chain: `CPU → tui.WBus → cpu.MMIO → cpu.RAM`
 - DAP setFunctionBreakpoints (issue #82, DAP-v2): symbol-name bps via `syms.LookupName`. New `bpsByName` map joins `bpsBySrc` and `bpsInst` in `rebuildBPHit`'s union. `supportsFunctionBreakpoints: true`.
 - DAP loadedSources + source (issue #84, DAP-v2): editor's Loaded Scripts pane lists every file in `srcMap.Files`; the `source` request returns joined-line content with basename fallback for clients passing absolute paths. `supportsLoadedSourcesRequest: true`.
 - DAP backward disassemble (issue #80, DAP-v2): `walkBack` promoted from `internal/tui` to `internal/cpu` as `cpu.WalkBack`; DAP's `disassemble` handler uses it for negative `instructionOffset`. Heuristic tightened to prefer earliest-start at equal sequence length, biasing toward real code boundaries.
+- DAP completions (issue #85, DAP-v2): debug-console autocomplete returns registers (A/X/Y/P/SP/PC), flag bits (N/V/B/D/I/Z/C), and `.dbg` symbol names matching the cursor's trailing identifier prefix. `supportsCompletionsRequest: true`.
 
 ### Open issues
 - #22 (homebrew-core) — blocked on stars

--- a/docs/dap.md
+++ b/docs/dap.md
@@ -83,6 +83,7 @@ require("dap").adapters.chippy = {
 | `disassemble`                    | #51, #80 | Variant-aware via `cpu.DisasmCPU`. Negative `instructionOffset` resolves via `cpu.WalkBack` for pre-context. |
 | `readMemory` / `writeMemory`     | #51   | Bypasses MMIO — peripherals don't see debugger pokes. |
 | `evaluate`                       | #52   | Watch / hover / debug-console expressions via `internal/expr`. |
+| `completions`                    | #85   | Debug-console autocomplete: registers, flag bits, and loaded `.dbg` symbols. |
 
 ## Known gaps
 

--- a/internal/dap/completions.go
+++ b/internal/dap/completions.go
@@ -1,0 +1,118 @@
+package dap
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// dapCompletionPool is the static list of identifiers chippy's expression
+// grammar recognizes outside of user-loaded symbols. Registers + flag
+// bits. Sorted for stable display in the editor's autocomplete popup.
+var dapCompletionPool = []string{
+	"A", "X", "Y", "P", "SP", "PC",
+	"N", "V", "B", "D", "I", "Z", "C",
+}
+
+// handleCompletions powers the debug-console autocomplete popup. Walks
+// back from the requested column to find the trailing identifier
+// (letters / digits / underscore), then offers prefix matches from:
+//
+//   - dapCompletionPool (registers + flag bits)
+//   - the loaded .dbg symbol table
+//
+// Returns items sorted alphabetically. Empty prefix yields the full
+// register/flag list so the user gets discoverable suggestions on a
+// blank prompt.
+func (s *Server) handleCompletions(req Request) {
+	if s.cpu == nil {
+		s.sendErrorResponse(req, "no debuggee — send launch first")
+		return
+	}
+	var args CompletionsArguments
+	if err := json.Unmarshal(req.Arguments, &args); err != nil {
+		s.sendErrorResponse(req, fmt.Sprintf("bad completions args: %v", err))
+		return
+	}
+	prefix, start := identifierPrefix(args.Text, args.Column)
+
+	matches := make([]CompletionItem, 0, 16)
+
+	// Registers + flags.
+	for _, name := range dapCompletionPool {
+		if hasPrefixCaseFold(name, prefix) {
+			matches = append(matches, CompletionItem{
+				Label:  name,
+				Text:   name,
+				Type:   "variable",
+				Start:  start,
+				Length: len(prefix),
+			})
+		}
+	}
+
+	// User symbols from the loaded .dbg.
+	if s.syms != nil {
+		for _, name := range s.syms.NamesWithPrefix(prefix) {
+			matches = append(matches, CompletionItem{
+				Label:  name,
+				Text:   name,
+				Type:   "function",
+				Start:  start,
+				Length: len(prefix),
+			})
+		}
+	}
+
+	sort.Slice(matches, func(i, j int) bool {
+		return strings.ToLower(matches[i].Label) < strings.ToLower(matches[j].Label)
+	})
+
+	type body struct {
+		Targets []CompletionItem `json:"targets"`
+	}
+	s.sendResponse(req, body{Targets: matches})
+}
+
+// identifierPrefix scans `text` backward from `column` (1-based, DAP
+// convention) and returns the trailing identifier — the longest run of
+// `[A-Za-z0-9_]` that ends at or just before the cursor. `start` is the
+// 1-based column where that identifier begins (so the editor can
+// replace the right span on accept).
+//
+// If the cursor isn't sitting on an identifier the function returns
+// ("", column) — the empty prefix produces the full register/flag list
+// on a blank input.
+func identifierPrefix(text string, column int) (string, int) {
+	// Convert 1-based column to a 0-based byte index, clamped.
+	end := column - 1
+	if end < 0 {
+		end = 0
+	}
+	if end > len(text) {
+		end = len(text)
+	}
+	i := end
+	for i > 0 && isIdentByte(text[i-1]) {
+		i--
+	}
+	return text[i:end], i + 1
+}
+
+func isIdentByte(b byte) bool {
+	return (b >= 'a' && b <= 'z') ||
+		(b >= 'A' && b <= 'Z') ||
+		(b >= '0' && b <= '9') ||
+		b == '_'
+}
+
+func hasPrefixCaseFold(s, prefix string) bool {
+	if prefix == "" {
+		return true
+	}
+	if len(prefix) > len(s) {
+		return false
+	}
+	return strings.EqualFold(s[:len(prefix)], prefix)
+}

--- a/internal/dap/completions_test.go
+++ b/internal/dap/completions_test.go
@@ -1,0 +1,119 @@
+package dap
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestCompletions_IdentifierPrefix(t *testing.T) {
+	cases := []struct {
+		text       string
+		column     int
+		wantPrefix string
+		wantStart  int
+	}{
+		// 1-based column = byte index after the prefix.
+		{"A + ma", 7, "ma", 5},
+		{"ma", 3, "ma", 1},
+		{"", 1, "", 1},
+		{"A + ", 5, "", 5},
+		{"main_loop", 10, "main_loop", 1},
+	}
+	for _, c := range cases {
+		gotPrefix, gotStart := identifierPrefix(c.text, c.column)
+		if gotPrefix != c.wantPrefix {
+			t.Errorf("identifierPrefix(%q, %d) prefix: want %q, got %q", c.text, c.column, c.wantPrefix, gotPrefix)
+		}
+		if gotStart != c.wantStart {
+			t.Errorf("identifierPrefix(%q, %d) start: want %d, got %d", c.text, c.column, c.wantStart, gotStart)
+		}
+	}
+}
+
+func TestCompletions_RegistersAndFlags(t *testing.T) {
+	s, _, out := newStoppedServer(t, nil)
+
+	s.handleCompletions(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "completions",
+		Arguments:       json.RawMessage(`{"text":"","column":1}`),
+	})
+
+	body := out.String()
+	for _, want := range []string{`"label":"A"`, `"label":"X"`, `"label":"PC"`, `"label":"C"`, `"label":"Z"`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("expected %s in body:\n%s", want, body)
+		}
+	}
+}
+
+func TestCompletions_PrefixFilter(t *testing.T) {
+	s, _, out := newStoppedServer(t, nil)
+	s.handleCompletions(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "completions",
+		Arguments:       json.RawMessage(`{"text":"P","column":2}`),
+	})
+
+	body := out.String()
+	if !strings.Contains(body, `"label":"P"`) || !strings.Contains(body, `"label":"PC"`) {
+		t.Fatalf("prefix P should match P and PC, got: %s", body)
+	}
+	if strings.Contains(body, `"label":"A"`) {
+		t.Fatalf("prefix P should not match A: %s", body)
+	}
+}
+
+func TestCompletions_Symbols(t *testing.T) {
+	s, _, out := newStoppedServer(t, nil)
+	s.syms = buildSyms(t, "main", 0x8000, "main_loop", 0x8010, "render", 0x9000)
+
+	s.handleCompletions(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "completions",
+		Arguments:       json.RawMessage(`{"text":"ma","column":3}`),
+	})
+
+	body := out.String()
+	for _, want := range []string{`"label":"main"`, `"label":"main_loop"`} {
+		if !strings.Contains(body, want) {
+			t.Errorf("expected %s in body:\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, `"label":"render"`) {
+		t.Fatalf("render shouldn't match prefix ma: %s", body)
+	}
+}
+
+func TestCompletions_StartReportedForReplacement(t *testing.T) {
+	s, _, out := newStoppedServer(t, nil)
+	s.syms = buildSyms(t, "main", 0x8000)
+
+	// Text "A + ma", column = 7 → prefix "ma" starting at column 5.
+	s.handleCompletions(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "completions",
+		Arguments:       json.RawMessage(`{"text":"A + ma","column":7}`),
+	})
+
+	body := out.String()
+	if !strings.Contains(body, `"start":5`) {
+		t.Fatalf("expected start=5 for prefix at col 5, got: %s", body)
+	}
+	if !strings.Contains(body, `"length":2`) {
+		t.Fatalf("expected length=2 for 'ma', got: %s", body)
+	}
+}
+
+func TestCompletions_CapabilityAdvertised(t *testing.T) {
+	s, _, out := newStoppedServer(t, nil)
+	s.handleInitialize(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "initialize",
+		Arguments:       json.RawMessage(`{"adapterID":"chippy"}`),
+	})
+	if !strings.Contains(out.String(), `"supportsCompletionsRequest":true`) {
+		t.Fatalf("initialize should advertise supportsCompletionsRequest:true, got: %s", out.String())
+	}
+}

--- a/internal/dap/protocol.go
+++ b/internal/dap/protocol.go
@@ -285,3 +285,21 @@ type SourceArguments struct {
 	Source          Source `json:"source"`
 	SourceReference int    `json:"sourceReference,omitempty"`
 }
+
+// CompletionsArguments is the request body for `completions`. Text is the
+// in-progress expression; Column is the 1-based cursor position.
+type CompletionsArguments struct {
+	FrameID int    `json:"frameId,omitempty"`
+	Text    string `json:"text"`
+	Column  int    `json:"column"`
+	Line    int    `json:"line,omitempty"`
+}
+
+// CompletionItem is one row in a `completions` response.
+type CompletionItem struct {
+	Label  string `json:"label"`
+	Text   string `json:"text,omitempty"`
+	Type   string `json:"type,omitempty"`
+	Start  int    `json:"start,omitempty"`
+	Length int    `json:"length,omitempty"`
+}

--- a/internal/dap/server.go
+++ b/internal/dap/server.go
@@ -168,6 +168,8 @@ func (s *Server) dispatch(req Request) {
 		s.handleLoadedSources(req)
 	case "source":
 		s.handleSource(req)
+	case "completions":
+		s.handleCompletions(req)
 	case "disconnect":
 		s.handleDisconnect(req)
 	case "terminate":
@@ -194,7 +196,7 @@ func (s *Server) handleInitialize(req Request) {
 		SupportsStepBack:                   true,
 		SupportsFunctionBreakpoints:        true,
 		SupportsRestartRequest:             false,
-		SupportsCompletionsRequest:         false,
+		SupportsCompletionsRequest:         true,
 		SupportsSetVariable:                true,
 	}
 	s.sendResponse(req, caps)


### PR DESCRIPTION
Closes #85. Part of #78 (DAP-v2 epic).

## Summary
- `handleCompletions` returns autocomplete suggestions for the debug-console expression input.
- Walks back from the 1-based `column` to find the trailing identifier prefix (`[A-Za-z0-9_]+`).
- Suggestion pool: registers (A/X/Y/P/SP/PC) + flag bits (N/V/B/D/I/Z/C) + every symbol from the loaded .dbg matching the prefix.
- Items carry `start` + `length` so the editor knows which span to overwrite on accept. Empty prefix returns the full register/flag list.
- `supportsCompletionsRequest: true` advertised in initialize.

## Test plan
- [x] `go build ./...` — green.
- [x] `go test -race ./...` — 6 new tests: identifier-prefix scanner (multiple positions / empty / multi-char), registers + flags returned on blank input, prefix filter rejects non-matching names, symbol matches via `syms.NamesWithPrefix`, `start`/`length` reported correctly, capability advertised.
- [x] `golangci-lint run` — 0 issues.

## Docs
- docs/dap.md: `completions` row added.
- docs/context.md: #85 noted in Merged-PRs-of-note.