### PR TITLE
feat(cpu): peripheral snapshots for reverse-step parity (#62)

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -176,10 +176,11 @@ Bus chain: `CPU → tui.WBus → cpu.MMIO → cpu.RAM`
 - v0.3.1 — patch release after the CMOS correctness pass.
 - `example/c/` — cc65-based C example programs (hello, sum, fizzbuzz) with shared `chippy.cfg` linker config + minimal `crt0.s` runtime. Builds via `make -C example/c`; runs via `chippy -rom example/c/<prog>.bin`. Source-map loader updated to prefer `.c` files over `.s` intermediates when both are recorded for the same PC, so the TUI source view (`v`) shows C source while stepping.
 - Immediate window (issue #70): `I` opens a modal REPL backed by `internal/expr`. Each Enter evaluates the buffer against current CPU state, appends `expr → result` to scrollback. `↑` recalls the last expression. Result formatting matches DAP's evaluate response so both surfaces report identical values.
+- Peripheral snapshots (issue #62): `cpu.Snapshot` grew a `Peripherals map[string][]byte` field; TUI and DAP both capture TextOutput buffer + Keyboard latch state into it on every push and restore on every pop. New `peripheral.Snapshotable` interface (Snapshot/Restore); both TextOutput and KeyboardInput implement it. Reverse-step across an MMIO write/read no longer desyncs the visible peripheral state.
 
 ### Open issues
 - #22 (homebrew-core) — blocked on stars
-- Post-DAP follow-ups: #59 Klaus 65C02, #60 BCD test, #61 CMOS e2e in CI, #62 peripheral snapshots, #63 VIA 6522, #64 trace replay, #65 mem-watch conditional expressions, #66 CoW RAM snapshots, #67 WebAssembly playground
+- Post-DAP follow-ups: #63 VIA 6522, #64 trace replay, #65 mem-watch conditional expressions, #66 CoW RAM snapshots, #67 WebAssembly playground
 
 ---
 

--- a/internal/cpu/snapshot.go
+++ b/internal/cpu/snapshot.go
@@ -2,14 +2,14 @@ package cpu
 
 // Snapshot captures the full architectural and bookkeeping state of a CPU
 // plus a copy of the RAM contents. Used by the TUI's reverse-step ring
-// buffer.
+// buffer and the DAP server's stepBack handler.
 //
-// Caveat: peripherals connected via MMIO are NOT snapshotted — only RAM is.
-// Reverse-stepping across a peripheral side-effect (e.g. a keyboard register
-// drain) won't unwind the peripheral. Acceptable in v1 because real
-// reverse-debugging sessions rarely span peripheral interactions; programs
-// that do should pause the CPU first or use a longer ring with periodic
-// peripheral snapshots in a follow-up.
+// Peripherals connected via MMIO snapshot themselves into the
+// Peripherals map — the cpu package defers the actual serialisation to
+// each peripheral (which implements peripheral.Snapshotable). The map
+// is keyed by a caller-chosen string (typically the peripheral's base
+// MMIO address like "$F001"). cpu.CPU.Snapshot leaves the map nil; the
+// caller (TUI or DAP server) fills it before pushing to the ring.
 type Snapshot struct {
 	A, X, Y, SP, P byte
 	PC             uint16
@@ -21,6 +21,11 @@ type Snapshot struct {
 	nmiPending  bool
 
 	RAM [0x10000]byte
+
+	// Peripherals: optional per-MMIO-device state. Populated by the
+	// caller (TUI / DAP) at snapshot time, consumed at restore time.
+	// Keys are caller-defined; values are peripheral-defined bytes.
+	Peripherals map[string][]byte
 }
 
 // Snapshot returns a full state capture of the CPU + the supplied RAM. ram

--- a/internal/dap/stepback_test.go
+++ b/internal/dap/stepback_test.go
@@ -103,6 +103,80 @@ func TestStepBack_NextAndStepOutPushSnapshots(t *testing.T) {
 	}
 }
 
+// TestStepBack_RestoresTextOutputBuffer drives the CPU to write two
+// bytes through the $F001 MMIO write port, then rewinds one step at a
+// time and confirms the TextOutput buffer rewinds along with the CPU.
+// Without peripheral snapshots the buffer would keep growing as steps
+// rewound.
+func TestStepBack_RestoresTextOutputBuffer(t *testing.T) {
+	// $8000: A9 41        LDA #'A'
+	// $8002: 8D 01 F0     STA $F001
+	// $8005: A9 42        LDA #'B'
+	// $8007: 8D 01 F0     STA $F001
+	prog := []byte{0xA9, 0x41, 0x8D, 0x01, 0xF0, 0xA9, 0x42, 0x8D, 0x01, 0xF0}
+	s, _, _ := newStoppedServer(t, prog)
+
+	step := Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "stepIn",
+	}
+	for i := 0; i < 4; i++ {
+		s.handleStepIn(step)
+	}
+	if got := s.textOut.String(); got != "AB" {
+		t.Fatalf("after 4 steps textOut want %q; got %q", "AB", got)
+	}
+
+	back := Request{
+		ProtocolMessage: ProtocolMessage{Seq: 2, Type: "request"},
+		Command:         "stepBack",
+	}
+	s.handleStepBack(back) // undo STA #2 -> "A"
+	if got := s.textOut.String(); got != "A" {
+		t.Fatalf("after 1 stepBack textOut want %q; got %q", "A", got)
+	}
+	s.handleStepBack(back) // undo LDA #'B' -> "A"
+	s.handleStepBack(back) // undo STA #1 -> ""
+	if got := s.textOut.String(); got != "" {
+		t.Fatalf("after 3 stepBacks textOut want empty; got %q", got)
+	}
+}
+
+// TestStepBack_RestoresKeyboardLatch confirms that when the CPU reads
+// $F004 mid-program, stepBack re-arms the keyboard latch so a re-step
+// observes the same byte.
+func TestStepBack_RestoresKeyboardLatch(t *testing.T) {
+	// $8000: AD 04 F0     LDA $F004   ; drains keyboard latch
+	prog := []byte{0xAD, 0x04, 0xF0}
+	s, _, _ := newStoppedServer(t, prog)
+
+	s.keyIn.Push('K')
+	if !s.keyIn.Ready() {
+		t.Fatalf("precondition: keyboard should be armed")
+	}
+
+	step := Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "stepIn",
+	}
+	s.handleStepIn(step)
+	if s.keyIn.Ready() {
+		t.Fatalf("post-LDA $F004 latch should be drained")
+	}
+	if s.cpu.A != ('K' | 0x80) {
+		t.Fatalf("A should hold latched key; got $%02X", s.cpu.A)
+	}
+
+	back := Request{
+		ProtocolMessage: ProtocolMessage{Seq: 2, Type: "request"},
+		Command:         "stepBack",
+	}
+	s.handleStepBack(back)
+	if !s.keyIn.Ready() {
+		t.Fatalf("stepBack should re-arm keyboard latch")
+	}
+}
+
 func TestStepBack_CapabilityAdvertised(t *testing.T) {
 	// initialize handshake should now report supportsStepBack:true.
 	var in, out interface {

--- a/internal/dap/steps.go
+++ b/internal/dap/steps.go
@@ -1,5 +1,11 @@
 package dap
 
+import (
+	"fmt"
+
+	"github.com/nkane/chippy/internal/cpu"
+)
+
 // Step controls — continue / next / stepIn / stepOut / pause — plus the
 // thin `threads` handler that 6502 needs (always one virtual thread).
 //
@@ -143,12 +149,44 @@ func (s *Server) handleStepIn(req Request) {
 // snapshotForRewind pushes a pre-step CPU+RAM snapshot onto the ring so
 // stepBack can undo. Matches the TUI's behavior: only explicit-step
 // paths snapshot — continue runs don't, to avoid the 64 KiB/step cost
-// at full throughput.
+// at full throughput. Also captures TextOutput + KeyboardInput state so
+// rewinding across an MMIO read/write doesn't desync peripherals.
 func (s *Server) snapshotForRewind() {
 	if s.rewind == nil || s.cpu == nil || s.ram == nil {
 		return
 	}
-	s.rewind.Push(s.cpu.Snapshot(s.ram))
+	snap := s.cpu.Snapshot(s.ram)
+	s.capturePeripherals(&snap)
+	s.rewind.Push(snap)
+}
+
+func (s *Server) capturePeripherals(snap *cpu.Snapshot) {
+	if s.textOut == nil && s.keyIn == nil {
+		return
+	}
+	snap.Peripherals = map[string][]byte{}
+	if s.textOut != nil {
+		snap.Peripherals[fmt.Sprintf("$%04X", s.textOut.Addr)] = s.textOut.Snapshot()
+	}
+	if s.keyIn != nil {
+		snap.Peripherals[fmt.Sprintf("$%04X", s.keyIn.DataAddr)] = s.keyIn.Snapshot()
+	}
+}
+
+func (s *Server) restorePeripherals(snap cpu.Snapshot) {
+	if snap.Peripherals == nil {
+		return
+	}
+	if s.textOut != nil {
+		if state, ok := snap.Peripherals[fmt.Sprintf("$%04X", s.textOut.Addr)]; ok {
+			s.textOut.Restore(state)
+		}
+	}
+	if s.keyIn != nil {
+		if state, ok := snap.Peripherals[fmt.Sprintf("$%04X", s.keyIn.DataAddr)]; ok {
+			s.keyIn.Restore(state)
+		}
+	}
 }
 
 // handleStepBack pops one snapshot and restores. Same protocol shape as
@@ -165,6 +203,7 @@ func (s *Server) handleStepBack(req Request) {
 	}
 	snap, _ := s.rewind.Pop()
 	s.cpu.Restore(snap, s.ram)
+	s.restorePeripherals(snap)
 	s.sendResponse(req, nil)
 	s.sendEvent("stopped", StoppedEventBody{Reason: "step", ThreadID: 1, AllThreadsStopped: true})
 }

--- a/internal/peripheral/keyboard.go
+++ b/internal/peripheral/keyboard.go
@@ -63,3 +63,25 @@ func (k *KeyboardInput) Write(addr uint16, v byte) {
 // Ready reports whether a keystroke is pending. Exposed for tests and the
 // TUI status line.
 func (k *KeyboardInput) Ready() bool { return k.ready }
+
+// Snapshot packs the keyboard's latched state into two bytes: data byte
+// and a ready flag (0 or 1). Implements peripheral.Snapshotable.
+func (k *KeyboardInput) Snapshot() []byte {
+	r := byte(0)
+	if k.ready {
+		r = 1
+	}
+	return []byte{k.data, r}
+}
+
+// Restore unpacks the two-byte form back into the keyboard. Out-of-shape
+// inputs are tolerated (clears state).
+func (k *KeyboardInput) Restore(state []byte) {
+	if len(state) < 2 {
+		k.data = 0
+		k.ready = false
+		return
+	}
+	k.data = state[0]
+	k.ready = state[1] != 0
+}

--- a/internal/peripheral/snapshot_test.go
+++ b/internal/peripheral/snapshot_test.go
@@ -1,0 +1,75 @@
+package peripheral
+
+import (
+	"bytes"
+	"testing"
+)
+
+// TextOutput Snapshot/Restore must round-trip the buffered bytes and not
+// alias the live buffer — mutations after Snapshot must not bleed into
+// the captured state.
+func TestTextOutputSnapshotRestoreRoundtrip(t *testing.T) {
+	tx := NewTextOutput(0xF001)
+	for _, b := range []byte("hello") {
+		tx.Write(0xF001, b)
+	}
+	snap := tx.Snapshot()
+
+	// Mutate after snapshot. Captured state must not change.
+	tx.Write(0xF001, '!')
+	if !bytes.Equal(snap, []byte("hello")) {
+		t.Fatalf("snapshot aliased live buf; got %q", snap)
+	}
+
+	tx.Restore(snap)
+	if got := tx.String(); got != "hello" {
+		t.Fatalf("Restore want %q; got %q", "hello", got)
+	}
+}
+
+// Restoring an empty snapshot must clear the buffer.
+func TestTextOutputRestoreEmpty(t *testing.T) {
+	tx := NewTextOutput(0xF001)
+	tx.Write(0xF001, 'A')
+	tx.Restore(nil)
+	if tx.Len() != 0 {
+		t.Fatalf("Restore(nil) should clear; len=%d", tx.Len())
+	}
+}
+
+// Keyboard Snapshot/Restore must round-trip both the data byte and the
+// ready latch — restoring across an MMIO data read should re-arm the
+// peripheral.
+func TestKeyboardSnapshotRestoreReadyArmed(t *testing.T) {
+	k := NewKeyboardInput(0xF004, 0xF005)
+	k.Push('Q')
+	snap := k.Snapshot()
+
+	// Drain the latch — emulates the 6502 reading $F004 mid-rewind window.
+	_ = k.Read(0xF004)
+	if k.Ready() {
+		t.Fatalf("precondition: data read should clear ready")
+	}
+
+	k.Restore(snap)
+	if !k.Ready() {
+		t.Fatalf("Restore should re-arm ready flag")
+	}
+	if v := k.Read(0xF004); v != ('Q' | 0x80) {
+		t.Fatalf("Restore should re-arm data; got %02X want %02X", v, byte('Q')|0x80)
+	}
+}
+
+// Restoring an empty/short snapshot is a hard clear.
+func TestKeyboardRestoreShort(t *testing.T) {
+	k := NewKeyboardInput(0xF004, 0xF005)
+	k.Push('A')
+	k.Restore(nil)
+	if k.Ready() {
+		t.Fatalf("Restore(nil) should clear ready")
+	}
+	k.Restore([]byte{0x42}) // 1 byte — malformed
+	if k.Ready() {
+		t.Fatalf("Restore(short) should clear ready")
+	}
+}

--- a/internal/peripheral/snapshotable.go
+++ b/internal/peripheral/snapshotable.go
@@ -1,0 +1,18 @@
+package peripheral
+
+// Snapshotable is the contract peripherals implement so the reverse-step
+// ring can round-trip their state alongside CPU + RAM. Implementations
+// must:
+//
+//   - Snapshot() returns a copy that's safe to retain after the
+//     peripheral keeps mutating.
+//   - Restore(state) replaces the peripheral's state with the supplied
+//     bytes. Tolerant of zero-length / malformed input (clears).
+//
+// Wire format is opaque to the caller — only the same peripheral type
+// will ever decode bytes it produced. The CPU side keys snapshots by
+// peripheral identity, not by serialised contents.
+type Snapshotable interface {
+	Snapshot() []byte
+	Restore(state []byte)
+}

--- a/internal/peripheral/textoutput.go
+++ b/internal/peripheral/textoutput.go
@@ -54,3 +54,18 @@ func (t *TextOutput) Len() int { return len(t.buf) }
 
 // Reset clears the buffer.
 func (t *TextOutput) Reset() { t.buf = t.buf[:0] }
+
+// Snapshot returns a deep copy of the buffer for reverse-step restoration.
+// Implements peripheral.Snapshotable so the CPU snapshot ring can round-trip
+// peripheral state alongside CPU + RAM.
+func (t *TextOutput) Snapshot() []byte {
+	out := make([]byte, len(t.buf))
+	copy(out, t.buf)
+	return out
+}
+
+// Restore replaces the buffer with the supplied bytes. The slice is copied
+// so the caller can reuse its backing array.
+func (t *TextOutput) Restore(state []byte) {
+	t.buf = append(t.buf[:0], state...)
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -397,6 +397,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			s, _ := m.Rewind.Pop()
 			m.CPU.Restore(s, m.RAM)
+			m.restoreperipherals(s)
 			m.Status = fmt.Sprintf("rewind -> $%04X (depth %d)", m.CPU.PC, m.Rewind.Len())
 		case "I":
 			m.ImmediateActive = true
@@ -553,9 +554,46 @@ func keyMsgToByte(msg tea.KeyMsg) (byte, bool) {
 // cost per cycle at multi-MHz throughput.
 func (m *Model) step() int {
 	if m.Rewind != nil {
-		m.Rewind.Push(m.CPU.Snapshot(m.RAM))
+		s := m.CPU.Snapshot(m.RAM)
+		m.captureperipherals(&s)
+		m.Rewind.Push(s)
 	}
 	return m.CPU.Step()
+}
+
+// captureperipherals fills the snapshot's Peripherals map with the
+// current state of every wired MMIO device. Keys are the peripheral's
+// base MMIO address as `"$XXXX"` so restore can route bytes back to
+// the right device.
+func (m *Model) captureperipherals(s *cpu.Snapshot) {
+	if m.TextOut == nil && m.Keyboard == nil {
+		return
+	}
+	s.Peripherals = map[string][]byte{}
+	if m.TextOut != nil {
+		s.Peripherals[fmt.Sprintf("$%04X", m.TextOut.Addr)] = m.TextOut.Snapshot()
+	}
+	if m.Keyboard != nil {
+		s.Peripherals[fmt.Sprintf("$%04X", m.Keyboard.DataAddr)] = m.Keyboard.Snapshot()
+	}
+}
+
+// restoreperipherals applies a snapshot's Peripherals map back to the
+// wired devices. Missing keys leave the corresponding device untouched.
+func (m *Model) restoreperipherals(s cpu.Snapshot) {
+	if s.Peripherals == nil {
+		return
+	}
+	if m.TextOut != nil {
+		if state, ok := s.Peripherals[fmt.Sprintf("$%04X", m.TextOut.Addr)]; ok {
+			m.TextOut.Restore(state)
+		}
+	}
+	if m.Keyboard != nil {
+		if state, ok := s.Peripherals[fmt.Sprintf("$%04X", m.Keyboard.DataAddr)]; ok {
+			m.Keyboard.Restore(state)
+		}
+	}
 }
 
 // statusAfterStep updates Status reflecting halt or normal stepping outcome.


### PR DESCRIPTION
## Summary
- Closes #62. Reverse-step rewound CPU+RAM but left peripheral state stale; rewinding across a `STA $F001` or `LDA $F004` produced a CPU history that disagreed with what the TUI text panel or keyboard latch reported.
- Adds `peripheral.Snapshotable` (Snapshot/Restore). TextOutput round-trips its buffer; KeyboardInput packs data+ready into 2 bytes.
- `cpu.Snapshot` grows a `Peripherals map[string][]byte`. cpu.CPU.Snapshot leaves it nil — caller (TUI or DAP) fills it before pushing, so the cpu package stays unaware of MMIO.
- TUI's `m.step()` / `<` keypath and DAP's `snapshotForRewind` / `handleStepBack` capture+restore the map keyed by peripheral base address.

## Test plan
- [x] `go test ./internal/peripheral/...` — new snapshot-roundtrip tests (snapshot stability across post-snap mutation; malformed-Restore tolerance for both peripherals).
- [x] `go test ./internal/dap/...` — new DAP-level stepBack tests: writing two bytes via `STA $F001` then rewinding step-by-step shows TextOutput buffer shrinks alongside the CPU; reading the keyboard latch then stepBack re-arms it.
- [x] `go test -race ./...` green.
- [x] `golangci-lint run` — 0 issues.