### PR TITLE
feat(tui): immediate window (expression REPL)

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -175,6 +175,7 @@ Bus chain: `CPU → tui.WBus → cpu.MMIO → cpu.RAM`
 - CMOS NOP fills + interrupt D-clear (issue #99): WDC-spec NOP widths for undefined CMOS slots ($44=ZP, $54/$D4/$F4=ZPX, $DC/$FC=ABS, $5C=ABS-quirky 8-cycle). BRK / serviceIRQ / serviceNMI now clear D on CMOS variant (NMOS bug preserved). Klaus 65C02 functional test now passes end-to-end and runs unconditionally in CI.
 - v0.3.1 — patch release after the CMOS correctness pass.
 - `example/c/` — cc65-based C example programs (hello, sum, fizzbuzz) with shared `chippy.cfg` linker config + minimal `crt0.s` runtime. Builds via `make -C example/c`; runs via `chippy -rom example/c/<prog>.bin`. Source-map loader updated to prefer `.c` files over `.s` intermediates when both are recorded for the same PC, so the TUI source view (`v`) shows C source while stepping.
+- Immediate window (issue #70): `I` opens a modal REPL backed by `internal/expr`. Each Enter evaluates the buffer against current CPU state, appends `expr → result` to scrollback. `↑` recalls the last expression. Result formatting matches DAP's evaluate response so both surfaces report identical values.
 
 ### Open issues
 - #22 (homebrew-core) — blocked on stars

--- a/internal/tui/immediate.go
+++ b/internal/tui/immediate.go
@@ -1,0 +1,133 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/nkane/chippy/internal/expr"
+)
+
+// ImmediateEntry is one row in the immediate-window scrollback. Result is
+// pre-formatted (with the `$XX` width-by-magnitude shape `evaluate` uses)
+// or an error string if the expression didn't compile / eval.
+type ImmediateEntry struct {
+	Expr   string
+	Result string
+	Err    bool
+}
+
+// immediateCap is the max number of scrollback rows kept in memory and
+// rendered. Old entries fall off the top.
+const immediateCap = 200
+
+// updateImmediate owns input while the immediate window is open. Same
+// key conventions as the `:` prompt: Esc closes, Enter evaluates,
+// backspace pops, ctrl+c quits.
+func (m Model) updateImmediate(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc":
+		m.ImmediateActive = false
+		m.ImmediateBuf = ""
+		m.Status = "immediate window closed"
+		return m, m.scheduleTick()
+	case "ctrl+c":
+		m.saveState()
+		return m, tea.Quit
+	case "enter":
+		expr := strings.TrimSpace(m.ImmediateBuf)
+		m.ImmediateBuf = ""
+		if expr == "" {
+			return m, m.scheduleTick()
+		}
+		entry := m.evaluateImmediate(expr)
+		m.ImmediateHistory = append(m.ImmediateHistory, entry)
+		if len(m.ImmediateHistory) > immediateCap {
+			m.ImmediateHistory = m.ImmediateHistory[len(m.ImmediateHistory)-immediateCap:]
+		}
+		return m, m.scheduleTick()
+	case "backspace":
+		if len(m.ImmediateBuf) > 0 {
+			m.ImmediateBuf = m.ImmediateBuf[:len(m.ImmediateBuf)-1]
+		}
+		return m, m.scheduleTick()
+	case "up":
+		// Recall last expression into the buffer.
+		if n := len(m.ImmediateHistory); n > 0 {
+			m.ImmediateBuf = m.ImmediateHistory[n-1].Expr
+		}
+		return m, m.scheduleTick()
+	}
+	if len(msg.Runes) > 0 {
+		m.ImmediateBuf += string(msg.Runes)
+	}
+	return m, m.scheduleTick()
+}
+
+// evaluateImmediate compiles + runs `src` against the current CPU state.
+// Width-by-magnitude hex formatting matches the DAP `evaluate` response
+// so the two surfaces show identical results for the same expression.
+func (m *Model) evaluateImmediate(src string) ImmediateEntry {
+	fn, err := expr.Compile(src, m.Syms)
+	if err != nil {
+		return ImmediateEntry{Expr: src, Result: err.Error(), Err: true}
+	}
+	v := fn(m.CPU, m.RAM)
+	return ImmediateEntry{Expr: src, Result: formatImmediateResult(v)}
+}
+
+func formatImmediateResult(v uint32) string {
+	switch {
+	case v <= 0xFF:
+		return fmt.Sprintf("$%02X  (%d)", v, v)
+	case v <= 0xFFFF:
+		return fmt.Sprintf("$%04X  (%d)", v, v)
+	}
+	return fmt.Sprintf("$%08X  (%d)", v, v)
+}
+
+// immediateModal renders the immediate-window overlay. Scrollback at top
+// shows `expr → result` pairs, errors highlighted; current input line at
+// bottom with a reversed cursor.
+func (m Model) immediateModal() string {
+	exprStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("213")).Bold(true)
+	resultStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("108"))
+	errStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("203")).Italic(true)
+	dim := lipgloss.NewStyle().Foreground(lipgloss.Color("244")).Italic(true)
+	cursor := lipgloss.NewStyle().Reverse(true).Render(" ")
+
+	const maxRows = 16
+	hist := m.ImmediateHistory
+	if len(hist) > maxRows {
+		hist = hist[len(hist)-maxRows:]
+	}
+
+	var b strings.Builder
+	b.WriteString(titleStyle.Render("immediate"))
+	b.WriteString("\n\n")
+	if len(hist) == 0 {
+		b.WriteString(dim.Render("  expressions evaluate against current CPU state\n"))
+		b.WriteString(dim.Render("  examples: A + X    [$0200]    PC >= main    A == $42\n"))
+		b.WriteString(dim.Render("  ↑ recalls last; Esc closes\n"))
+		b.WriteString("\n")
+	}
+	for _, e := range hist {
+		line := fmt.Sprintf("  %s  →  ", exprStyle.Render(e.Expr))
+		if e.Err {
+			line += errStyle.Render(e.Result)
+		} else {
+			line += resultStyle.Render(e.Result)
+		}
+		b.WriteString(line + "\n")
+	}
+	b.WriteString("\n")
+	b.WriteString(exprStyle.Render("> ") + m.ImmediateBuf + cursor)
+
+	return lipgloss.NewStyle().
+		Border(lipgloss.DoubleBorder()).
+		BorderForeground(lipgloss.Color("213")).
+		Padding(1, 3).
+		Render(b.String())
+}

