### PR TITLE
feat(dap): attach v1 (Server.AttachExisting)

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -167,6 +167,7 @@ Bus chain: `CPU → tui.WBus → cpu.MMIO → cpu.RAM`
 - DAP exception bps (issue #83, DAP-v2): `brk` filter advertised in initialize as `exceptionBreakpointFilters`. `setExceptionBreakpoints` flips `brkOnException`; run loop pauses before any `$00` opcode and writes `lastExceptionPC` for the `exceptionInfo` response. `supportsExceptionInfoRequest: true`.
 - DAP bp condition/hitCondition/logMessage (issue #81, DAP-v2): every breakpoint family (source-line, instruction, function) honors the DAP modifier triple. New `bpMeta` per PC carries the compiled `expr.EvalFn`, hit target + running count, and an interpolating log template. `shouldFireBP` is the run-loop hit handler — logMessage emits an `output` event then continues without stopping.
 - DAP integration test (issue #86, DAP-v2): `internal/dap/integration_test.go` under build-tag `integration`. Builds the binary, spawns `chippy -dap stdio`, drives initialize → launch → setInstructionBreakpoints → continue → variables → stackTrace → disconnect via an in-test JSON wire client. New `dap-integration` CI job runs it on every push.
+- DAP attach v1 (issue #87, DAP-v2): `Server.AttachExisting(AttachConfig)` populates debuggee from an externally-built CPU/RAM/MMIO bundle without going through the loader. `attach` request now responds OK + emits stopped(entry) when a debuggee is wired. The TUI plumbing (`:dap PORT` command + shared CPU mutex) is deferred to #97.
 
 ### Open issues
 - #22 (homebrew-core) — blocked on stars

--- a/docs/dap.md
+++ b/docs/dap.md
@@ -65,7 +65,7 @@ require("dap").adapters.chippy = {
 |----------------------------------|-------|-------|
 | `initialize`                     | #47   | Negotiates capabilities; reports the full subset below in one shot. |
 | `launch`                         | #47   | Takes `rom`, `loadAddr`, `resetVec`, `linkerCfg`, `dbgPath`, `cpuVariant`, `tracePath`, `stopOnEntry`. |
-| `attach`                         | —     | Not supported. Returns an error. |
+| `attach`                         | #87   | Supported when the host process pre-populates the debuggee via `Server.AttachExisting`. The in-TUI listener that ties this to the `:dap` command is filed as a follow-up (#97). |
 | `disconnect` / `terminate`       | #47   | Tears down the run goroutine, closes the trace file, exits. |
 | `continue` / `pause`             | #50   | Continue spawns a CPU run goroutine; pause flips a signal. |
 | `next` / `stepIn` / `stepOut`    | #50   | Step-over runs to PC+3 past a JSR; step-out runs until SP rises. |
@@ -89,7 +89,7 @@ require("dap").adapters.chippy = {
 
 ## Known gaps
 
-- `attach` is unsupported — only `launch` boots a fresh debuggee.
+- `attach` requires the host process to wire a debuggee via `Server.AttachExisting`. The cross-process / in-TUI flow is filed at #97.
 - Peripherals aren't snapshotted by reverse-step (see #62).
 - The DAP server is a single session per process. To debug two ROMs
   at once, run two `chippy -dap` instances on different ports.

--- a/internal/dap/attach.go
+++ b/internal/dap/attach.go
@@ -1,0 +1,83 @@
+package dap
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/nkane/chippy/internal/cpu"
+	"github.com/nkane/chippy/internal/peripheral"
+	"github.com/nkane/chippy/internal/symbols"
+)
+
+// AttachConfig is the externally-supplied debuggee a hosting process
+// hands to the DAP server before/while the editor connects. The hosting
+// process (e.g. the TUI when it later grows a `:dap` command) owns the
+// CPU + RAM + peripherals; the DAP server just observes and steps them
+// when the editor asks.
+//
+// Compare LaunchArguments, which builds the debuggee from scratch inside
+// the server. Attach is the path for sharing an already-running CPU.
+type AttachConfig struct {
+	CPU     *cpu.CPU
+	RAM     *cpu.RAM
+	MMIO    *cpu.MMIO
+	Tracer  *cpu.FileTracer
+	Syms    *symbols.Table
+	SrcMap  *symbols.SourceMap
+	TextOut *peripheral.TextOutput
+	KeyIn   *peripheral.KeyboardInput
+}
+
+// AttachExisting wires an already-constructed debuggee into the server
+// without going through the loader. The hosting process calls this
+// before Serve() so the next attach request finds the state ready.
+// Returns an error if a debuggee is already wired.
+func (s *Server) AttachExisting(cfg AttachConfig) error {
+	if s.cpu != nil {
+		return fmt.Errorf("a debuggee is already attached; disconnect first")
+	}
+	if cfg.CPU == nil || cfg.RAM == nil {
+		return fmt.Errorf("AttachConfig requires at minimum a CPU and RAM")
+	}
+	s.cpu = cfg.CPU
+	s.ram = cfg.RAM
+	s.mmio = cfg.MMIO
+	s.tracer = cfg.Tracer
+	s.syms = cfg.Syms
+	s.srcMap = cfg.SrcMap
+	s.textOut = cfg.TextOut
+	s.keyIn = cfg.KeyIn
+	return nil
+}
+
+// handleAttach acknowledges an editor's attach request. v1 supports
+// only the "attach to the debuggee already wired by AttachExisting"
+// flow. Cross-process attach (a separate chippy connecting to a
+// long-running session over a side channel) is a follow-up.
+//
+// stopOnEntry: when true (default), emit `stopped` with reason=entry so
+// the editor immediately renders state. When false, the run loop the
+// hosting process drives keeps going — the editor sees state at the
+// next natural stop (breakpoint, pause, exception).
+func (s *Server) handleAttach(req Request) {
+	if s.cpu == nil {
+		s.sendErrorResponse(req, "no debuggee wired; the host process must call AttachExisting before serving")
+		return
+	}
+	var args AttachArguments
+	if len(req.Arguments) > 0 {
+		if err := json.Unmarshal(req.Arguments, &args); err != nil {
+			s.sendErrorResponse(req, fmt.Sprintf("bad attach args: %v", err))
+			return
+		}
+	}
+	s.sendResponse(req, nil)
+	_ = args // StopOnEntry / ProcessID currently advisory; we always
+	// emit a stopped event so the editor's debugger UI has a state to
+	// render. Cross-process attach + run-on-attach are follow-up work.
+	s.sendEvent("stopped", StoppedEventBody{
+		Reason:            "entry",
+		ThreadID:          1,
+		AllThreadsStopped: true,
+	})
+}

--- a/internal/dap/attach_test.go
+++ b/internal/dap/attach_test.go
@@ -1,0 +1,83 @@
+package dap
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/nkane/chippy/internal/cpu"
+)
+
+func TestAttach_AttachExistingRefusesWhenAlreadyAttached(t *testing.T) {
+	s, _, _ := newStoppedServer(t, []byte{0xEA})
+	// newStoppedServer already wired cpu+ram; AttachExisting should refuse.
+	err := s.AttachExisting(AttachConfig{
+		CPU: cpu.New(cpu.NewRAM()),
+		RAM: cpu.NewRAM(),
+	})
+	if err == nil {
+		t.Fatalf("AttachExisting should refuse when a debuggee is already wired")
+	}
+	if !strings.Contains(err.Error(), "already attached") {
+		t.Fatalf("expected 'already attached' in error, got: %v", err)
+	}
+}
+
+func TestAttach_AttachExistingRequiresCPUAndRAM(t *testing.T) {
+	var s Server
+	err := s.AttachExisting(AttachConfig{})
+	if err == nil {
+		t.Fatalf("empty config should error")
+	}
+	if !strings.Contains(err.Error(), "CPU and RAM") {
+		t.Fatalf("expected error to call out CPU/RAM requirement, got: %v", err)
+	}
+}
+
+func TestAttach_HandleAttachEmitsStopped(t *testing.T) {
+	s, _, out := newStoppedServer(t, []byte{0xEA, 0xEA})
+
+	req := Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "attach",
+		Arguments:       json.RawMessage(`{"stopOnEntry":true}`),
+	}
+	s.handleAttach(req)
+
+	body := out.String()
+	if !strings.Contains(body, `"command":"attach"`) || !strings.Contains(body, `"success":true`) {
+		t.Fatalf("attach should succeed when debuggee is wired, got: %s", body)
+	}
+	if !strings.Contains(body, `"event":"stopped"`) {
+		t.Fatalf("attach should emit stopped event, got: %s", body)
+	}
+	if !strings.Contains(body, `"reason":"entry"`) {
+		t.Fatalf("stopped reason should be entry, got: %s", body)
+	}
+}
+
+func TestAttach_AttachExistingPopulatesAllFields(t *testing.T) {
+	// Build everything externally — what a host process like the TUI
+	// would hand to NewServer + AttachExisting.
+	ram := cpu.NewRAM()
+	mmio := cpu.NewMMIO(ram)
+	c := cpu.New(mmio)
+
+	var s Server
+	if err := s.AttachExisting(AttachConfig{
+		CPU:  c,
+		RAM:  ram,
+		MMIO: mmio,
+	}); err != nil {
+		t.Fatalf("AttachExisting: %v", err)
+	}
+	if s.cpu != c {
+		t.Fatalf("server.cpu should be the supplied CPU")
+	}
+	if s.ram != ram {
+		t.Fatalf("server.ram should be the supplied RAM")
+	}
+	if s.mmio != mmio {
+		t.Fatalf("server.mmio should be the supplied MMIO")
+	}
+}

--- a/internal/dap/protocol.go
+++ b/internal/dap/protocol.go
@@ -101,6 +101,14 @@ type LaunchArguments struct {
 	TracePath   string `json:"tracePath,omitempty"`
 }
 
+// AttachArguments is the editor-side request body for `attach`. Empty
+// `processId` means "attach to whatever debuggee the server is already
+// running"; non-empty is reserved for a future cross-process flow.
+type AttachArguments struct {
+	ProcessID   string `json:"processId,omitempty"`
+	StopOnEntry bool   `json:"stopOnEntry,omitempty"`
+}
+
 // StoppedEventBody is the body of a `stopped` event. Reason values include
 // "entry", "step", "breakpoint", "pause", "exception".
 type StoppedEventBody struct {

--- a/internal/dap/server.go
+++ b/internal/dap/server.go
@@ -140,7 +140,7 @@ func (s *Server) dispatch(req Request) {
 	case "launch":
 		s.handleLaunch(req)
 	case "attach":
-		s.sendErrorResponse(req, "attach is not supported in this build; use launch")
+		s.handleAttach(req)
 	case "configurationDone":
 		s.sendResponse(req, nil)
 	case "continue":

--- a/internal/dap/server_test.go
+++ b/internal/dap/server_test.go
@@ -101,7 +101,9 @@ func TestServer_InitializeHandshake(t *testing.T) {
 	}
 }
 
-func TestServer_AttachUnsupported(t *testing.T) {
+func TestServer_AttachWithoutDebuggeeErrors(t *testing.T) {
+	// attach with no AttachExisting call beforehand should report an
+	// error explaining the host hasn't wired a debuggee yet.
 	var in bytes.Buffer
 	frameRequest(t, &in, 1, "attach", `{}`)
 	frameRequest(t, &in, 2, "disconnect", `{}`)
@@ -116,7 +118,7 @@ func TestServer_AttachUnsupported(t *testing.T) {
 		t.Fatalf("no response captured")
 	}
 	if msgs[0]["success"] != false {
-		t.Fatalf("attach should fail with error response: %v", msgs[0])
+		t.Fatalf("attach without debuggee should fail: %v", msgs[0])
 	}
 	if msgs[0]["message"] == nil {
 		t.Fatalf("error response should include a message: %v", msgs[0])


### PR DESCRIPTION
Closes #87. Part of #78 (DAP-v2 epic).

## Summary
- New `AttachConfig` + `Server.AttachExisting(cfg)` — populates the server's debuggee from externally-built CPU/RAM/MMIO/tracer/syms/srcMap/textOut/keyIn without going through `bootDebuggee`.
- `handleAttach` now succeeds when a debuggee is wired (responds OK + emits `stopped(entry)` so the editor's debugger UI renders immediately).
- Missing debuggee now yields a useful error pointing the host process at `AttachExisting`, instead of the previous blanket \"unsupported\".

## What's NOT in this PR
The in-TUI consumer that ties `AttachExisting` to a runtime `:dap PORT` command lives at #97. v1 here is the server-side building block; #97 is the TUI plumbing + shared-CPU mutex audit.

## Test plan
- [x] `go build ./...` — green.
- [x] `go test -race ./...` — 4 new attach tests cover: refuse when a debuggee is already attached, require CPU+RAM, handleAttach emits stopped(entry) on success, fields populated correctly. Existing `TestServer_AttachUnsupported` renamed to `TestServer_AttachWithoutDebuggeeErrors` and reframed for the new error path.
- [x] `golangci-lint run` — 0 issues.

## Docs
- docs/dap.md: `attach` row updated, Known gaps line now points at #97.
- docs/context.md: #87 noted in Merged-PRs-of-note; #97 added as the open follow-up.