### PR TITLE
feat(dap): condition / hit / log on breakpoints

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -165,6 +165,7 @@ Bus chain: `CPU → tui.WBus → cpu.MMIO → cpu.RAM`
 - DAP backward disassemble (issue #80, DAP-v2): `walkBack` promoted from `internal/tui` to `internal/cpu` as `cpu.WalkBack`; DAP's `disassemble` handler uses it for negative `instructionOffset`. Heuristic tightened to prefer earliest-start at equal sequence length, biasing toward real code boundaries.
 - DAP completions (issue #85, DAP-v2): debug-console autocomplete returns registers (A/X/Y/P/SP/PC), flag bits (N/V/B/D/I/Z/C), and `.dbg` symbol names matching the cursor's trailing identifier prefix. `supportsCompletionsRequest: true`.
 - DAP exception bps (issue #83, DAP-v2): `brk` filter advertised in initialize as `exceptionBreakpointFilters`. `setExceptionBreakpoints` flips `brkOnException`; run loop pauses before any `$00` opcode and writes `lastExceptionPC` for the `exceptionInfo` response. `supportsExceptionInfoRequest: true`.
+- DAP bp condition/hitCondition/logMessage (issue #81, DAP-v2): every breakpoint family (source-line, instruction, function) honors the DAP modifier triple. New `bpMeta` per PC carries the compiled `expr.EvalFn`, hit target + running count, and an interpolating log template. `shouldFireBP` is the run-loop hit handler — logMessage emits an `output` event then continues without stopping.
 
 ### Open issues
 - #22 (homebrew-core) — blocked on stars

--- a/docs/dap.md
+++ b/docs/dap.md
@@ -75,9 +75,9 @@ require("dap").adapters.chippy = {
 | `scopes`                         | #48   | Two scopes per frame: Registers, Flags. |
 | `variables`                      | #48   | ref=1 → A/X/Y/SP/PC/P/Cycles; ref=2 → 8 P-flag bits. |
 | `setVariable`                    | #48   | Writes hex / decimal to a register or flag bit. |
-| `setBreakpoints`                 | #49   | Source-line bps resolved through the `.dbg` source map. |
-| `setInstructionBreakpoints`      | #49   | Address bps (`$XX`, `0xXX`, decimal). |
-| `setFunctionBreakpoints`         | #82   | Symbol-name bps via `syms.LookupName`. Unknown names report `verified: false`. |
+| `setBreakpoints`                 | #49, #81 | Source-line bps resolved through the `.dbg` source map. Honors `condition` / `hitCondition` (integer) / `logMessage` (with `{expr}` interpolation). |
+| `setInstructionBreakpoints`      | #49, #81 | Address bps (`$XX`, `0xXX`, decimal). Same modifier support as source bps. |
+| `setFunctionBreakpoints`         | #82, #81 | Symbol-name bps via `syms.LookupName`. Same modifier support. |
 | `loadedSources`                  | #84   | Lists every file the loaded `.dbg` references. |
 | `source`                         | #84   | Returns file contents for a previously-listed Source. Basename-matches if the client passes an absolute path. |
 | `disassemble`                    | #51, #80 | Variant-aware via `cpu.DisasmCPU`. Negative `instructionOffset` resolves via `cpu.WalkBack` for pre-context. |

--- a/internal/dap/bpmeta.go
+++ b/internal/dap/bpmeta.go
@@ -1,0 +1,113 @@
+package dap
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/nkane/chippy/internal/expr"
+)
+
+// bpMeta carries the condition / hit / log modifiers attached to a single
+// breakpoint. nil meta means "plain bp — stop unconditionally."
+//
+// Hit count is stored on the meta itself, not on the Server, so resetting
+// bps on a re-send naturally resets the count. Concurrent reads from the
+// run loop + writes from set* handlers are guarded by Server.bpMu.
+type bpMeta struct {
+	Cond       expr.EvalFn // compiled condition; nil = always true
+	CondText   string
+	HitTarget  int    // 0 = fire every hit; N>0 = fire only on Nth hit
+	Hits       int    // running count
+	LogMessage string // when non-empty, log + continue instead of pause
+}
+
+// buildBPMeta compiles a SourceBreakpoint-style triple into a bpMeta.
+// Returns nil when all three modifiers are empty (faster run-loop path).
+func (s *Server) buildBPMeta(condText, hitText, logMessage string) (*bpMeta, error) {
+	if condText == "" && hitText == "" && logMessage == "" {
+		return nil, nil
+	}
+	m := &bpMeta{
+		CondText:   condText,
+		LogMessage: logMessage,
+	}
+	if condText != "" {
+		fn, err := expr.Compile(condText, s.syms)
+		if err != nil {
+			return nil, fmt.Errorf("condition: %w", err)
+		}
+		m.Cond = fn
+	}
+	if hitText != "" {
+		// DAP accepts integers ("5" -> fire on 5th hit) or simple
+		// expressions like ">= 3". v1 handles plain ints; anything
+		// else is a soft error reported back as message.
+		n, err := strconv.Atoi(strings.TrimSpace(hitText))
+		if err != nil {
+			return nil, fmt.Errorf("hitCondition %q: expected integer", hitText)
+		}
+		if n < 1 {
+			return nil, fmt.Errorf("hitCondition must be >= 1, got %d", n)
+		}
+		m.HitTarget = n
+	}
+	return m, nil
+}
+
+// shouldFireBP evaluates the meta for one hit. Returns:
+//
+//	fire=true  -> caller should emit `stopped` with reason=breakpoint
+//	log non-"" -> caller should emit an `output` event with this body
+//	            (caller continues regardless of fire after logging)
+//
+// For meta=nil the bp is a plain stop (fire=true, no log).
+func (s *Server) shouldFireBP(meta *bpMeta) (fire bool, log string) {
+	if meta == nil {
+		return true, ""
+	}
+	meta.Hits++
+	// HitTarget == 0 -> fire every hit. >0 -> fire only on that hit.
+	if meta.HitTarget > 0 && meta.Hits != meta.HitTarget {
+		return false, ""
+	}
+	if meta.Cond != nil {
+		if meta.Cond(s.cpu, s.ram) == 0 {
+			return false, ""
+		}
+	}
+	if meta.LogMessage != "" {
+		return false, s.formatLogMessage(meta.LogMessage)
+	}
+	return true, ""
+}
+
+// formatLogMessage expands `{expression}` placeholders by compiling each
+// expression and substituting its evaluated result. Bad expressions
+// render as `{!err}` so the user sees something useful in the console.
+func (s *Server) formatLogMessage(msg string) string {
+	var out strings.Builder
+	i := 0
+	for i < len(msg) {
+		if msg[i] != '{' {
+			out.WriteByte(msg[i])
+			i++
+			continue
+		}
+		// Find matching '}'.
+		j := strings.IndexByte(msg[i+1:], '}')
+		if j < 0 {
+			out.WriteString(msg[i:])
+			break
+		}
+		exprSrc := msg[i+1 : i+1+j]
+		fn, err := expr.Compile(exprSrc, s.syms)
+		if err != nil {
+			out.WriteString("{!" + err.Error() + "}")
+		} else {
+			out.WriteString(formatEvalResult(fn(s.cpu, s.ram)))
+		}
+		i += 1 + j + 1
+	}
+	return out.String()
+}

--- a/internal/dap/bpmeta_test.go
+++ b/internal/dap/bpmeta_test.go
@@ -1,0 +1,174 @@
+package dap
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBPMeta_ConditionSuppressesUntilTrue(t *testing.T) {
+	// LDA #$00 ; LDA #$11 ; LDA #$22 ; JMP $8000. Bp at $8002 (the
+	// second LDA) with condition A == $11 — fires only when A is $11,
+	// which is true on the second iteration of the loop.
+	s, _, _ := newStoppedServer(t, []byte{0xA9, 0x00, 0xA9, 0x11, 0xA9, 0x22, 0x4C, 0x00, 0x80})
+
+	req := Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "setInstructionBreakpoints",
+		Arguments: json.RawMessage(`{"breakpoints":[
+			{"instructionReference":"$8002","condition":"X == $42"}
+		]}`),
+	}
+	s.handleSetInstructionBreakpoints(req)
+
+	// Continue: condition X==$42 is never true (X stays $00) so the bp
+	// shouldn't fire; the run loop ends up looping forever until we
+	// pause.
+	s.handleContinue(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 2, Type: "request"},
+		Command:         "continue",
+	})
+	// Let the run loop spin a few iterations so we know it executed
+	// past the suppressed bp.
+	time.Sleep(20 * time.Millisecond)
+	s.pauseRequested.Store(true)
+	<-s.runDone
+	if s.cpu.Cycles < 50 {
+		t.Fatalf("expected free-run past the bp; cycles only %d", s.cpu.Cycles)
+	}
+}
+
+func TestBPMeta_ConditionFiresWhenTrue(t *testing.T) {
+	// $8002 = LDA #$11. After it executes A=$11. Bp at $8004 (the
+	// third LDA) with condition A == $11 fires immediately.
+	s, _, _ := newStoppedServer(t, []byte{0xA9, 0x00, 0xA9, 0x11, 0xA9, 0x22, 0x4C, 0x00, 0x80})
+
+	s.handleSetInstructionBreakpoints(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "setInstructionBreakpoints",
+		Arguments: json.RawMessage(`{"breakpoints":[
+			{"instructionReference":"$8004","condition":"A == $11"}
+		]}`),
+	})
+	s.handleContinue(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 2, Type: "request"},
+		Command:         "continue",
+	})
+	<-s.runDone
+	if s.cpu.PC != 0x8004 {
+		t.Fatalf("bp with true cond should stop at $8004, got $%04X", s.cpu.PC)
+	}
+}
+
+func TestBPMeta_HitConditionThirdHit(t *testing.T) {
+	// Loop: NOP ; JMP $8000. Bp at $8001 (JMP) with hitCondition "3".
+	s, _, _ := newStoppedServer(t, []byte{0xEA, 0x4C, 0x00, 0x80})
+
+	s.handleSetInstructionBreakpoints(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "setInstructionBreakpoints",
+		Arguments: json.RawMessage(`{"breakpoints":[
+			{"instructionReference":"$8001","hitCondition":"3"}
+		]}`),
+	})
+	s.handleContinue(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 2, Type: "request"},
+		Command:         "continue",
+	})
+	<-s.runDone
+
+	meta := s.lookupBPMeta(0x8001)
+	if meta == nil {
+		t.Fatalf("expected meta at $8001")
+	}
+	if meta.Hits != 3 {
+		t.Fatalf("hitCondition 3 should fire on the 3rd hit; got Hits=%d", meta.Hits)
+	}
+}
+
+func TestBPMeta_LogMessageEmitsOutputEvent(t *testing.T) {
+	// Same NOP-JMP loop. Bp at $8001 with logMessage that should fire
+	// repeatedly without stopping. Force pause after a bit to confirm
+	// we're still running.
+	s, _, out := newStoppedServer(t, []byte{0xEA, 0x4C, 0x00, 0x80})
+
+	s.handleSetInstructionBreakpoints(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "setInstructionBreakpoints",
+		Arguments: json.RawMessage(`{"breakpoints":[
+			{"instructionReference":"$8001"}
+		]}`),
+	})
+	// Re-set with logMessage by recreating — first set covered the
+	// fast happy path, second confirms logMessage suppresses the stop.
+	s.handleSetInstructionBreakpoints(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 2, Type: "request"},
+		Command:         "setInstructionBreakpoints",
+		Arguments:       json.RawMessage(`{"breakpoints":[]}`),
+	})
+
+	// Use a source-line breakpoint path with logMessage: jam the meta
+	// in directly through buildBPMeta to keep the test focused on the
+	// log-on-hit semantics. Setting via a source bp requires a real
+	// srcMap, which is overkill here.
+	s.bpMu.Lock()
+	s.bpsInst[0x8001] = true
+	meta, err := s.buildBPMeta("", "", "tick at {PC}")
+	if err != nil {
+		s.bpMu.Unlock()
+		t.Fatalf("buildBPMeta: %v", err)
+	}
+	s.bpMetaInst[0x8001] = meta
+	s.rebuildBPHit()
+	s.bpMu.Unlock()
+
+	s.handleContinue(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 3, Type: "request"},
+		Command:         "continue",
+	})
+	time.Sleep(20 * time.Millisecond)
+	s.pauseRequested.Store(true)
+	<-s.runDone
+
+	body := out.String()
+	if !strings.Contains(body, `"event":"output"`) {
+		t.Fatalf("logMessage should emit output event, got: %s", body)
+	}
+	if !strings.Contains(body, "tick at $") {
+		t.Fatalf("output event should carry interpolated message, got: %s", body)
+	}
+}
+
+func TestBPMeta_BuildErrorOnBadCondition(t *testing.T) {
+	s, _, _ := newStoppedServer(t, nil)
+	_, err := s.buildBPMeta("A +", "", "")
+	if err == nil {
+		t.Fatalf("malformed condition should return error")
+	}
+	if !strings.Contains(err.Error(), "condition") {
+		t.Fatalf("error message should mention condition: %v", err)
+	}
+}
+
+func TestBPMeta_BuildErrorOnNonIntHitCondition(t *testing.T) {
+	s, _, _ := newStoppedServer(t, nil)
+	_, err := s.buildBPMeta("", ">= 3", "")
+	if err == nil {
+		t.Fatalf("non-integer hitCondition should return error (v1 limitation)")
+	}
+}
+
+func TestBPMeta_LogMessageBadExprFallback(t *testing.T) {
+	s, _, _ := newStoppedServer(t, nil)
+	meta, err := s.buildBPMeta("", "", "value: {A +}")
+	if err != nil {
+		t.Fatalf("logMessage build shouldn't pre-compile placeholders: %v", err)
+	}
+	// formatLogMessage runs at hit time and should produce {!...} for
+	// malformed inner expressions.
+	out := s.formatLogMessage(meta.LogMessage)
+	if !strings.Contains(out, "{!") {
+		t.Fatalf("expected {!err} fallback for malformed inner expr, got: %s", out)
+	}
+}

