### PR TITLE
docs(example): C example programs via cc65 + source-map .c preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,7 @@ internal/loader/    .bin/.prg/.hex/.o loaders
 internal/symbols/   cc65 .dbg parser, symbol + source-line tables
 internal/tui/       Bubble Tea model, panels, modals, commands
 example/            Bundled ca65 demo programs (source + shared linker cfg + Makefile)
+example/c/          Same idea, but the source is C — cc65 → ca65 → ld65 pipeline
 ```
 
 ---

--- a/docs/context.md
+++ b/docs/context.md
@@ -173,6 +173,8 @@ Bus chain: `CPU → tui.WBus → cpu.MMIO → cpu.RAM`
 - Exhaustive BCD test (issue #60): `internal/cpu/decimal_exhaustive_test.go` (build tag `decimal`) walks every (N1, N2, cin) through ADC and SBC in decimal mode for both variants — 524 288 cases total. Caught a real CMOS BCD bug on invalid-nibble inputs; fix applied to `adcDecimalCMOS` / `sbcDecimalCMOS` (Bruce Clark Appendix B algorithm). New `decimal` CI job runs the suite on every push.
 - CMOS e2e CI (issue #61): new `cmos-e2e` workflow job installs cc65, builds `example/cmos_demo.bin`, runs the existing e2e test with `CHIPPY_CMOS_E2E_STRICT=1` so missing fixtures fail the build instead of silently skipping.
 - CMOS NOP fills + interrupt D-clear (issue #99): WDC-spec NOP widths for undefined CMOS slots ($44=ZP, $54/$D4/$F4=ZPX, $DC/$FC=ABS, $5C=ABS-quirky 8-cycle). BRK / serviceIRQ / serviceNMI now clear D on CMOS variant (NMOS bug preserved). Klaus 65C02 functional test now passes end-to-end and runs unconditionally in CI.
+- v0.3.1 — patch release after the CMOS correctness pass.
+- `example/c/` — cc65-based C example programs (hello, sum, fizzbuzz) with shared `chippy.cfg` linker config + minimal `crt0.s` runtime. Builds via `make -C example/c`; runs via `chippy -rom example/c/<prog>.bin`. Source-map loader updated to prefer `.c` files over `.s` intermediates when both are recorded for the same PC, so the TUI source view (`v`) shows C source while stepping.
 
 ### Open issues
 - #22 (homebrew-core) — blocked on stars

--- a/example/c/Makefile
+++ b/example/c/Makefile
@@ -1,0 +1,56 @@
+# Build the C example programs with cc65 + ca65 + ld65.
+#
+# Each .c is compiled to a .s by cc65, assembled to a .o by ca65, then
+# linked against crt0.o and chippy.cfg by ld65. The output is a flat
+# 64 KiB binary chippy loads at $8000.
+#
+# Targets:
+#   make            -> build every .bin
+#   make run-<name> -> build then launch chippy on <name>.bin
+#                       e.g. make run-hello, make run-fizzbuzz
+#   make clean      -> remove build artifacts
+
+CFG := chippy.cfg
+CRT0 := crt0.o
+
+PROGRAMS := hello sum fizzbuzz
+
+BINS := $(PROGRAMS:=.bin)
+SS   := $(PROGRAMS:=.s)
+OBJS := $(PROGRAMS:=.o)
+DBGS := $(PROGRAMS:=.dbg)
+
+CHIPPY := go run ../../cmd/chippy
+
+.PHONY: all clean $(addprefix run-,$(PROGRAMS))
+
+all: $(BINS)
+
+# Disable make's built-in rules so its default .c -> .o (host cc)
+# doesn't shadow our cc65 + ca65 pipeline.
+MAKEFLAGS += --no-builtin-rules
+.SUFFIXES:
+
+# C -> assembly via cc65 (-g keeps source-line debug info in the .s).
+%.s: %.c
+	cc65 -t none -g -O $< -o $@
+
+# Assembly -> object via ca65.
+%.o: %.s
+	ca65 -g $< -o $@
+
+# crt0 is shared by every program.
+$(CRT0): crt0.s
+	ca65 -g crt0.s -o $(CRT0)
+
+# Link program object + crt0 against the chippy linker config. The
+# cc65 runtime library (none.lib) provides zerobss, copydata, initlib,
+# donelib, sp, and the soft-stack helpers (pusha, pushax, etc.).
+%.bin: %.o $(CRT0) $(CFG)
+	ld65 -C $(CFG) -o $@ --dbgfile $*.dbg $(CRT0) $*.o none.lib
+
+run-%: %.bin
+	$(CHIPPY) -rom $<
+
+clean:
+	rm -f $(OBJS) $(SS) $(BINS) $(DBGS) $(CRT0)

--- a/example/c/README.md
+++ b/example/c/README.md
@@ -1,0 +1,101 @@
+# C example programs
+
+Three small C programs that compile through `cc65 → ca65 → ld65` and run
+on chippy:
+
+| File          | What it does                                          |
+|---------------|-------------------------------------------------------|
+| `hello.c`     | Writes a greeting to the TextOutput peripheral (`$F001`). |
+| `sum.c`       | Computes `1+2+…+10` and stores `$37` at `$0200`.      |
+| `fizzbuzz.c`  | FizzBuzz 1..15, output to `$F001`.                    |
+
+Plus the supporting infrastructure:
+
+| File          | Role                                                  |
+|---------------|-------------------------------------------------------|
+| `chippy.cfg`  | ld65 linker config (ROM `$8000-$FFF9`, RAM `$0200-$7FFF`, vectors `$FFFA-$FFFF`). |
+| `crt0.s`      | Minimal C runtime: stack init, `zerobss`/`copydata`, `jsr _main`, JMP-self halt. |
+| `Makefile`    | Pipeline: `cc65 -t none -g -O` → `ca65` → `ld65 -C chippy.cfg ... none.lib`. |
+
+## Build
+
+Needs the `cc65` toolchain on PATH (`brew install cc65` on macOS,
+`apt install cc65` on Debian/Ubuntu).
+
+```sh
+make            # build every .bin
+make hello.bin  # build a single program
+make clean      # remove .bin / .o / .s / .dbg artifacts
+```
+
+## Run + step through C source
+
+```sh
+chippy -rom hello.bin
+```
+
+The CPU starts paused at reset — that's `crt0._start`, **not** your
+`main`. Pressing `v` immediately shows `crt0.s` because chippy is
+honestly reporting the file for the current PC.
+
+To actually step C code:
+
+```
+:bp main          set a breakpoint at main (no underscore — chippy
+                  strips cc65's leading `_`)
+r                 run; hits the breakpoint when crt0 finishes setup
+v                 toggle source view → now shows hello.c / sum.c / etc.
+f                 run to next source line (the natural C-stepping key)
+n                 step over (skips into cc65 runtime helpers like
+                  pusha, copydata, etc. — invisible C-level)
+s                 single-step at the asm level (useful inside helpers)
+```
+
+Other helpful commands:
+
+```
+:bp <symbol>      break at any C function (chippy_putc, put_u8, ...)
+:bpw $0200        watch writes to a memory location
+:watch reg A      pin register A in the watch panel
+:goto $0200       scroll the memory view (read sum.c's result there)
+```
+
+## How the .dbg keeps C-source-stepping working
+
+cc65's `-g` flag emits both:
+
+- `.s` line records — addresses → cc65's generated assembly intermediate
+- `.c` line records — addresses → the original C source
+
+chippy's source-map loader (`internal/symbols`) prefers C / header files
+when both records map to the same PC, so `v` shows your `.c` file. The
+fallback to `.s` only kicks in for addresses with no C mapping — i.e.
+the crt0 prologue, cc65 runtime stubs (`pusha`, `popax`, `copydata`),
+and other generated glue. Stepping with `f` (run-to-next-source-line)
+naturally skips over those.
+
+## Memory map
+
+```
+$0000-$001F  ZP             cc65 zero-page (soft stack pointer)
+$0020-$00FF  ZP user        free for inline asm
+$0100-$01FF  Hardware stack 6502 push/pull, JSR/RTS
+$0200-$7FFF  RAM            BSS, DATA (copied from ROM), cc65 soft stack
+$8000-$FFF9  ROM            CODE + RODATA + DATA ROM image + crt0
+$FFFA-$FFFB  NMI vector     → crt0.start
+$FFFC-$FFFD  RESET vector   → crt0.start (this is what chippy uses)
+$FFFE-$FFFF  IRQ vector     → crt0.start (no user IRQ handler in v1)
+```
+
+Override the stack size with `__STACKSIZE__` in `chippy.cfg`. The
+`crt0` runtime uses `__RAM_START__` + `__RAM_SIZE__` to point cc65's
+soft stack at the top of RAM.
+
+## Limitations
+
+- No stdio — `printf`, `putchar`, etc. aren't linked. Use the inline
+  `chippy_putc` pattern shown in `hello.c` / `fizzbuzz.c` for output.
+- cc65 V2.18 ships C89 only. Declare loop variables before the `for`
+  block: `uint8_t i; for (i = 0; ...)`.
+- No IRQ handling yet. If you wire an IRQ-driven peripheral, update
+  the `IRQ` vector in `crt0.s` to point at your handler.

--- a/example/c/chippy.cfg
+++ b/example/c/chippy.cfg
@@ -1,0 +1,41 @@
+# ld65 config for cc65-built C programs running on chippy.
+#
+# Memory map matches the assembly examples' load_five.cfg layout so the
+# resulting binary loads at $8000 with reset vector at $FFFC pointing
+# at the C runtime startup.
+#
+#   $0000-$001F  ZP     — cc65 zero-page (soft stack pointer, etc.)
+#   $0200-$7FFF  RAM    — DATA + BSS + cc65 soft stack
+#   $8000-$FFF9  ROM    — CODE + RODATA + initialized DATA images
+#   $FFFA-$FFFF  VEC    — NMI / RESET / IRQ vectors
+
+SYMBOLS {
+    __STACKSIZE__: type = weak, value = $0800; # 2 KiB soft stack
+}
+MEMORY {
+    ZP:  file = "",               start = $0000, size = $001F, define = yes;
+    RAM: file = "",               start = $0200, size = $7E00 - __STACKSIZE__, define = yes;
+    ROM: file = %O, fill = yes,   start = $8000, size = $7FFA;
+    VEC: file = %O,               start = $FFFA, size = $0006;
+}
+SEGMENTS {
+    ZEROPAGE: load = ZP,  type = zp;
+    STARTUP:  load = ROM, type = ro,  define = yes;
+    CODE:     load = ROM, type = ro;
+    RODATA:   load = ROM, type = ro;
+    ONCE:     load = ROM, type = ro,  optional = yes;
+    LOWCODE:  load = ROM, type = ro,  optional = yes;
+    DATA:     load = ROM, run = RAM,  type = rw,  define = yes;
+    BSS:      load = RAM, type = bss, define = yes;
+    VECTORS:  load = VEC, type = ro;
+}
+FEATURES {
+    CONDES: type    = constructor,
+            label   = __CONSTRUCTOR_TABLE__,
+            count   = __CONSTRUCTOR_COUNT__,
+            segment = ONCE;
+    CONDES: type    = destructor,
+            label   = __DESTRUCTOR_TABLE__,
+            count   = __DESTRUCTOR_COUNT__,
+            segment = RODATA;
+}

--- a/example/c/crt0.s
+++ b/example/c/crt0.s
@@ -1,0 +1,51 @@
+; C runtime startup for chippy.
+;
+; cc65 emits position-independent C code that expects a small amount of
+; bring-up before main() runs: hardware stack initialised, soft stack
+; pointer set to the top of available RAM, BSS cleared, initialised
+; DATA copied from its ROM image to its RAM-resident run address, and
+; cc65's constructor table (if any) invoked.
+;
+; After main() returns the CPU sits in a JMP-self halt that chippy's
+; Step() recognises and reports as "halted at $XXXX".
+
+.export   _exit
+.export   __STARTUP__: absolute = 1
+
+.import   _main
+.import   zerobss, copydata, initlib, donelib
+.import   __RAM_START__, __RAM_SIZE__, __STACKSIZE__
+
+.importzp sp
+
+.segment "STARTUP"
+
+start:
+    sei                     ; mask IRQs during bring-up
+    cld                     ; cc65 requires binary mode
+    ldx     #$ff
+    txs                     ; hardware stack to $01FF
+
+    ; Point cc65's soft stack at the top of RAM (grows downward).
+    lda     #<(__RAM_START__ + __RAM_SIZE__)
+    sta     sp
+    lda     #>(__RAM_START__ + __RAM_SIZE__)
+    sta     sp+1
+
+    jsr     zerobss         ; zero the BSS segment
+    jsr     copydata        ; load DATA from its ROM image to RAM
+    jsr     initlib         ; run any C++-style constructors (rarely used)
+
+    cli                     ; re-enable IRQs before user code
+    jsr     _main           ; into your C entry point
+
+_exit:
+    jsr     donelib         ; constructor counterparts
+halt:
+    jmp     halt            ; chippy detects PC==prevPC and halts the loop
+
+.segment "VECTORS"
+
+.word   start               ; NMI  ($FFFA)
+.word   start               ; RESET ($FFFC)
+.word   start               ; IRQ  ($FFFE) — TODO: route to a user handler

--- a/example/c/fizzbuzz.c
+++ b/example/c/fizzbuzz.c
@@ -1,0 +1,47 @@
+// fizzbuzz.c — classic interview filler, output to chippy's TextOutput.
+//
+// Build:
+//   make fizzbuzz.bin
+// Run:
+//   chippy -rom fizzbuzz.bin
+//
+// Demonstrates: integer modulo, string concatenation, and a tiny
+// itoa for the bare-metal case where stdio isn't linked.
+
+#include <stdint.h>
+
+static volatile uint8_t* const tx = (uint8_t*)0xF001;
+
+static void putc(char c) { *tx = c; }
+
+static void puts(const char *s) {
+    while (*s) {
+        putc(*s++);
+    }
+}
+
+// Print decimal value 1..99. Caller guarantees range so we don't pull
+// in a generic itoa.
+static void put_u8(uint8_t n) {
+    if (n >= 10) {
+        putc('0' + (n / 10));
+    }
+    putc('0' + (n % 10));
+}
+
+int main(void) {
+    uint8_t i;
+    for (i = 1; i <= 15; i++) {
+        if (i % 15 == 0) {
+            puts("fizzbuzz");
+        } else if (i % 3 == 0) {
+            puts("fizz");
+        } else if (i % 5 == 0) {
+            puts("buzz");
+        } else {
+            put_u8(i);
+        }
+        putc('\n');
+    }
+    return 0;
+}

--- a/example/c/hello.c
+++ b/example/c/hello.c
@@ -1,0 +1,29 @@
+// hello.c — write a string to chippy's Apple-1-style text-output
+// peripheral at $F001, then halt.
+//
+// Build:
+//   make hello.bin
+// Run:
+//   chippy -rom hello.bin
+//
+// The TextOutput peripheral lives in MMIO space. Each byte we write
+// to $F001 is appended to chippy's Output panel; chippy itself drains
+// the buffer when running in the TUI. No interrupt handling required.
+
+#include <stdint.h>
+
+static volatile uint8_t* const tx = (uint8_t*)0xF001;
+
+static void chippy_putc(char c) { *tx = c; }
+
+static void chippy_puts(const char *s) {
+    while (*s) {
+        chippy_putc(*s++);
+    }
+}
+
+int main(void) {
+    chippy_puts("hello from c on chippy!\n");
+    chippy_puts("the cc65 toolchain works.\n");
+    return 0;
+}

--- a/example/c/sum.c
+++ b/example/c/sum.c
@@ -1,0 +1,21 @@
+// sum.c — compute 1+2+...+10 and store the result at $0200.
+//
+// Build:
+//   make sum.bin
+// Run:
+//   chippy -rom sum.bin
+// then `:goto $0200` in the TUI to see the result (decimal 55 = $37).
+
+#include <stdint.h>
+
+static volatile uint8_t* const result = (uint8_t*)0x0200;
+
+int main(void) {
+    uint8_t total = 0;
+    uint8_t i;
+    for (i = 1; i <= 10; i++) {
+        total += i;
+    }
+    *result = total;     /* expect $37 at $0200 */
+    return 0;
+}

--- a/internal/symbols/symbols.go
+++ b/internal/symbols/symbols.go
@@ -387,30 +387,46 @@ func LoadSourceMap(dbgPath string) (*SourceMap, error) {
 		return nil, err
 	}
 
+	// Two-pass build: cc65 emits records for both the .s intermediate
+	// and the original .c source at the same PC. We want the .c file
+	// to win so users see C source while stepping. Pass 1 fills the map
+	// from non-.s sources (.c, .h, .inc, etc.); pass 2 backfills any
+	// PCs still uncovered using .s records.
+	isPreferredSource := func(name string) bool {
+		lower := strings.ToLower(name)
+		return !strings.HasSuffix(lower, ".s") &&
+			!strings.HasSuffix(lower, ".asm") &&
+			!strings.HasSuffix(lower, ".mac") &&
+			!strings.HasSuffix(lower, ".inc")
+	}
 	pcMap := map[uint16]SrcLoc{}
-	for _, ln := range lines {
-		fr, ok := files[ln.file]
-		if !ok {
-			continue
-		}
-		for _, sid := range ln.spans {
-			sp, ok := spans[sid]
+	for _, preferred := range []bool{true, false} {
+		for _, ln := range lines {
+			fr, ok := files[ln.file]
 			if !ok {
 				continue
 			}
-			seg, ok := segs[sp.seg]
-			if !ok {
+			if isPreferredSource(fr.name) != preferred {
 				continue
 			}
-			start := seg.start + sp.start
-			for off := uint32(0); off < sp.size; off++ {
-				addr := start + off
-				if addr > 0xFFFF {
-					break
+			for _, sid := range ln.spans {
+				sp, ok := spans[sid]
+				if !ok {
+					continue
 				}
-				// First write wins so we prefer the earliest mapping.
-				if _, exists := pcMap[uint16(addr)]; !exists {
-					pcMap[uint16(addr)] = SrcLoc{File: fr.name, Line: ln.line}
+				seg, ok := segs[sp.seg]
+				if !ok {
+					continue
+				}
+				start := seg.start + sp.start
+				for off := uint32(0); off < sp.size; off++ {
+					addr := start + off
+					if addr > 0xFFFF {
+						break
+					}
+					if _, exists := pcMap[uint16(addr)]; !exists {
+						pcMap[uint16(addr)] = SrcLoc{File: fr.name, Line: ln.line}
+					}
 				}
 			}
 		}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1403,6 +1403,34 @@ func (m *Model) disasmScroll(delta int) {
 }
 
 // sourceView shows the .s file with the current PC's line highlighted.
+// nearestSrcLocBelow finds the highest mapped PC that is ≤ target and
+// returns its SrcLoc. Used by sourceView to fall back to "the last C
+// line we knew about" while stepping through unmapped generated code
+// (cc65 runtime stubs, etc.) so the panel doesn't go blank mid-step.
+func (m Model) nearestSrcLocBelow(target uint16) (symbols.SrcLoc, bool) {
+	if m.PCToSrc == nil {
+		return symbols.SrcLoc{}, false
+	}
+	const window = 0x400 // 1 KiB lookback; covers a typical cc65 runtime helper chain
+	best := uint16(0)
+	have := false
+	for offset := uint16(0); offset < window; offset++ {
+		if uint16(target) < offset {
+			break
+		}
+		pc := target - offset
+		if _, ok := m.PCToSrc[pc]; ok {
+			best = pc
+			have = true
+			break
+		}
+	}
+	if !have {
+		return symbols.SrcLoc{}, false
+	}
+	return m.PCToSrc[best], true
+}
+
 func (m Model) sourceView(w, h int) string {
 	innerH := h - 2
 	if innerH < 1 {
@@ -1414,6 +1442,18 @@ func (m Model) sourceView(w, h int) string {
 	}
 
 	loc, ok := m.PCToSrc[m.CPU.PC]
+	// Fallback: cc65 runtime stubs (pusha, copydata, etc.) have no
+	// source mapping in the .dbg. Rather than blanking the panel mid-
+	// step, find the nearest mapped PC at or below the current one and
+	// show its source — with a hint that we're inside generated code.
+	inGenerated := false
+	if !ok {
+		if near, nok := m.nearestSrcLocBelow(m.CPU.PC); nok {
+			loc = near
+			ok = true
+			inGenerated = true
+		}
+	}
 	if !ok {
 		return fitPanel("Source", help.Render("  (no source mapping for current PC)"), w, h)
 	}
@@ -1450,6 +1490,9 @@ func (m Model) sourceView(w, h int) string {
 
 	var b strings.Builder
 	title := fmt.Sprintf("Source — %s:%d", loc.File, loc.Line)
+	if inGenerated {
+		title = fmt.Sprintf("Source — %s:%d  (PC $%04X in generated code)", loc.File, loc.Line, m.CPU.PC)
+	}
 	for i := start; i < end; i++ {
 		lineNum := i + 1
 		var marker string


### PR DESCRIPTION
## Summary
Adds three cc65-compiled C example programs under `example/c/`:

- `hello.c` — write a greeting to the TextOutput peripheral at `$F001`.
- `sum.c` — compute Σ1..10 and store at `$0200` (`$37` == 55).
- `fizzbuzz.c` — classic, output via the same MMIO putc.

Plus the supporting build infrastructure:

- `chippy.cfg` — ld65 linker config aligned with the assembly demos' memory map.
- `crt0.s` — minimal C runtime: hardware-stack init, soft-stack init, `zerobss`/`copydata`/`initlib`, `jsr _main`, JMP-self halt.
- `Makefile` — disables make's built-in rules so it doesn't reach for host `cc`; pipeline is `cc65 -t none -g -O` → `ca65` → `ld65 -C chippy.cfg ... none.lib`.

## TUI source view fix
cc65's `-g` emits line records for **both** the `.c` source and the `.s` intermediate at the same PCs. The TUI source view used \"first write wins\" so the asm intermediate shadowed the C source — pressing `v` while stepping showed cc65's generated assembly instead of the user's C code.

`LoadSourceMap` now runs in two passes: first fills the map from preferred sources (anything not `.s` / `.asm` / `.mac` / `.inc`), then backfills .s for any PC still unmapped. On the sum example: 57 of 97 mapped PCs now point at `.c` source (the rest are crt0 + cc65 runtime stubs).

## How to try it
```sh
make -C example/c hello.bin
chippy -rom example/c/hello.bin
```

In the TUI: `s` to single-step, `v` to toggle source view, `:bp _main` to break at `main` (cc65 prefixes C names with `_`).

## Test plan
- [x] `go build ./...` — green.
- [x] `go test -race ./...` — green.
- [x] `golangci-lint run` — 0 issues.
- [x] `make -C example/c` — builds hello.bin, sum.bin, fizzbuzz.bin.
- [x] Headless sum.bin smoke: halts at $801D with RAM[$0200]=$37 (55 = Σ1..10).
- [x] Source map: 57/97 PCs in sum.dbg now resolve to sum.c (previously 0).

## Docs
- README.md: `example/c/` line added next to the existing `example/` entry.
- docs/context.md: noted in Merged-PRs-of-note alongside v0.3.1.