### PR TITLE
feat(dap): exception breakpoints (BRK)

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -164,6 +164,7 @@ Bus chain: `CPU → tui.WBus → cpu.MMIO → cpu.RAM`
 - DAP loadedSources + source (issue #84, DAP-v2): editor's Loaded Scripts pane lists every file in `srcMap.Files`; the `source` request returns joined-line content with basename fallback for clients passing absolute paths. `supportsLoadedSourcesRequest: true`.
 - DAP backward disassemble (issue #80, DAP-v2): `walkBack` promoted from `internal/tui` to `internal/cpu` as `cpu.WalkBack`; DAP's `disassemble` handler uses it for negative `instructionOffset`. Heuristic tightened to prefer earliest-start at equal sequence length, biasing toward real code boundaries.
 - DAP completions (issue #85, DAP-v2): debug-console autocomplete returns registers (A/X/Y/P/SP/PC), flag bits (N/V/B/D/I/Z/C), and `.dbg` symbol names matching the cursor's trailing identifier prefix. `supportsCompletionsRequest: true`.
+- DAP exception bps (issue #83, DAP-v2): `brk` filter advertised in initialize as `exceptionBreakpointFilters`. `setExceptionBreakpoints` flips `brkOnException`; run loop pauses before any `$00` opcode and writes `lastExceptionPC` for the `exceptionInfo` response. `supportsExceptionInfoRequest: true`.
 
 ### Open issues
 - #22 (homebrew-core) — blocked on stars

--- a/docs/dap.md
+++ b/docs/dap.md
@@ -84,6 +84,8 @@ require("dap").adapters.chippy = {
 | `readMemory` / `writeMemory`     | #51   | Bypasses MMIO — peripherals don't see debugger pokes. |
 | `evaluate`                       | #52   | Watch / hover / debug-console expressions via `internal/expr`. |
 | `completions`                    | #85   | Debug-console autocomplete: registers, flag bits, and loaded `.dbg` symbols. |
+| `setExceptionBreakpoints`        | #83   | Toggles "pause on BRK" via the `brk` filter. Run loop checks for `$00` opcode before each `cpu.Step()`. |
+| `exceptionInfo`                  | #83   | Describes the last-fired exception (`brk` with PC). |
 
 ## Known gaps
 

--- a/internal/dap/exceptions.go
+++ b/internal/dap/exceptions.go
@@ -1,0 +1,48 @@
+package dap
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// handleSetExceptionBreakpoints toggles chippy's "pause on BRK" mode.
+// The filter ID "brk" is the only one we advertise (declared in
+// handleInitialize). Any other filter the client sends is silently
+// ignored; the spec lets servers reject unknown filters but VS Code in
+// particular will pass an empty list to clear, so we accept gracefully.
+func (s *Server) handleSetExceptionBreakpoints(req Request) {
+	if s.cpu == nil {
+		s.sendErrorResponse(req, "no debuggee — send launch first")
+		return
+	}
+	var args SetExceptionBreakpointsArguments
+	if err := json.Unmarshal(req.Arguments, &args); err != nil {
+		s.sendErrorResponse(req, fmt.Sprintf("bad setExceptionBreakpoints args: %v", err))
+		return
+	}
+	on := false
+	for _, f := range args.Filters {
+		if f == "brk" {
+			on = true
+			break
+		}
+	}
+	s.brkOnException.Store(on)
+	s.sendResponse(req, nil)
+}
+
+// handleExceptionInfo describes the most recently fired exception.
+// Currently chippy only surfaces BRK; the response leans on
+// `lastExceptionPC` written by the run loop when the exception fires.
+func (s *Server) handleExceptionInfo(req Request) {
+	if s.cpu == nil {
+		s.sendErrorResponse(req, "no debuggee")
+		return
+	}
+	pc := uint16(s.lastExceptionPC.Load())
+	s.sendResponse(req, ExceptionInfoResponseBody{
+		ExceptionID: "brk",
+		Description: fmt.Sprintf("BRK at $%04X", pc),
+		BreakMode:   "always",
+	})
+}

--- a/internal/dap/exceptions_test.go
+++ b/internal/dap/exceptions_test.go
@@ -1,0 +1,101 @@
+package dap
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestExceptions_FilterAdvertised(t *testing.T) {
+	s, _, out := newStoppedServer(t, nil)
+	s.handleInitialize(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "initialize",
+		Arguments:       json.RawMessage(`{"adapterID":"chippy"}`),
+	})
+	body := out.String()
+	if !strings.Contains(body, `"filter":"brk"`) {
+		t.Fatalf("initialize should advertise brk filter, got: %s", body)
+	}
+	if !strings.Contains(body, `"supportsExceptionInfoRequest":true`) {
+		t.Fatalf("initialize should advertise exceptionInfo support, got: %s", body)
+	}
+}
+
+func TestExceptions_SetEnablesAndDisablesBRK(t *testing.T) {
+	s, _, _ := newStoppedServer(t, nil)
+
+	on := Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "setExceptionBreakpoints",
+		Arguments:       json.RawMessage(`{"filters":["brk"]}`),
+	}
+	s.handleSetExceptionBreakpoints(on)
+	if !s.brkOnException.Load() {
+		t.Fatalf("brk filter set should turn brkOnException on")
+	}
+
+	off := Request{
+		ProtocolMessage: ProtocolMessage{Seq: 2, Type: "request"},
+		Command:         "setExceptionBreakpoints",
+		Arguments:       json.RawMessage(`{"filters":[]}`),
+	}
+	s.handleSetExceptionBreakpoints(off)
+	if s.brkOnException.Load() {
+		t.Fatalf("empty filter list should turn brkOnException off")
+	}
+}
+
+func TestExceptions_RunStopsAtBRK(t *testing.T) {
+	// LDA #$00 (2B) ; LDA #$11 (2B) ; BRK ($00) — non-degenerate path
+	// to reach a BRK during free-run.
+	s, _, _ := newStoppedServer(t, []byte{0xA9, 0x00, 0xA9, 0x11, 0x00})
+
+	s.handleSetExceptionBreakpoints(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "setExceptionBreakpoints",
+		Arguments:       json.RawMessage(`{"filters":["brk"]}`),
+	})
+	s.handleContinue(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 2, Type: "request"},
+		Command:         "continue",
+	})
+	<-s.runDone
+	if s.cpu.PC != 0x8004 {
+		t.Fatalf("continue+brk-filter: want stop at $8004 (the BRK), got $%04X", s.cpu.PC)
+	}
+	if s.lastExceptionPC.Load() != 0x8004 {
+		t.Fatalf("lastExceptionPC should be $8004, got $%04X", s.lastExceptionPC.Load())
+	}
+}
+
+func TestExceptions_RunStillRunsWithoutFilter(t *testing.T) {
+	// Same ROM but no filter set — run should execute past the BRK
+	// straight into the IRQ vector (which is $0000 here), not pause.
+	s, _, _ := newStoppedServer(t, []byte{0xEA, 0xEA, 0x4C, 0x00, 0x80})
+
+	s.handleContinue(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "continue",
+	})
+	// Loop is infinite — kill it after a beat.
+	s.pauseRequested.Store(true)
+	<-s.runDone
+}
+
+func TestExceptions_ExceptionInfo(t *testing.T) {
+	s, _, out := newStoppedServer(t, nil)
+	s.lastExceptionPC.Store(0x9042)
+
+	s.handleExceptionInfo(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "exceptionInfo",
+	})
+	body := out.String()
+	if !strings.Contains(body, `"exceptionId":"brk"`) {
+		t.Fatalf("exceptionInfo missing exceptionId: %s", body)
+	}
+	if !strings.Contains(body, `"BRK at $9042"`) {
+		t.Fatalf("exceptionInfo description should reference PC: %s", body)
+	}
+}

