### PR TITLE
ci: wire example/cmos_demo end-to-end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,3 +104,26 @@ jobs:
 
       - name: Run exhaustive decimal-mode test (Bruce Clark Appendix B)
         run: go test -tags=decimal -timeout 2m -run TestDecimal -v ./internal/cpu/...
+
+  cmos-e2e:
+    name: cmos e2e demo
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: 'stable'
+          cache: true
+
+      - name: Install cc65 toolchain
+        run: sudo apt-get update && sudo apt-get install -y cc65
+
+      - name: Build example/cmos_demo.bin
+        run: make -C example cmos_demo.bin
+
+      - name: Run CMOS demo end-to-end test
+        env:
+          CHIPPY_CMOS_E2E_STRICT: "1"
+        run: go test -v -run TestCMOSDemo ./internal/cpu/...

--- a/docs/context.md
+++ b/docs/context.md
@@ -171,6 +171,7 @@ Bus chain: `CPU → tui.WBus → cpu.MMIO → cpu.RAM`
 - v0.3.0 — release cut after DAP-v2 push.
 - Klaus 65C02 functional test (issue #59): `internal/cpu/klaus_cmos_test.go` runs against `65C02_extended_opcodes_test.bin` (download-on-demand + sha256-pinned). v1 skipped behind `CHIPPY_KLAUS_CMOS_STRICT` env because chippy's CMOS undocumented-opcode slots aren't WDC-spec'd yet (bug #99); test infrastructure is ready for #99's fix to be validated against.
 - Exhaustive BCD test (issue #60): `internal/cpu/decimal_exhaustive_test.go` (build tag `decimal`) walks every (N1, N2, cin) through ADC and SBC in decimal mode for both variants — 524 288 cases total. Caught a real CMOS BCD bug on invalid-nibble inputs; fix applied to `adcDecimalCMOS` / `sbcDecimalCMOS` (Bruce Clark Appendix B algorithm). New `decimal` CI job runs the suite on every push.
+- CMOS e2e CI (issue #61): new `cmos-e2e` workflow job installs cc65, builds `example/cmos_demo.bin`, runs the existing e2e test with `CHIPPY_CMOS_E2E_STRICT=1` so missing fixtures fail the build instead of silently skipping.
 
 ### Open issues
 - #22 (homebrew-core) — blocked on stars

--- a/internal/cpu/cmos_e2e_test.go
+++ b/internal/cpu/cmos_e2e_test.go
@@ -1,6 +1,7 @@
 package cpu_test
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -23,6 +24,12 @@ func TestCMOSDemo_E2E(t *testing.T) {
 
 	ram := cpu.NewRAM()
 	if _, err := loader.Load(ram, bin, loader.Options{Addr: 0x8000}); err != nil {
+		// CI sets CHIPPY_CMOS_E2E_STRICT=1 so a missing fixture fails
+		// the build instead of silently skipping. Local devs run
+		// `make -C example cmos_demo.bin` once and it Just Works.
+		if os.Getenv("CHIPPY_CMOS_E2E_STRICT") != "" {
+			t.Fatalf("cmos_demo.bin missing under strict mode (CI must build it before running this test): %v", err)
+		}
 		t.Skipf("cmos_demo.bin not built (run `make -C example cmos_demo.bin`): %v", err)
 	}
 


### PR DESCRIPTION
Closes #61.

## Summary
- New `cmos-e2e` CI job installs the cc65 toolchain (`sudo apt-get install -y cc65`), builds `example/cmos_demo.bin` via the existing Makefile target, and runs the e2e test against it.
- `CHIPPY_CMOS_E2E_STRICT=1` env (set by CI) promotes the test's friendly `t.Skip` into a `t.Fatal` so a busted pipeline can't go unnoticed. Local devs without the binary still see the make-hint skip.

## Why this matters
`example/cmos_demo.bin` is gitignored, so the e2e test has been silently skipping on every CI run since it landed. Chippy's CMOS variant has zero CI signal on a real ca65-assembled program until now.

## Test plan
- [x] `go test ./internal/cpu/ -run TestCMOSDemo` — passes locally (binary built).
- [x] `CHIPPY_CMOS_E2E_STRICT=1 go test ./internal/cpu/ -run TestCMOSDemo` — still passes locally; will fail in CI if the binary is missing.
- [x] `go build ./...` + `go test -race ./...` + `golangci-lint run` — all green.
- [ ] CI green on first push (validates the cc65 install path).

## Docs
- docs/context.md: #61 noted in Merged-PRs-of-note.