### PR TITLE
fix(cpu): CMOS NOP fills + interrupt D-clear

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -172,6 +172,7 @@ Bus chain: `CPU → tui.WBus → cpu.MMIO → cpu.RAM`
 - Klaus 65C02 functional test (issue #59): `internal/cpu/klaus_cmos_test.go` runs against `65C02_extended_opcodes_test.bin` (download-on-demand + sha256-pinned). v1 skipped behind `CHIPPY_KLAUS_CMOS_STRICT` env because chippy's CMOS undocumented-opcode slots aren't WDC-spec'd yet (bug #99); test infrastructure is ready for #99's fix to be validated against.
 - Exhaustive BCD test (issue #60): `internal/cpu/decimal_exhaustive_test.go` (build tag `decimal`) walks every (N1, N2, cin) through ADC and SBC in decimal mode for both variants — 524 288 cases total. Caught a real CMOS BCD bug on invalid-nibble inputs; fix applied to `adcDecimalCMOS` / `sbcDecimalCMOS` (Bruce Clark Appendix B algorithm). New `decimal` CI job runs the suite on every push.
 - CMOS e2e CI (issue #61): new `cmos-e2e` workflow job installs cc65, builds `example/cmos_demo.bin`, runs the existing e2e test with `CHIPPY_CMOS_E2E_STRICT=1` so missing fixtures fail the build instead of silently skipping.
+- CMOS NOP fills + interrupt D-clear (issue #99): WDC-spec NOP widths for undefined CMOS slots ($44=ZP, $54/$D4/$F4=ZPX, $DC/$FC=ABS, $5C=ABS-quirky 8-cycle). BRK / serviceIRQ / serviceNMI now clear D on CMOS variant (NMOS bug preserved). Klaus 65C02 functional test now passes end-to-end and runs unconditionally in CI.
 
 ### Open issues
 - #22 (homebrew-core) — blocked on stars

--- a/internal/cpu/cpu.go
+++ b/internal/cpu/cpu.go
@@ -161,6 +161,11 @@ func (c *CPU) serviceNMI() {
 	c.push16(c.PC)
 	c.push((c.P | FlagU) &^ FlagB)
 	c.setFlag(FlagI, true)
+	// CMOS quirk: interrupt entry also clears D so handlers can rely
+	// on binary mode. NMOS leaves D alone.
+	if c.Variant == VariantCMOS65C02 {
+		c.setFlag(FlagD, false)
+	}
 	lo := uint16(c.Bus.Read(VecNMI))
 	hi := uint16(c.Bus.Read(VecNMI + 1))
 	c.PC = lo | hi<<8
@@ -174,6 +179,9 @@ func (c *CPU) serviceIRQ() {
 	c.push16(c.PC)
 	c.push((c.P | FlagU) &^ FlagB)
 	c.setFlag(FlagI, true)
+	if c.Variant == VariantCMOS65C02 {
+		c.setFlag(FlagD, false)
+	}
 	lo := uint16(c.Bus.Read(VecIRQ))
 	hi := uint16(c.Bus.Read(VecIRQ + 1))
 	c.PC = lo | hi<<8

--- a/internal/cpu/exec.go
+++ b/internal/cpu/exec.go
@@ -313,6 +313,12 @@ func opBRK(c *CPU, _ uint16, _ AddrMode) {
 	c.push16(c.PC)
 	c.push(c.P | FlagB | FlagU)
 	c.setFlag(FlagI, true)
+	// CMOS quirk: BRK also clears the D flag (the running CPU's flag,
+	// AFTER the pre-clear value has already been pushed). NMOS leaves
+	// D alone — a real 6502 bug Klaus's test specifically checks for.
+	if c.Variant == VariantCMOS65C02 {
+		c.setFlag(FlagD, false)
+	}
 	lo := uint16(c.Bus.Read(VecIRQ))
 	hi := uint16(c.Bus.Read(VecIRQ + 1))
 	c.PC = lo | hi<<8

--- a/internal/cpu/klaus_cmos_test.go
+++ b/internal/cpu/klaus_cmos_test.go
@@ -29,15 +29,6 @@ const (
 )
 
 func TestKlausCMOSFunctionalTest(t *testing.T) {
-	// The CMOS table currently treats undocumented opcodes as 1-byte
-	// NOPs — but WDC 65C02 silicon defines several of them as 2-byte
-	// NOPs (e.g. $44 = NOP ZP). This makes the test trap at $0DDE
-	// after ~9k instructions. Tracked as #99; once that lands, drop
-	// the skip and the test will run end-to-end in CI.
-	if os.Getenv("CHIPPY_KLAUS_CMOS_STRICT") == "" {
-		t.Skip("CMOS NOP fills not yet WDC-spec'd; see #99. Set " +
-			"CHIPPY_KLAUS_CMOS_STRICT=1 to run the test anyway.")
-	}
 	bin, err := loadKlausCMOSBinary(t)
 	if err != nil {
 		t.Skipf("klaus cmos rom unavailable (set CHIPPY_KLAUS_CMOS_BIN to a local copy): %v", err)

--- a/internal/cpu/opcodes_cmos.go
+++ b/internal/cpu/opcodes_cmos.go
@@ -138,15 +138,33 @@ func cmosNOPs(set func(op byte, name string, mode AddrMode, bytes, cycles int, p
 		lo := op & 0x0F
 		switch lo {
 		case 0x02:
-			set(byte(op), "NOP", IMM, 2, 2, false, opNOP)
+			// $x2 slots not used as IZP ops above act as 2-byte/2-cycle
+			// IMM NOPs (load + discard).
+			set(byte(op), "NOP", IMM, 2, 2, false, opNOP2)
 		case 0x03, 0x0B:
+			// $x3 and $xB are all 1-byte/1-cycle NOPs per WDC datasheet.
 			set(byte(op), "NOP", IMP, 1, 1, false, opNOP)
+		case 0x04:
+			// $44 is the only undefined $x4 slot — 2-byte/3-cycle ZP
+			// NOP per WDC silicon. Klaus's `db $44` test at $0DCC
+			// requires exactly this width.
+			set(byte(op), "NOP", ZP, 2, 3, false, opNOP2)
 		case 0x0C:
-			// $5C is documented as 3-byte/8-cycle; other xC slots are
-			// official ops (BIT abs, JMP abs, JMP (abs,X), CPY abs, CPX abs)
-			// already in the table, so the only "???" $xC left is $5C.
-			set(byte(op), "NOP", ABS, 3, 8, false, opNOP)
+			// $5C is the WDC-quirky 3-byte/8-cycle slot. $DC + $FC are
+			// the only other "???" $xC slots; both are 3-byte/4-cycle
+			// ABS NOPs (+1 on page cross).
+			if op == 0x5C {
+				set(byte(op), "NOP", ABS, 3, 8, false, opNOP3)
+			} else {
+				set(byte(op), "NOP", ABS, 3, 4, true, opNOP3)
+			}
 		default:
+			// $54, $D4, $F4 reach here (low nibble 4 above only
+			// matched $44). They're 2-byte/4-cycle ZPX NOPs.
+			if lo == 0x04 || op == 0x54 || op == 0xD4 || op == 0xF4 {
+				set(byte(op), "NOP", ZPX, 2, 4, false, opNOP2)
+				continue
+			}
 			// All other unimplemented: 1-byte/1-cycle NOP.
 			set(byte(op), "NOP", IMP, 1, 1, false, opNOP)
 		}


### PR DESCRIPTION
Closes #99.

## Summary
Two related CMOS correctness bugs surfaced by the Klaus 65C02 functional test that landed in PR #100 (#59). Both fixed; test gate dropped.

### Bug 1: undefined-opcode NOP widths
`cmosNOPs` mapped most undefined slots to 1-byte/1-cycle NOPs, but WDC silicon defines several as wider:

| Opcode | Old | WDC | Mode |
|--------|-----|-----|------|
| `$44` | 1B/1c | 2B/3c | NOP ZP |
| `$54, $D4, $F4` | 1B/1c | 2B/4c | NOP ZPX |
| `$DC, $FC` | 3B/8c | 3B/4+1c | NOP ABS (page-cross adds) |
| `$5C` | 3B/8c | 3B/8c | NOP ABS-quirky (unchanged) |

### Bug 2: D flag not cleared on interrupt entry
WDC 65C02 clears `D` when BRK / IRQ / NMI fires so the handler can rely on binary mode. NMOS doesn't — a 6502 quirk Klaus's test checks both directions. `opBRK` + `serviceIRQ` + `serviceNMI` now do `c.setFlag(FlagD, false)` guarded by `c.Variant == VariantCMOS65C02`.

## Test plan
- [x] `go test -tags=klaus -run TestKlaus` — Klaus NMOS passes (30M instructions, unchanged); Klaus CMOS passes (~22M instructions, gate dropped).
- [x] `go test -tags=decimal -run TestDecimal` — all 4 exhaustive BCD suites still pass.
- [x] `go test ./internal/cpu/ -run CMOSDemo` — CMOS e2e demo still passes.
- [x] `go test -race ./...` — default suite green.
- [x] `golangci-lint run` — 0 issues.

## Docs
- docs/context.md: #99 noted in Merged-PRs-of-note.