--- a/internal/dap/protocol.go
+++ b/internal/dap/protocol.go
@@ -303,3 +303,28 @@ type CompletionItem struct {
 	Start  int    `json:"start,omitempty"`
 	Length int    `json:"length,omitempty"`
 }
+
+// ExceptionBreakpointsFilter is one selectable filter the client offers
+// in its Breakpoints pane. The user toggles each filter on/off; the
+// resulting set arrives via setExceptionBreakpoints.
+type ExceptionBreakpointsFilter struct {
+	Filter            string `json:"filter"`
+	Label             string `json:"label"`
+	Description       string `json:"description,omitempty"`
+	Default           bool   `json:"default,omitempty"`
+	SupportsCondition bool   `json:"supportsCondition,omitempty"`
+}
+
+// SetExceptionBreakpointsArguments is the request body for
+// `setExceptionBreakpoints` — the list of filter IDs currently enabled.
+type SetExceptionBreakpointsArguments struct {
+	Filters []string `json:"filters"`
+}
+
+// ExceptionInfoResponseBody is what `exceptionInfo` returns when the
+// editor asks for details on the active exception.
+type ExceptionInfoResponseBody struct {
+	ExceptionID string `json:"exceptionId"`
+	Description string `json:"description,omitempty"`
+	BreakMode   string `json:"breakMode"`
+}

