### PR TITLE
test(cpu): exhaustive BCD + fix CMOS invalid-nibble BCD bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,3 +89,18 @@ jobs:
 
       - name: Run DAP end-to-end stdio session
         run: go test -tags=integration -race -timeout 2m -run TestIntegration -v ./internal/dap/...
+
+  decimal:
+    name: exhaustive BCD test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: 'stable'
+          cache: true
+
+      - name: Run exhaustive decimal-mode test (Bruce Clark Appendix B)
+        run: go test -tags=decimal -timeout 2m -run TestDecimal -v ./internal/cpu/...

--- a/docs/context.md
+++ b/docs/context.md
@@ -170,6 +170,7 @@ Bus chain: `CPU → tui.WBus → cpu.MMIO → cpu.RAM`
 - DAP attach v1 (issue #87, DAP-v2): `Server.AttachExisting(AttachConfig)` populates debuggee from an externally-built CPU/RAM/MMIO bundle without going through the loader. `attach` request now responds OK + emits stopped(entry) when a debuggee is wired. The TUI plumbing (`:dap PORT` command + shared CPU mutex) is deferred to #97.
 - v0.3.0 — release cut after DAP-v2 push.
 - Klaus 65C02 functional test (issue #59): `internal/cpu/klaus_cmos_test.go` runs against `65C02_extended_opcodes_test.bin` (download-on-demand + sha256-pinned). v1 skipped behind `CHIPPY_KLAUS_CMOS_STRICT` env because chippy's CMOS undocumented-opcode slots aren't WDC-spec'd yet (bug #99); test infrastructure is ready for #99's fix to be validated against.
+- Exhaustive BCD test (issue #60): `internal/cpu/decimal_exhaustive_test.go` (build tag `decimal`) walks every (N1, N2, cin) through ADC and SBC in decimal mode for both variants — 524 288 cases total. Caught a real CMOS BCD bug on invalid-nibble inputs; fix applied to `adcDecimalCMOS` / `sbcDecimalCMOS` (Bruce Clark Appendix B algorithm). New `decimal` CI job runs the suite on every push.
 
 ### Open issues
 - #22 (homebrew-core) — blocked on stars

--- a/internal/cpu/decimal_exhaustive_test.go
+++ b/internal/cpu/decimal_exhaustive_test.go
@@ -1,0 +1,166 @@
+//go:build decimal
+
+// Exhaustive 6502 decimal-mode test. Bruce Clark's canonical BCD test
+// (https://6502.org/tutorials/decimal_mode.html Appendix B) walks
+// 256 × 256 × 2 input cases through ADC and SBC in decimal mode,
+// including invalid BCD inputs (nibbles A-F). The existing
+// bcd_test.go covers spot-checks plus a 100 × 100 × 2 valid-BCD
+// sweep; this file fills in the invalid-BCD coverage that catches
+// the cases real software accidentally hits.
+//
+// Reference rules per Appendix B:
+//
+//   - NMOS: only A and C are well-defined. N/V/Z reflect the parallel
+//     binary path (a real 6502 quirk).
+//   - CMOS: A, C, N, and Z reflect the decimal path. V remains
+//     documented-undefined; we don't compare it.
+//
+// Build-tagged so default `go test` skips the 4 × 262 144 case loops.
+// CI runs it via `go test -tags=decimal ./internal/cpu/...`.
+package cpu
+
+import (
+	"testing"
+)
+
+// referenceADC computes (A, C, N, V, Z) for decimal ADC per Appendix B.
+// Binary path drives NMOS N/V/Z; the decimal path drives A and C; CMOS
+// overrides N/Z from the decimal A.
+func referenceADC(n1, n2, cin uint8, cmos bool) (a uint8, c, n, v, z bool) {
+	bin := uint16(n1) + uint16(n2) + uint16(cin)
+	binByte := byte(bin)
+	flagNbin := binByte&0x80 != 0
+	flagZbin := binByte == 0
+	flagV := ((^(uint16(n1)^uint16(n2)))&(uint16(n1)^bin))&0x80 != 0
+
+	al := uint16(n1&0x0F) + uint16(n2&0x0F) + uint16(cin)
+	if al >= 0x0A {
+		al = ((al + 0x06) & 0x0F) + 0x10
+	}
+	ah := uint16(n1&0xF0) + uint16(n2&0xF0) + al
+	flagC := false
+	if ah >= 0xA0 {
+		ah += 0x60
+	}
+	if ah >= 0x100 {
+		flagC = true
+	}
+	a = byte(ah & 0xFF)
+
+	flagN := flagNbin
+	flagZ := flagZbin
+	if cmos {
+		flagN = a&0x80 != 0
+		flagZ = a == 0
+	}
+	return a, flagC, flagN, flagV, flagZ
+}
+
+// referenceSBC mirrors referenceADC for decimal SBC. cin acts as
+// ~borrow (1 = no borrow, the 6502 convention).
+func referenceSBC(n1, n2, cin uint8, cmos bool) (a uint8, c, n, v, z bool) {
+	w := uint16(n2 ^ 0xFF)
+	bin := uint16(n1) + w + uint16(cin)
+	binByte := byte(bin)
+	flagC := bin > 0xFF
+	flagV := ((^(uint16(n1)^w))&(uint16(n1)^bin))&0x80 != 0
+	flagNbin := binByte&0x80 != 0
+	flagZbin := binByte == 0
+
+	n1l := int(n1 & 0x0F)
+	n2l := int(n2 & 0x0F)
+	al := n1l - n2l + int(cin) - 1
+	if al < 0 {
+		al = ((al - 0x06) & 0x0F) - 0x10
+	}
+	res := int(n1&0xF0) - int(n2&0xF0) + al
+	if res < 0 {
+		res -= 0x60
+	}
+	a = byte(res & 0xFF)
+
+	flagN := flagNbin
+	flagZ := flagZbin
+	if cmos {
+		flagN = a&0x80 != 0
+		flagZ = a == 0
+	}
+	return a, flagC, flagN, flagV, flagZ
+}
+
+// runDecimalInstruction primes the CPU with one ADC or SBC at $8000
+// and runs a single Step. Caller sets c.A + c.P (with D=1) first.
+func runDecimalInstruction(c *CPU, ram *RAM, opcode, operand byte) {
+	ram.Write(0x8000, opcode)
+	ram.Write(0x8001, operand)
+	c.PC = 0x8000
+	c.Step()
+}
+
+func decimalExhaustive(t *testing.T, variant Variant, opcode byte, isSBC bool) {
+	t.Helper()
+	ram := NewRAM()
+	c := NewVariant(ram, variant)
+	cmos := variant == VariantCMOS65C02
+
+	cases := 0
+	for n1 := 0; n1 < 256; n1++ {
+		for n2 := 0; n2 < 256; n2++ {
+			for cin := 0; cin < 2; cin++ {
+				c.A = byte(n1)
+				p := byte(FlagU | FlagD)
+				if cin != 0 {
+					p |= FlagC
+				}
+				c.P = p
+				runDecimalInstruction(c, ram, opcode, byte(n2))
+
+				var wantA byte
+				var wantC, wantN, wantV, wantZ bool
+				if isSBC {
+					wantA, wantC, wantN, wantV, wantZ = referenceSBC(byte(n1), byte(n2), byte(cin), cmos)
+				} else {
+					wantA, wantC, wantN, wantV, wantZ = referenceADC(byte(n1), byte(n2), byte(cin), cmos)
+				}
+				_ = wantV // not compared per Appendix B
+
+				if c.A != wantA {
+					t.Fatalf("variant=%v op=$%02X n1=$%02X n2=$%02X cin=%d: A want $%02X got $%02X",
+						variant, opcode, n1, n2, cin, wantA, c.A)
+				}
+				if (c.P&FlagC != 0) != wantC {
+					t.Fatalf("variant=%v op=$%02X n1=$%02X n2=$%02X cin=%d: C want %v got %v",
+						variant, opcode, n1, n2, cin, wantC, c.P&FlagC != 0)
+				}
+				if cmos {
+					if (c.P&FlagN != 0) != wantN {
+						t.Fatalf("variant=%v op=$%02X n1=$%02X n2=$%02X cin=%d: N want %v got %v",
+							variant, opcode, n1, n2, cin, wantN, c.P&FlagN != 0)
+					}
+					if (c.P&FlagZ != 0) != wantZ {
+						t.Fatalf("variant=%v op=$%02X n1=$%02X n2=$%02X cin=%d: Z want %v got %v",
+							variant, opcode, n1, n2, cin, wantZ, c.P&FlagZ != 0)
+					}
+				}
+				cases++
+			}
+		}
+	}
+	t.Logf("exhausted %d cases", cases)
+}
+
+func TestDecimal_NMOS_ADC_Exhaustive(t *testing.T) {
+	decimalExhaustive(t, VariantNMOS, 0x69, false) // ADC #imm
+}
+
+func TestDecimal_NMOS_SBC_Exhaustive(t *testing.T) {
+	decimalExhaustive(t, VariantNMOS, 0xE9, true) // SBC #imm
+}
+
+func TestDecimal_CMOS_ADC_Exhaustive(t *testing.T) {
+	decimalExhaustive(t, VariantCMOS65C02, 0x69, false)
+}
+
+func TestDecimal_CMOS_SBC_Exhaustive(t *testing.T) {
+	decimalExhaustive(t, VariantCMOS65C02, 0xE9, true)
+}

--- a/internal/cpu/opcodes_cmos.go
+++ b/internal/cpu/opcodes_cmos.go
@@ -184,37 +184,46 @@ func opBITimm(c *CPU, addr uint16, _ AddrMode) {
 	c.setFlag(FlagZ, c.A&v == 0)
 }
 
-// adcDecimalCMOS performs the 65C02 packed-BCD ADC. Unlike NMOS, the CMOS
-// variant computes N, V, and Z from the *decimal* result and adds 1 cycle.
+// adcDecimalCMOS performs the 65C02 packed-BCD ADC. Algorithm matches
+// Bruce Clark's reference (https://6502.org/tutorials/decimal_mode.html
+// Appendix B): low-nibble carry both bumps the nibble AND masks the
+// result, so invalid BCD inputs ($0A..$0F low nibble) produce the same
+// answer as real WDC silicon. CMOS-specific tweaks vs. NMOS: N and Z
+// reflect the decimal result; +1 cycle penalty.
 func adcDecimalCMOS(c *CPU, v byte, carry uint16) {
 	a := uint16(c.A)
 	al := (a & 0x0F) + (uint16(v) & 0x0F) + carry
-	if al > 9 {
-		al += 6
+	if al >= 0x0A {
+		al = ((al + 0x06) & 0x0F) + 0x10
 	}
 	res := (a & 0xF0) + (uint16(v) & 0xF0) + al
-	if res > 0x9F {
+	if res >= 0xA0 {
 		res += 0x60
 	}
-	c.setFlag(FlagC, res > 0xFF)
+	c.setFlag(FlagC, res >= 0x100)
 	c.setFlag(FlagV, ((a^res)&^(a^uint16(v)))&0x80 != 0)
 	c.A = byte(res & 0xFF)
 	c.setZN(c.A)
 	c.extraCycles++ // CMOS BCD takes one extra cycle
 }
 
-// sbcDecimalCMOS performs the 65C02 packed-BCD SBC.
+// sbcDecimalCMOS performs the 65C02 packed-BCD SBC. Mirrors the
+// Appendix B reference: low-nibble underflow both shifts the nibble
+// AND masks the result, so invalid-BCD inputs match real silicon.
+// CMOS: N and Z come from the decimal result; V is documented
+// undefined but we report the binary-path V (matches NMOS and our
+// NMOS tests).
 func sbcDecimalCMOS(c *CPU, v byte, carry uint16) {
 	a := int(c.A)
 	vi := int(v)
 	cin := int(carry)
 	al := (a & 0x0F) - (vi & 0x0F) + cin - 1
-	res := a - vi + cin - 1
+	if al < 0 {
+		al = ((al - 0x06) & 0x0F) - 0x10
+	}
+	res := (a & 0xF0) - (vi & 0xF0) + al
 	if res < 0 {
 		res -= 0x60
-	}
-	if al < 0 {
-		res -= 0x06
 	}
 	// Flags from binary subtract.
 	w := v ^ 0xFF


### PR DESCRIPTION
Closes #60.

## Summary
- New `internal/cpu/decimal_exhaustive_test.go` (build tag `decimal`) walks every `(N1, N2, cin)` combination through ADC and SBC in decimal mode for both NMOS and CMOS variants — 524 288 cases total, covering invalid-BCD inputs.
- Reference algorithm ported inline from [Bruce Clark's Appendix B](https://6502.org/tutorials/decimal_mode.html). Appendix-B rules: NMOS checks A + C; CMOS checks A + C + N + Z (V is documented undefined and skipped).
- New CI job `decimal` runs the suite via `go test -tags=decimal -timeout 2m -run TestDecimal` on every push.

## Bug surfaced and fixed
The exhaustive sweep caught a real CMOS BCD bug. `adcDecimalCMOS` used `al += 6` without masking the low nibble, so invalid-BCD inputs with low nibbles `$0A-$0F` produced the wrong result (e.g. `$0A + $0F + 1` gave `$20` instead of `$10`). `sbcDecimalCMOS` had the symmetric defect.

Both rewritten to the Appendix-B algorithm exactly: low-nibble carry/borrow both bumps AND masks. NMOS BCD already matched Appendix B and is unchanged.

## Test plan
- [x] `go test -tags=decimal -timeout 2m -run TestDecimal` — 4 tests, 524 288 cases total, all pass.
- [x] `go test -race ./...` — default suite still green (existing bcd_test.go valid-BCD coverage included).
- [x] `go test -tags=klaus -run TestKlaus` — NMOS Klaus still passes; CMOS Klaus still skipped behind #99 (different bug — undocumented opcode widths).
- [x] `golangci-lint run` — 0 issues.

## Docs
- docs/context.md: #60 noted in Merged-PRs-of-note; CMOS BCD fix flagged.