### PR TITLE
test(cpu): Klaus 65C02 functional test (gated on #99)

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -168,6 +168,8 @@ Bus chain: `CPU → tui.WBus → cpu.MMIO → cpu.RAM`
 - DAP bp condition/hitCondition/logMessage (issue #81, DAP-v2): every breakpoint family (source-line, instruction, function) honors the DAP modifier triple. New `bpMeta` per PC carries the compiled `expr.EvalFn`, hit target + running count, and an interpolating log template. `shouldFireBP` is the run-loop hit handler — logMessage emits an `output` event then continues without stopping.
 - DAP integration test (issue #86, DAP-v2): `internal/dap/integration_test.go` under build-tag `integration`. Builds the binary, spawns `chippy -dap stdio`, drives initialize → launch → setInstructionBreakpoints → continue → variables → stackTrace → disconnect via an in-test JSON wire client. New `dap-integration` CI job runs it on every push.
 - DAP attach v1 (issue #87, DAP-v2): `Server.AttachExisting(AttachConfig)` populates debuggee from an externally-built CPU/RAM/MMIO bundle without going through the loader. `attach` request now responds OK + emits stopped(entry) when a debuggee is wired. The TUI plumbing (`:dap PORT` command + shared CPU mutex) is deferred to #97.
+- v0.3.0 — release cut after DAP-v2 push.
+- Klaus 65C02 functional test (issue #59): `internal/cpu/klaus_cmos_test.go` runs against `65C02_extended_opcodes_test.bin` (download-on-demand + sha256-pinned). v1 skipped behind `CHIPPY_KLAUS_CMOS_STRICT` env because chippy's CMOS undocumented-opcode slots aren't WDC-spec'd yet (bug #99); test infrastructure is ready for #99's fix to be validated against.
 
 ### Open issues
 - #22 (homebrew-core) — blocked on stars

--- a/internal/cpu/klaus_cmos_test.go
+++ b/internal/cpu/klaus_cmos_test.go
@@ -1,0 +1,115 @@
+//go:build klaus
+
+// 65C02 companion to klaus_test.go. Klaus Dormann's extended opcodes test
+// exercises CMOS-only instructions (STZ, PHX/PHY/PLX/PLY, BRA, BBR0-7,
+// BBS0-7, TRB, TSB, INC A, plus the variant ADC/SBC + JMP (abs,x)
+// changes). Same harness conventions as the NMOS test: 64K ROM image
+// placed at $0000, code entry at $0400, success on self-jump at the
+// fixed pass trap, any other PC self-jump means a subtest failed.
+//
+// The ROM is GPL-3.0 so it's downloaded + sha256-verified on demand,
+// not vendored.
+
+package cpu
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+const (
+	klausCMOSURL    = "https://github.com/Klaus2m5/6502_65C02_functional_tests/raw/master/bin_files/65C02_extended_opcodes_test.bin"
+	klausCMOSSHA256 = "10a2a07fa240666fa610c46accebe8d42b1000feef3aae619da15a8d152869b2"
+	klausCMOSSize   = 65536
+	klausCMOSStart  = 0x0400
+	klausCMOSPass   = 0x24F1
+)
+
+func TestKlausCMOSFunctionalTest(t *testing.T) {
+	// The CMOS table currently treats undocumented opcodes as 1-byte
+	// NOPs — but WDC 65C02 silicon defines several of them as 2-byte
+	// NOPs (e.g. $44 = NOP ZP). This makes the test trap at $0DDE
+	// after ~9k instructions. Tracked as #99; once that lands, drop
+	// the skip and the test will run end-to-end in CI.
+	if os.Getenv("CHIPPY_KLAUS_CMOS_STRICT") == "" {
+		t.Skip("CMOS NOP fills not yet WDC-spec'd; see #99. Set " +
+			"CHIPPY_KLAUS_CMOS_STRICT=1 to run the test anyway.")
+	}
+	bin, err := loadKlausCMOSBinary(t)
+	if err != nil {
+		t.Skipf("klaus cmos rom unavailable (set CHIPPY_KLAUS_CMOS_BIN to a local copy): %v", err)
+	}
+	if len(bin) != klausCMOSSize {
+		t.Fatalf("klaus cmos rom: want %d bytes, got %d", klausCMOSSize, len(bin))
+	}
+
+	ram := NewRAM()
+	ram.Load(0x0000, bin)
+
+	c := NewVariant(ram, VariantCMOS65C02)
+	c.Reset()
+	c.PC = klausCMOSStart // bypass reset trap per suite convention
+
+	start := time.Now()
+	for i := 0; i < klausMaxInstr; i++ {
+		pc := c.PC
+		c.Step()
+		if c.PC == pc {
+			if pc == klausCMOSPass {
+				t.Logf("klaus 65c02 functional test PASSED in %d instructions, %s",
+					i+1, time.Since(start).Round(time.Millisecond))
+				return
+			}
+			t.Fatalf("klaus 65c02 functional test FAILED: trap at PC=$%04X "+
+				"after %d instructions  A=%02X X=%02X Y=%02X SP=%02X P=%02X",
+				pc, i+1, c.A, c.X, c.Y, c.SP, c.P)
+		}
+	}
+	t.Fatalf("klaus 65c02 functional test did not converge within %d instructions "+
+		"(last PC=$%04X)", klausMaxInstr, c.PC)
+}
+
+// loadKlausCMOSBinary mirrors loadKlausBinary's resolution order. Cache
+// file uses a different basename so the NMOS + CMOS caches coexist.
+func loadKlausCMOSBinary(t *testing.T) ([]byte, error) {
+	t.Helper()
+	if p := os.Getenv("CHIPPY_KLAUS_CMOS_BIN"); p != "" {
+		return os.ReadFile(p)
+	}
+	cachePath, err := klausCMOSCachePath()
+	if err != nil {
+		return nil, err
+	}
+	if data, err := os.ReadFile(cachePath); err == nil {
+		if verifySHA256(data, klausCMOSSHA256) {
+			return data, nil
+		}
+		t.Logf("klaus cmos cache file %s has wrong sha256, re-downloading", cachePath)
+	}
+	if err := os.MkdirAll(filepath.Dir(cachePath), 0o755); err != nil {
+		return nil, err
+	}
+	t.Logf("downloading klaus 65c02 test rom -> %s", cachePath)
+	data, err := httpDownload(klausCMOSURL, 30*time.Second)
+	if err != nil {
+		return nil, err
+	}
+	if !verifySHA256(data, klausCMOSSHA256) {
+		return nil, fmt.Errorf("downloaded klaus cmos rom sha256 mismatch")
+	}
+	if err := os.WriteFile(cachePath, data, 0o644); err != nil {
+		t.Logf("warning: could not cache klaus cmos rom: %v", err)
+	}
+	return data, nil
+}
+
+func klausCMOSCachePath() (string, error) {
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "chippy-tests", "klaus_65c02_extended_opcodes_test.bin"), nil
+}


### PR DESCRIPTION
Closes #59.

## Summary
- New `internal/cpu/klaus_cmos_test.go` mirrors the #30 NMOS harness against `65C02_extended_opcodes_test.bin` from Klaus2m5/6502_65C02_functional_tests. Same pattern: download on demand, cache under user-cache dir, sha256-pinned to `10a2a07f...69b2`.
- Start address `$0400`, pass trap `$24F1` (verified against the .lst at master).
- Runs with `go test -tags=klaus -run TestKlausCMOS`. The existing CI klaus job's `-run TestKlaus` regex matches the new test too.

## Bug surfaced + gated
The test caught a real CMOS table-init bug — undefined opcodes that should be 2-byte NOPs on WDC silicon (e.g. `$44 = NOP ZP`) are 1-byte NOPs in chippy because CMOS table init copies NMOS BEFORE the illegal-NOP patch step runs. Trap at `$0DDE` after ~9k instructions.

Bug filed as #99. The test is gated behind `CHIPPY_KLAUS_CMOS_STRICT=1` so CI stays green; once #99 lands, drop the skip and the assertion runs in CI.

## Test plan
- [x] `go test -tags=klaus -run TestKlaus` — NMOS passes, CMOS skips with a pointer to #99.
- [x] `go build ./...` + `go test -race ./...` — green.
- [x] `golangci-lint run` — 0 issues.

## Docs
- docs/context.md: #59 noted in Merged-PRs-of-note plus a reference to the gating bug #99.