--- a/internal/dap/server.go
+++ b/internal/dap/server.go
@@ -69,6 +69,13 @@ type Server struct {
 	// (stepIn/next/stepOut) and on continue→bp stops. stepBack pops one
 	// snapshot and restores. Same 256-entry ring the TUI uses for `<`.
 	rewind *cpu.SnapshotRing
+
+	// Exception-break state. `brkOnException` is set by
+	// setExceptionBreakpoints when the "brk" filter is enabled; while
+	// true, the run loop pauses just before executing a $00 (BRK)
+	// opcode. `lastExceptionPC` is the PC reported by exceptionInfo.
+	brkOnException  atomic.Bool
+	lastExceptionPC atomic.Uint32
 }
 
 // NewServer wires the transport to a fresh Server. r/w must point at the
@@ -170,6 +177,10 @@ func (s *Server) dispatch(req Request) {
 		s.handleSource(req)
 	case "completions":
 		s.handleCompletions(req)
+	case "setExceptionBreakpoints":
+		s.handleSetExceptionBreakpoints(req)
+	case "exceptionInfo":
+		s.handleExceptionInfo(req)
 	case "disconnect":
 		s.handleDisconnect(req)
 	case "terminate":
@@ -180,6 +191,13 @@ func (s *Server) dispatch(req Request) {
 }
 
 func (s *Server) handleInitialize(req Request) {
+	// initialize response embeds the exception-filter list. Defined here
+	// rather than carried on Capabilities so it stays close to the
+	// initialize handler — Capabilities is a flat bool struct.
+	type capsWithFilters struct {
+		Capabilities
+		ExceptionBreakpointFilters []ExceptionBreakpointsFilter `json:"exceptionBreakpointFilters,omitempty"`
+	}
 	caps := Capabilities{
 		SupportsConfigurationDoneRequest:   true,
 		SupportsConditionalBreakpoints:     true,
@@ -198,8 +216,19 @@ func (s *Server) handleInitialize(req Request) {
 		SupportsRestartRequest:             false,
 		SupportsCompletionsRequest:         true,
 		SupportsSetVariable:                true,
+		SupportsExceptionInfoRequest:       true,
 	}
-	s.sendResponse(req, caps)
+	resp := capsWithFilters{
+		Capabilities: caps,
+		ExceptionBreakpointFilters: []ExceptionBreakpointsFilter{
+			{
+				Filter:      "brk",
+				Label:       "BRK ($00 opcode)",
+				Description: "Pause just before the CPU executes a BRK instruction.",
+			},
+		},
+	}
+	s.sendResponse(req, resp)
 	s.sendEvent("initialized", nil)
 }
 

--- a/internal/dap/steps.go
+++ b/internal/dap/steps.go
@@ -71,6 +71,15 @@ func (s *Server) runLoop() {
 			reason = "pause"
 			break
 		}
+		// Exception filter: pause BEFORE executing a BRK so the user
+		// can inspect state at the trap point rather than landing in
+		// the IRQ handler. lastExceptionPC drives exceptionInfo's
+		// description.
+		if s.brkOnException.Load() && s.ram.Read(s.cpu.PC) == 0x00 {
+			s.lastExceptionPC.Store(uint32(s.cpu.PC))
+			reason = "exception"
+			break
+		}
 		s.cpu.Step()
 		if s.cpu.Halted {
 			reason = "exception"


### PR DESCRIPTION
Closes #83. Part of #78 (DAP-v2 epic).

## Summary
- `initialize` advertises one `exceptionBreakpointFilters` entry: `{filter: \"brk\", label: \"BRK ($00 opcode)\"}`.
- `setExceptionBreakpoints` flips `brkOnException` (atomic.Bool). Empty filter list disables.
- Run loop checks `ram.Read(PC) == $00` BEFORE `cpu.Step()` — pauses at the trap point, not after the IRQ has already pushed PC/P. `lastExceptionPC` records where the BRK fired.
- `exceptionInfo` returns `{exceptionId: \"brk\", description: \"BRK at $XXXX\", breakMode: \"always\"}`.
- `supportsExceptionInfoRequest: true` advertised.

## Test plan
- [x] `go build ./...` — green.
- [x] `go test -race ./...` — 5 new tests: filter advertised in initialize, set toggles state on and off, continue+filter stops at BRK with lastExceptionPC populated, run-without-filter doesn't stop early, exceptionInfo response shape.
- [x] `golangci-lint run` — 0 issues.

## Docs
- docs/dap.md: `setExceptionBreakpoints` + `exceptionInfo` rows added.
- docs/context.md: #83 noted in Merged-PRs-of-note.