--- a/internal/tui/immediate_test.go
+++ b/internal/tui/immediate_test.go
@@ -1,0 +1,63 @@
+package tui
+
+import (
+	"testing"
+
+	"github.com/nkane/chippy/internal/cpu"
+)
+
+func newImmediateModel() Model {
+	c := cpu.New(cpu.NewRAM())
+	return New(c, cpu.NewRAM())
+}
+
+func TestImmediate_EvaluateBasic(t *testing.T) {
+	m := newImmediateModel()
+	m.CPU.A = 0x11
+	m.CPU.X = 0x22
+	got := m.evaluateImmediate("A + X")
+	if got.Err {
+		t.Fatalf("eval error: %s", got.Result)
+	}
+	if got.Result != "$33  (51)" {
+		t.Fatalf("want $33 (51), got %q", got.Result)
+	}
+}
+
+func TestImmediate_MemoryDeref(t *testing.T) {
+	m := newImmediateModel()
+	m.RAM.Write(0x0200, 0xAB)
+	got := m.evaluateImmediate("[$0200]")
+	if got.Err {
+		t.Fatalf("eval error: %s", got.Result)
+	}
+	if got.Result != "$AB  (171)" {
+		t.Fatalf("want $AB (171), got %q", got.Result)
+	}
+}
+
+func TestImmediate_BadExpression(t *testing.T) {
+	m := newImmediateModel()
+	got := m.evaluateImmediate("A +")
+	if !got.Err {
+		t.Fatalf("malformed expression should report error")
+	}
+}
+
+func TestImmediate_FormatWidthByMagnitude(t *testing.T) {
+	cases := []struct {
+		v    uint32
+		want string
+	}{
+		{0x42, "$42  (66)"},
+		{0xFF, "$FF  (255)"},
+		{0x100, "$0100  (256)"},
+		{0xFFFF, "$FFFF  (65535)"},
+		{0x10000, "$00010000  (65536)"},
+	}
+	for _, c := range cases {
+		if got := formatImmediateResult(c.v); got != c.want {
+			t.Errorf("formatImmediateResult($%X): want %q, got %q", c.v, c.want, got)
+		}
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -139,6 +139,14 @@ type Model struct {
 	// the runtime cost. Nil disables the feature; default cap is set in New.
 	Rewind *rewindRing
 
+	// Immediate window — a modal REPL over the chippy expression grammar.
+	// `I` opens, Esc closes; while open, all keystrokes feed
+	// updateImmediate. Each Enter compiles + evaluates the buffer against
+	// current CPU state and appends `{Expr, Result}` to ImmediateHistory.
+	ImmediateActive  bool
+	ImmediateBuf     string
+	ImmediateHistory []ImmediateEntry
+
 	// Disassembly viewport: when DisasmFollow is true (default), the panel
 	// re-anchors on PC each frame. User scroll keys flip it off and pin
 	// DisasmAnchor as the address shown at the top of the window.
@@ -300,6 +308,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.MemEditing {
 			return m.updateMemEdit(msg)
 		}
+		// Immediate window owns input while open.
+		if m.ImmediateActive {
+			return m.updateImmediate(msg)
+		}
 
 		switch msg.String() {
 		case "q", "ctrl+c":
@@ -386,6 +398,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			s, _ := m.Rewind.Pop()
 			m.CPU.Restore(s, m.RAM)
 			m.Status = fmt.Sprintf("rewind -> $%04X (depth %d)", m.CPU.PC, m.Rewind.Len())
+		case "I":
+			m.ImmediateActive = true
+			m.ImmediateBuf = ""
+			m.Status = "immediate window"
 		case "b":
 			if _, ok := m.Breakpoints[m.CPU.PC]; ok {
 				delete(m.Breakpoints, m.CPU.PC)
@@ -873,6 +889,8 @@ func (m Model) View() string {
 		bodyBlock = lipgloss.Place(m.W, bodyHeight, lipgloss.Center, lipgloss.Center, m.helpModal())
 	case m.ShowBPs:
 		bodyBlock = lipgloss.Place(m.W, bodyHeight, lipgloss.Center, lipgloss.Center, m.bpModal())
+	case m.ImmediateActive:
+		bodyBlock = lipgloss.Place(m.W, bodyHeight, lipgloss.Center, lipgloss.Center, m.immediateModal())
 	default:
 		bodyBlock = lipgloss.PlaceHorizontal(m.W, lipgloss.Center, body)
 	}
@@ -974,6 +992,12 @@ func helpPages() [][]helpSection {
 				{"Tab", "complete verb or symbol (after :bp etc.)"},
 				{"Ctrl-R", "reverse-incremental search history (Ctrl-R again = next)"},
 				{"Esc", "cancel prompt or RI search"},
+			}},
+			{"Immediate window", [][2]string{
+				{"I", "open expression REPL"},
+				{"<expr>", "evaluate against CPU state (A+X, [$0200], PC>=main, …)"},
+				{"↑", "recall last expression"},
+				{"Esc", "close"},
 			}},
 			{"Breakpoints", [][2]string{
 				{":bp X", "toggle plain bp at addr/symbol/file.s:42"},


### PR DESCRIPTION
Closes #70.

## Summary
Press `I` to open a modal REPL over chippy's expression grammar. Type `A + X`, `[$0200]`, `PC >= main`, etc., hit Enter, see the result in the scrollback. `↑` recalls the last expression; Esc closes.

Same compiler as conditional breakpoints (`:bp X if E`) and the DAP `evaluate` request — three surfaces now share `internal/expr` and report identical values for the same expression.

## Result formatting
Width-by-magnitude hex with decimal in parentheses:

- `$42  (66)` — byte
- `$0100  (256)` — word
- `$00010000  (65536)` — wider

Matches the DAP evaluate response shape.

## Scope choices
- v1 history is in-memory only; the `:` prompt's `~/.chippy/history` is separate. Persisting immediate-window history is a follow-up — noted in #70.
- 200-row scrollback cap with FIFO eviction.
- No assignment yet (`[$0200] = $42`). The grammar doesn't support it; would need a small parser extension.
- Single-line input only. Multi-line expressions can be filed if anyone asks.

## Test plan
- [x] `go build ./...` — green.
- [x] `go test -race ./...` — 4 new tests: register arithmetic, memory deref, malformed-expression error path, format-width table.
- [x] `golangci-lint run` — 0 issues.
- [x] Live tmux smoke: `I` opens modal, three expressions (`A+X`, `PC`, `[$8000]`) evaluate against `example/c/hello.bin` state.

## Docs
- Help-modal page 3 grows a new \"Immediate window\" section.
- docs/context.md notes the merge.