--- a/internal/dap/breakpoints.go
+++ b/internal/dap/breakpoints.go
@@ -28,6 +28,7 @@ func (s *Server) handleSetBreakpoints(req Request) {
 
 	srcKey := canonicalSourcePath(args.Source)
 	resolved := make(map[int]uint16)
+	metaForLine := make(map[int]*bpMeta)
 	results := make([]Breakpoint, 0, len(args.Breakpoints))
 	for _, bp := range args.Breakpoints {
 		pc, ok := s.lookupSourceLine(args.Source, bp.Line)
@@ -39,7 +40,19 @@ func (s *Server) handleSetBreakpoints(req Request) {
 			})
 			continue
 		}
+		meta, mErr := s.buildBPMeta(bp.Condition, bp.HitCondition, bp.LogMessage)
+		if mErr != nil {
+			results = append(results, Breakpoint{
+				Verified: false,
+				Line:     bp.Line,
+				Message:  mErr.Error(),
+			})
+			continue
+		}
 		resolved[bp.Line] = pc
+		if meta != nil {
+			metaForLine[bp.Line] = meta
+		}
 		results = append(results, Breakpoint{
 			Verified:                    true,
 			Line:                        bp.Line,
@@ -51,8 +64,14 @@ func (s *Server) handleSetBreakpoints(req Request) {
 	s.bpMu.Lock()
 	if len(resolved) == 0 {
 		delete(s.bpsBySrc, srcKey)
+		delete(s.bpMetaBySrc, srcKey)
 	} else {
 		s.bpsBySrc[srcKey] = resolved
+		if len(metaForLine) > 0 {
+			s.bpMetaBySrc[srcKey] = metaForLine
+		} else {
+			delete(s.bpMetaBySrc, srcKey)
+		}
 	}
 	s.rebuildBPHit()
 	s.bpMu.Unlock()
@@ -78,6 +97,7 @@ func (s *Server) handleSetInstructionBreakpoints(req Request) {
 	}
 
 	newInst := map[uint16]bool{}
+	newMeta := map[uint16]*bpMeta{}
 	results := make([]Breakpoint, 0, len(args.Breakpoints))
 	for _, bp := range args.Breakpoints {
 		n, err := parseDAPNumber(bp.InstructionReference)
@@ -89,7 +109,18 @@ func (s *Server) handleSetInstructionBreakpoints(req Request) {
 			continue
 		}
 		pc := uint16(int(n) + bp.Offset)
+		meta, mErr := s.buildBPMeta(bp.Condition, bp.HitCondition, "")
+		if mErr != nil {
+			results = append(results, Breakpoint{
+				Verified: false,
+				Message:  mErr.Error(),
+			})
+			continue
+		}
 		newInst[pc] = true
+		if meta != nil {
+			newMeta[pc] = meta
+		}
 		results = append(results, Breakpoint{
 			Verified:                    true,
 			InstructionPointerReference: fmt.Sprintf("$%04X", pc),
@@ -98,6 +129,7 @@ func (s *Server) handleSetInstructionBreakpoints(req Request) {
 
 	s.bpMu.Lock()
 	s.bpsInst = newInst
+	s.bpMetaInst = newMeta
 	s.rebuildBPHit()
 	s.bpMu.Unlock()
 
@@ -108,21 +140,52 @@ func (s *Server) handleSetInstructionBreakpoints(req Request) {
 }
 
 // rebuildBPHit flattens bpsBySrc + bpsInst + bpsByName into the single PC
-// set the run loop checks. Call under bpMu.
+// set the run loop checks, and rebuilds bpMetaByPC so the run loop's
+// hit handler can look up condition/hit/log modifiers in one read. Call
+// under bpMu.
+//
+// When the same PC is set by multiple sources (e.g. both a source-line
+// and an instruction bp) the instruction-side meta wins. Function and
+// source meta are layered after, with source last — bp set ordering is
+// stable for typical sessions, so this is a defensible v1.
 func (s *Server) rebuildBPHit() {
 	hit := make(map[uint16]bool, len(s.bpsInst))
+	metaByPC := make(map[uint16]*bpMeta)
+
 	for pc := range s.bpsInst {
 		hit[pc] = true
-	}
-	for _, lineMap := range s.bpsBySrc {
-		for _, pc := range lineMap {
-			hit[pc] = true
+		if m := s.bpMetaInst[pc]; m != nil {
+			metaByPC[pc] = m
 		}
 	}
-	for _, pc := range s.bpsByName {
+	for name, pc := range s.bpsByName {
 		hit[pc] = true
+		if m := s.bpMetaByName[name]; m != nil {
+			metaByPC[pc] = m
+		}
 	}
+	for path, lineMap := range s.bpsBySrc {
+		metaForLine := s.bpMetaBySrc[path]
+		for line, pc := range lineMap {
+			hit[pc] = true
+			if metaForLine != nil {
+				if m := metaForLine[line]; m != nil {
+					metaByPC[pc] = m
+				}
+			}
+		}
+	}
+
 	s.bpHit = hit
+	s.bpMetaByPC = metaByPC
+}
+
+// lookupBPMeta returns the meta for pc, or nil if the bp has no
+// modifiers. Read under bpMu.
+func (s *Server) lookupBPMeta(pc uint16) *bpMeta {
+	s.bpMu.Lock()
+	defer s.bpMu.Unlock()
+	return s.bpMetaByPC[pc]
 }
 
 // handleSetFunctionBreakpoints replaces all symbol-name breakpoints in
@@ -140,6 +203,7 @@ func (s *Server) handleSetFunctionBreakpoints(req Request) {
 	}
 
 	newByName := map[string]uint16{}
+	newMeta := map[string]*bpMeta{}
 	results := make([]Breakpoint, 0, len(args.Breakpoints))
 	for _, bp := range args.Breakpoints {
 		if s.syms == nil {
@@ -157,7 +221,18 @@ func (s *Server) handleSetFunctionBreakpoints(req Request) {
 			})
 			continue
 		}
+		meta, mErr := s.buildBPMeta(bp.Condition, bp.HitCondition, "")
+		if mErr != nil {
+			results = append(results, Breakpoint{
+				Verified: false,
+				Message:  mErr.Error(),
+			})
+			continue
+		}
 		newByName[bp.Name] = addr
+		if meta != nil {
+			newMeta[bp.Name] = meta
+		}
 		results = append(results, Breakpoint{
 			Verified:                    true,
 			InstructionPointerReference: fmt.Sprintf("$%04X", addr),
@@ -166,6 +241,7 @@ func (s *Server) handleSetFunctionBreakpoints(req Request) {
 
 	s.bpMu.Lock()
 	s.bpsByName = newByName
+	s.bpMetaByName = newMeta
 	s.rebuildBPHit()
 	s.bpMu.Unlock()
 

--- a/internal/dap/server.go
+++ b/internal/dap/server.go
@@ -59,11 +59,15 @@ type Server struct {
 	// PC-set the run loop checks each iteration (recomputed on every
 	// set request). All three are guarded by bpMu since setBreakpoints
 	// may arrive while the run loop is reading bpHit.
-	bpMu      sync.Mutex
-	bpsBySrc  map[string]map[int]uint16
-	bpsInst   map[uint16]bool
-	bpsByName map[string]uint16
-	bpHit     map[uint16]bool
+	bpMu         sync.Mutex
+	bpsBySrc     map[string]map[int]uint16
+	bpsInst      map[uint16]bool
+	bpsByName    map[string]uint16
+	bpHit        map[uint16]bool
+	bpMetaBySrc  map[string]map[int]*bpMeta // parallel to bpsBySrc
+	bpMetaInst   map[uint16]*bpMeta         // parallel to bpsInst
+	bpMetaByName map[string]*bpMeta         // parallel to bpsByName
+	bpMetaByPC   map[uint16]*bpMeta         // flattened union for run-loop
 
 	// Reverse-step ring. Populated on every explicit-step request
 	// (stepIn/next/stepOut) and on continue→bp stops. stepBack pops one
@@ -83,13 +87,17 @@ type Server struct {
 // in tcp mode.
 func NewServer(r io.Reader, w io.Writer) *Server {
 	return &Server{
-		in:        bufio.NewReader(r),
-		out:       w,
-		bpsBySrc:  map[string]map[int]uint16{},
-		bpsInst:   map[uint16]bool{},
-		bpsByName: map[string]uint16{},
-		bpHit:     map[uint16]bool{},
-		rewind:    cpu.NewSnapshotRing(cpu.DefaultSnapshotRingCap),
+		in:           bufio.NewReader(r),
+		out:          w,
+		bpsBySrc:     map[string]map[int]uint16{},
+		bpsInst:      map[uint16]bool{},
+		bpsByName:    map[string]uint16{},
+		bpHit:        map[uint16]bool{},
+		bpMetaBySrc:  map[string]map[int]*bpMeta{},
+		bpMetaInst:   map[uint16]*bpMeta{},
+		bpMetaByName: map[string]*bpMeta{},
+		bpMetaByPC:   map[uint16]*bpMeta{},
+		rewind:       cpu.NewSnapshotRing(cpu.DefaultSnapshotRingCap),
 	}
 }
 

--- a/internal/dap/steps.go
+++ b/internal/dap/steps.go
@@ -19,6 +19,13 @@ package dap
 // runaway program doesn't pin the goroutine.
 const guardSteps = 2_000_000
 
+// outputEventBody mirrors the DAP `output` event payload. Used by
+// logpoint emissions and any future server-to-console traffic.
+type outputEventBody struct {
+	Category string `json:"category,omitempty"`
+	Output   string `json:"output"`
+}
+
 func (s *Server) handleThreads(req Request) {
 	type thread struct {
 		ID   int    `json:"id"`
@@ -86,8 +93,25 @@ func (s *Server) runLoop() {
 			break
 		}
 		if s.isBreakpoint(s.cpu.PC) {
-			reason = "breakpoint"
-			break
+			meta := s.lookupBPMeta(s.cpu.PC)
+			fire, logLine := s.shouldFireBP(meta)
+			if logLine != "" {
+				s.sendEvent("output", outputEventBody{
+					Category: "console",
+					Output:   logLine + "\n",
+				})
+			}
+			if fire {
+				reason = "breakpoint"
+				break
+			}
+			// Continue past a non-firing bp: step once so we don't
+			// re-trigger on the same PC immediately.
+			s.cpu.Step()
+			if s.cpu.Halted {
+				reason = "exception"
+				break
+			}
 		}
 	}
 	s.sendEvent("stopped", StoppedEventBody{


### PR DESCRIPTION
Closes #81. Part of #78 (DAP-v2 epic).

## Summary
Every DAP breakpoint family — source-line (#49), instruction (#49), and function (#82) — now honors the spec's modifier triple:

- `condition` — chippy expression grammar (reuses `internal/expr`).
- `hitCondition` — integer N → fire only on the Nth hit.
- `logMessage` — `{expr}` placeholders; emits `output` event then continues.

## Implementation
- New `bpMeta` struct stores compiled cond + hit count + log template.
- Per-container meta tables (`bpMetaBySrc` / `bpMetaInst` / `bpMetaByName`) parallel the existing PC maps.
- `rebuildBPHit` flattens to `bpMetaByPC` for run-loop lookup. When multiple sources cover the same PC, source-line meta wins (last layered).
- Run loop's bp-hit branch consults `shouldFireBP(meta)` → suppress / log / fire. Non-firing bps single-step past the PC so the loop doesn't re-trigger on the same address.
- Build errors (bad condition, non-integer hitCondition) come back as `verified: false` with a useful message.

## Test plan
- [x] `go build ./...` — green.
- [x] `go test -race ./...` — 7 new tests cover condition suppress vs. fire, hitCondition fires on 3rd hit, logMessage emits output + continues, build errors on bad cond / non-int hit, logMessage `{!err}` fallback for malformed inner expression.
- [x] `golangci-lint run` — 0 issues.

## Docs
- docs/dap.md: `setBreakpoints` / `setInstructionBreakpoints` / `setFunctionBreakpoints` rows updated to credit #81.
- docs/context.md: #81 noted in Merged-PRs-of-note.