### PR TITLE
feat(cpu): copy-on-write page snapshots, free-run rewind (#66)

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -177,10 +177,11 @@ Bus chain: `CPU → tui.WBus → cpu.MMIO → cpu.RAM`
 - `example/c/` — cc65-based C example programs (hello, sum, fizzbuzz) with shared `chippy.cfg` linker config + minimal `crt0.s` runtime. Builds via `make -C example/c`; runs via `chippy -rom example/c/<prog>.bin`. Source-map loader updated to prefer `.c` files over `.s` intermediates when both are recorded for the same PC, so the TUI source view (`v`) shows C source while stepping.
 - Immediate window (issue #70): `I` opens a modal REPL backed by `internal/expr`. Each Enter evaluates the buffer against current CPU state, appends `expr → result` to scrollback. `↑` recalls the last expression. Result formatting matches DAP's evaluate response so both surfaces report identical values.
 - Peripheral snapshots (issue #62): `cpu.Snapshot` grew a `Peripherals map[string][]byte` field; TUI and DAP both capture TextOutput buffer + Keyboard latch state into it on every push and restore on every pop. New `peripheral.Snapshotable` interface (Snapshot/Restore); both TextOutput and KeyboardInput implement it. Reverse-step across an MMIO write/read no longer desyncs the visible peripheral state.
+- CoW RAM snapshots (issue #66): `cpu.Snapshot.RAM [0x10000]byte` is now `Pages map[byte][256]byte`. RAM gained an opt-in (`EnableShadow`) page-level write barrier that captures pre-write images. Two-phase capture protocol — caller takes the snapshot before the step, resets the shadow, runs the step (or multi-step sweep), then claims `snap.Pages = ram.TakeShadow()` and pushes. Typical 1-instr snap is ~hundreds of bytes vs 64 KiB before, so free-run now pushes on every step in both TUI tickMsg loop and DAP runLoop — reverse-step works across an unattended continue. 1000-iteration tight loop costs <1 MiB of total ring storage (validated by test).
 
 ### Open issues
 - #22 (homebrew-core) — blocked on stars
-- Post-DAP follow-ups: #63 VIA 6522, #64 trace replay, #65 mem-watch conditional expressions, #66 CoW RAM snapshots, #67 WebAssembly playground
+- Post-DAP follow-ups: #63 VIA 6522, #64 trace replay, #65 mem-watch conditional expressions, #67 WebAssembly playground
 
 ---
 

--- a/internal/cpu/memory.go
+++ b/internal/cpu/memory.go
@@ -6,19 +6,72 @@ type Bus interface {
 	Write(addr uint16, v byte)
 }
 
-// RAM is a simple 64KB flat memory.
+// RAM is a simple 64KB flat memory with an optional page-level
+// copy-on-write shadow. When the shadow is enabled, every Write captures
+// the affected 256-byte page's pre-write contents on first touch within
+// the current epoch. Reverse-step snapshots use that delta to undo a
+// step without copying the full 64 KiB.
 type RAM struct {
-	Data [0x10000]byte
+	Data   [0x10000]byte
+	shadow map[byte][256]byte // nil = shadow tracking disabled
 }
 
 func NewRAM() *RAM { return &RAM{} }
 
-func (r *RAM) Read(addr uint16) byte     { return r.Data[addr] }
-func (r *RAM) Write(addr uint16, v byte) { r.Data[addr] = v }
+func (r *RAM) Read(addr uint16) byte { return r.Data[addr] }
 
-// Load copies bytes into RAM at addr.
+func (r *RAM) Write(addr uint16, v byte) {
+	if r.shadow != nil {
+		page := byte(addr >> 8)
+		if _, ok := r.shadow[page]; !ok {
+			var img [256]byte
+			base := int(page) << 8
+			copy(img[:], r.Data[base:base+256])
+			r.shadow[page] = img
+		}
+	}
+	r.Data[addr] = v
+}
+
+// Load copies bytes into RAM at addr. Bypasses the shadow on purpose —
+// ROM-load happens before any rewind epoch exists and shouldn't pollute
+// it.
 func (r *RAM) Load(addr uint16, data []byte) {
 	for i, b := range data {
 		r.Data[int(addr)+i] = b
+	}
+}
+
+// EnableShadow turns on the page-level write barrier. Idempotent.
+// Called by surfaces that intend to take rewind snapshots (TUI + DAP);
+// leaving it off keeps Write a single bounds-checked store for tests
+// and headless harnesses that don't care about reverse-step.
+func (r *RAM) EnableShadow() {
+	if r.shadow == nil {
+		r.shadow = make(map[byte][256]byte)
+	}
+}
+
+// ShadowEnabled reports whether the page-level write barrier is active.
+func (r *RAM) ShadowEnabled() bool { return r.shadow != nil }
+
+// TakeShadow returns the accumulated before-image pages since the last
+// reset and starts a fresh epoch. Returns nil if shadow tracking is
+// off. Caller owns the returned map.
+func (r *RAM) TakeShadow() map[byte][256]byte {
+	if r.shadow == nil {
+		return nil
+	}
+	out := r.shadow
+	r.shadow = make(map[byte][256]byte)
+	return out
+}
+
+// ResetShadow clears the current epoch without returning its contents.
+// Use after a manual write or Restore that shouldn't be folded into the
+// next snapshot's delta.
+func (r *RAM) ResetShadow() {
+	if r.shadow != nil {
+		r.shadow = make(map[byte][256]byte)
 	}
 }

--- a/internal/cpu/snapshot.go
+++ b/internal/cpu/snapshot.go
@@ -1,15 +1,29 @@
 package cpu
 
-// Snapshot captures the full architectural and bookkeeping state of a CPU
-// plus a copy of the RAM contents. Used by the TUI's reverse-step ring
-// buffer and the DAP server's stepBack handler.
+// Snapshot captures the architectural and bookkeeping state of a CPU
+// plus enough RAM delta to undo one execution unit. Used by the TUI's
+// reverse-step ring buffer and the DAP server's stepBack handler.
+//
+// RAM is stored as page-level deltas (Pages: page-index → before-image
+// of that 256-byte page). To restore: copy each page's image back. A
+// typical instruction touches 0–1 pages, so a snapshot costs ~hundreds
+// of bytes instead of 64 KiB. Worst case (an instruction that somehow
+// rewrites every page) collapses back to ~64 KiB.
+//
+// Capture protocol — two-phase, caller-driven, so a single snapshot
+// can wrap a multi-step sweep (next-over-JSR, runToLine):
+//
+//  1. snap := cpu.Snapshot(ram)      // regs BEFORE the step
+//  2. (capture peripherals; the caller fills snap.Peripherals)
+//  3. ram.ResetShadow()              // start a fresh page-delta epoch
+//  4. cpu.Step() / multi-step sweep  // writes populate the shadow
+//  5. snap.Pages = ram.TakeShadow()  // claim the before-images
+//  6. ring.Push(snap)
 //
 // Peripherals connected via MMIO snapshot themselves into the
 // Peripherals map — the cpu package defers the actual serialisation to
-// each peripheral (which implements peripheral.Snapshotable). The map
-// is keyed by a caller-chosen string (typically the peripheral's base
-// MMIO address like "$F001"). cpu.CPU.Snapshot leaves the map nil; the
-// caller (TUI or DAP server) fills it before pushing to the ring.
+// each peripheral (which implements peripheral.Snapshotable). Keys are
+// caller-defined; cpu.CPU.Snapshot leaves the map nil.
 type Snapshot struct {
 	A, X, Y, SP, P byte
 	PC             uint16
@@ -20,7 +34,10 @@ type Snapshot struct {
 	irqLine     bool
 	nmiPending  bool
 
-	RAM [0x10000]byte
+	// Pages: page-index → before-image of that 256-byte page. Apply
+	// each page back to RAM at restore time to undo writes performed
+	// during the snapshot's epoch.
+	Pages map[byte][256]byte
 
 	// Peripherals: optional per-MMIO-device state. Populated by the
 	// caller (TUI / DAP) at snapshot time, consumed at restore time.
@@ -28,11 +45,11 @@ type Snapshot struct {
 	Peripherals map[string][]byte
 }
 
-// Snapshot returns a full state capture of the CPU + the supplied RAM. ram
-// must be the same backing store the CPU's Bus eventually resolves to —
-// snapshots aren't useful if MMIO wraps a different RAM.
+// Snapshot returns a regs-only state capture. Page deltas and
+// peripheral state are filled in by the caller after Step using
+// ram.TakeShadow() — see the capture protocol on Snapshot.
 func (c *CPU) Snapshot(ram *RAM) Snapshot {
-	s := Snapshot{
+	return Snapshot{
 		A: c.A, X: c.X, Y: c.Y, SP: c.SP, P: c.P,
 		PC:          c.PC,
 		Cycles:      c.Cycles,
@@ -41,13 +58,13 @@ func (c *CPU) Snapshot(ram *RAM) Snapshot {
 		irqLine:     c.irqLine,
 		nmiPending:  c.nmiPending,
 	}
-	s.RAM = ram.Data
-	return s
 }
 
-// Restore writes the snapshot back into the CPU and RAM. The opcodes pointer
-// is left alone — Variant doesn't change at runtime, so the table binding
-// from New/Reset remains valid.
+// Restore writes the snapshot back into the CPU and applies any page
+// deltas back to RAM. The opcodes pointer is left alone — Variant
+// doesn't change at runtime, so the table binding from New/Reset
+// remains valid. The shadow epoch is reset because the writes Restore
+// just performed are not part of any user-visible step.
 func (c *CPU) Restore(s Snapshot, ram *RAM) {
 	c.A, c.X, c.Y, c.SP, c.P = s.A, s.X, s.Y, s.SP, s.P
 	c.PC = s.PC
@@ -56,5 +73,9 @@ func (c *CPU) Restore(s Snapshot, ram *RAM) {
 	c.extraCycles = s.extraCycles
 	c.irqLine = s.irqLine
 	c.nmiPending = s.nmiPending
-	ram.Data = s.RAM
+	for page, img := range s.Pages {
+		base := int(page) << 8
+		copy(ram.Data[base:base+256], img[:])
+	}
+	ram.ResetShadow()
 }

--- a/internal/cpu/snapshot_test.go
+++ b/internal/cpu/snapshot_test.go
@@ -14,9 +14,14 @@ func TestSnapshotRestore_RoundTrip(t *testing.T) {
 	ram.Write(cpu.VecReset+1, 0x80)
 	c := cpu.New(ram)
 
+	// CoW snapshot protocol (issue #66): regs captured before step,
+	// pages claimed after via ram.TakeShadow().
+	ram.EnableShadow()
 	pre := c.Snapshot(ram)
+	ram.ResetShadow()
 	c.Step() // LDA #$42 -> A=$42, PC=$8002
 	c.Step() // STA $0200 -> RAM[$0200]=$42, PC=$8005
+	pre.Pages = ram.TakeShadow()
 	if c.A != 0x42 {
 		t.Fatalf("post-step A want $42, got $%02X", c.A)
 	}
@@ -38,6 +43,7 @@ func TestSnapshotRestore_RoundTrip(t *testing.T) {
 
 func TestSnapshotRestore_BookkeepingFields(t *testing.T) {
 	ram := cpu.NewRAM()
+	ram.EnableShadow()
 	ram.Write(cpu.VecReset, 0x00)
 	ram.Write(cpu.VecReset+1, 0x80)
 	ram.Load(0x8000, []byte{0xEA, 0xEA}) // NOP NOP
@@ -60,15 +66,113 @@ func TestSnapshotRestore_BookkeepingFields(t *testing.T) {
 	}
 }
 
-func TestSnapshot_RAMIsDeepCopy(t *testing.T) {
+// CoW page tracking: a tight 1000-iteration loop that writes to two RAM
+// pages should produce 1000 snapshots whose total before-image volume
+// is well under 1 MiB. Validates issue #66's acceptance criterion.
+func TestSnapshotCoW_TightLoopRingFitsInMemoryBudget(t *testing.T) {
 	ram := cpu.NewRAM()
+	ram.EnableShadow()
+	// LDX #$00              ; $8000 A2 00
+	// loop: STX $0200       ; $8002 8E 00 02
+	//       INX             ; $8005 E8
+	//       STX $0300       ; $8006 8E 00 03
+	//       JMP loop        ; $8009 4C 02 80
+	ram.Load(0x8000, []byte{
+		0xA2, 0x00,
+		0x8E, 0x00, 0x02,
+		0xE8,
+		0x8E, 0x00, 0x03,
+		0x4C, 0x02, 0x80,
+	})
+	ram.Write(cpu.VecReset, 0x00)
+	ram.Write(cpu.VecReset+1, 0x80)
+	c := cpu.New(ram)
+
+	const N = 1000
+	snaps := make([]cpu.Snapshot, 0, N)
+	totalBytes := 0
+	for i := 0; i < N; i++ {
+		snap := c.Snapshot(ram)
+		ram.ResetShadow()
+		c.Step()
+		snap.Pages = ram.TakeShadow()
+		totalBytes += len(snap.Pages) * 256
+		snaps = append(snaps, snap)
+	}
+
+	if totalBytes >= 1<<20 {
+		t.Fatalf("CoW snapshots should fit in <1 MiB for 1000-step tight loop; got %d bytes", totalBytes)
+	}
+
+	// Rewinding all the way back must restore the CPU to its pre-loop state.
+	for i := len(snaps) - 1; i >= 0; i-- {
+		c.Restore(snaps[i], ram)
+	}
+	if c.PC != 0x8000 {
+		t.Fatalf("full rewind want PC $8000; got $%04X", c.PC)
+	}
+	if c.X != 0 {
+		t.Fatalf("full rewind want X=0; got $%02X", c.X)
+	}
+}
+
+// Cross-page writes (STA $00FF,Y where the target wraps into page $01)
+// must capture both pages' before-images independently.
+func TestSnapshotCoW_TwoPagesInOneStep(t *testing.T) {
+	ram := cpu.NewRAM()
+	ram.EnableShadow()
+	ram.Write(0x00FF, 0xAA)
+	ram.Write(0x0100, 0xBB)
+
+	ram.ResetShadow()
+	ram.Write(0x00FF, 0x11)
+	ram.Write(0x0100, 0x22)
+	delta := ram.TakeShadow()
+
+	if len(delta) != 2 {
+		t.Fatalf("two-page mutation want 2 entries in delta; got %d", len(delta))
+	}
+	if delta[0x00][0xFF] != 0xAA {
+		t.Fatalf("page 0 before-image want $AA; got $%02X", delta[0x00][0xFF])
+	}
+	if delta[0x01][0x00] != 0xBB {
+		t.Fatalf("page 1 before-image want $BB; got $%02X", delta[0x01][0x00])
+	}
+}
+
+// Without EnableShadow(), Write must NOT track anything. Existing
+// non-rewind callers (Klaus harness, decimal tests) rely on zero
+// overhead.
+func TestSnapshotCoW_ShadowDisabledByDefault(t *testing.T) {
+	ram := cpu.NewRAM()
+	if ram.ShadowEnabled() {
+		t.Fatalf("shadow should be disabled by default")
+	}
+	ram.Write(0x1234, 0xFF)
+	if d := ram.TakeShadow(); d != nil {
+		t.Fatalf("TakeShadow on disabled RAM should return nil; got %v", d)
+	}
+}
+
+func TestSnapshot_PageDeltaIsIndependent(t *testing.T) {
+	ram := cpu.NewRAM()
+	ram.EnableShadow()
 	ram.Write(0x0500, 0xAA)
 	c := cpu.New(ram)
 
+	// Capture pre-step regs, then mutate, then claim the delta. Restore
+	// should roll back to $AA and the captured before-image must not
+	// alias the live RAM.
 	s := c.Snapshot(ram)
-	ram.Write(0x0500, 0xBB) // mutate after snapshot
+	ram.ResetShadow()
+	ram.Write(0x0500, 0xBB)
+	s.Pages = ram.TakeShadow()
+
+	// Mutate live RAM again AFTER claiming the delta. The captured page
+	// image must not change.
+	ram.Write(0x0500, 0xCC)
 	c.Restore(s, ram)
 	if ram.Read(0x0500) != 0xAA {
-		t.Fatalf("snapshot.RAM must be an independent copy: got $%02X, want $AA", ram.Read(0x0500))
+		t.Fatalf("delta page must round-trip cleanly: got $%02X, want $AA", ram.Read(0x0500))
 	}
 }

--- a/internal/dap/attach.go
+++ b/internal/dap/attach.go
@@ -41,6 +41,7 @@ func (s *Server) AttachExisting(cfg AttachConfig) error {
 	}
 	s.cpu = cfg.CPU
 	s.ram = cfg.RAM
+	s.ram.EnableShadow() // CoW page tracking powers stepBack (issue #66).
 	s.mmio = cfg.MMIO
 	s.tracer = cfg.Tracer
 	s.syms = cfg.Syms

--- a/internal/dap/server.go
+++ b/internal/dap/server.go
@@ -342,6 +342,7 @@ func (s *Server) bootDebuggee(args LaunchArguments) error {
 
 	s.cpu = c
 	s.ram = ram
+	s.ram.EnableShadow() // CoW page tracking powers stepBack (issue #66).
 	s.mmio = mmio
 	s.tracer = tracer
 	s.textOut = textOut

--- a/internal/dap/stepback_test.go
+++ b/internal/dap/stepback_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestStepBack_RestoresPriorState(t *testing.T) {
@@ -174,6 +175,45 @@ func TestStepBack_RestoresKeyboardLatch(t *testing.T) {
 	s.handleStepBack(back)
 	if !s.keyIn.Ready() {
 		t.Fatalf("stepBack should re-arm keyboard latch")
+	}
+}
+
+// TestStepBack_FreeRunRecordsDeltas confirms that runLoop now pushes
+// snapshots during free-run (issue #66). After a continue/pause sweep
+// the ring should be non-empty and stepBack must walk us back through
+// each instruction the run loop executed.
+func TestStepBack_FreeRunRecordsDeltas(t *testing.T) {
+	// LDA #$00 ; LDA #$11 ; LDA #$22 ; JMP $8000 — non-degenerate loop.
+	// Each LDA leaves a distinct register trace so we can verify rewind.
+	prog := []byte{0xA9, 0x00, 0xA9, 0x11, 0xA9, 0x22, 0x4C, 0x00, 0x80}
+	s, _, _ := newStoppedServer(t, prog)
+
+	s.handleContinue(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "continue",
+	})
+
+	// Let the run loop execute a handful of iterations before pausing.
+	// Reading s.rewind.Len() here would race with runLoop's pushes; the
+	// run loop synchronizes only via runDone after pauseRequested.
+	time.Sleep(40 * time.Millisecond)
+	s.pauseRequested.Store(true)
+	<-s.runDone
+
+	if s.rewind.Len() == 0 {
+		t.Fatalf("free-run should have pushed snapshots; ring is empty")
+	}
+
+	// stepBack twice. PC should walk backwards across the executed instructions.
+	preBackPC := s.cpu.PC
+	back := Request{
+		ProtocolMessage: ProtocolMessage{Seq: 2, Type: "request"},
+		Command:         "stepBack",
+	}
+	s.handleStepBack(back)
+	s.handleStepBack(back)
+	if s.cpu.PC == preBackPC {
+		t.Fatalf("stepBack after free-run should rewind PC; stuck at $%04X", preBackPC)
 	}
 }
 

--- a/internal/dap/steps.go
+++ b/internal/dap/steps.go
@@ -93,7 +93,7 @@ func (s *Server) runLoop() {
 			reason = "exception"
 			break
 		}
-		s.cpu.Step()
+		s.stepWithSnapshot(func() { s.cpu.Step() })
 		if s.cpu.Halted {
 			reason = "exception"
 			break
@@ -113,7 +113,7 @@ func (s *Server) runLoop() {
 			}
 			// Continue past a non-firing bp: step once so we don't
 			// re-trigger on the same PC immediately.
-			s.cpu.Step()
+			s.stepWithSnapshot(func() { s.cpu.Step() })
 			if s.cpu.Halted {
 				reason = "exception"
 				break
@@ -140,23 +140,26 @@ func (s *Server) handleStepIn(req Request) {
 	if !s.requireStopped(req) {
 		return
 	}
-	s.snapshotForRewind()
-	s.cpu.Step()
+	s.stepWithSnapshot(func() { s.cpu.Step() })
 	s.sendResponse(req, nil)
 	s.sendEvent("stopped", StoppedEventBody{Reason: "step", ThreadID: 1, AllThreadsStopped: true})
 }
 
-// snapshotForRewind pushes a pre-step CPU+RAM snapshot onto the ring so
-// stepBack can undo. Matches the TUI's behavior: only explicit-step
-// paths snapshot — continue runs don't, to avoid the 64 KiB/step cost
-// at full throughput. Also captures TextOutput + KeyboardInput state so
-// rewinding across an MMIO read/write doesn't desync peripherals.
-func (s *Server) snapshotForRewind() {
+// stepWithSnapshot wraps one or more cpu.Step calls in a single rewind
+// snapshot. Captures regs + peripherals BEFORE the step, resets the
+// RAM shadow epoch, runs the step body, and folds the page deltas into
+// the pushed snapshot. Issue #66: CoW deltas keep a wide sweep
+// (next-over-JSR, stepOut) at the same memory cost as a single Step.
+func (s *Server) stepWithSnapshot(body func()) {
 	if s.rewind == nil || s.cpu == nil || s.ram == nil {
+		body()
 		return
 	}
 	snap := s.cpu.Snapshot(s.ram)
 	s.capturePeripherals(&snap)
+	s.ram.ResetShadow()
+	body()
+	snap.Pages = s.ram.TakeShadow()
 	s.rewind.Push(snap)
 }
 
@@ -214,11 +217,12 @@ func (s *Server) handleNext(req Request) {
 	if !s.requireStopped(req) {
 		return
 	}
-	s.snapshotForRewind()
 	op := s.ram.Read(s.cpu.PC)
-	if op != 0x20 {
-		s.cpu.Step()
-	} else {
+	s.stepWithSnapshot(func() {
+		if op != 0x20 {
+			s.cpu.Step()
+			return
+		}
 		retPC := s.cpu.PC + 3
 		for i := 0; i < guardSteps; i++ {
 			s.cpu.Step()
@@ -226,7 +230,7 @@ func (s *Server) handleNext(req Request) {
 				break
 			}
 		}
-	}
+	})
 	s.sendResponse(req, nil)
 	s.sendEvent("stopped", StoppedEventBody{Reason: "step", ThreadID: 1, AllThreadsStopped: true})
 }
@@ -237,17 +241,18 @@ func (s *Server) handleStepOut(req Request) {
 	if !s.requireStopped(req) {
 		return
 	}
-	s.snapshotForRewind()
 	startSP := s.cpu.SP
-	for i := 0; i < guardSteps; i++ {
-		s.cpu.Step()
-		if s.cpu.Halted {
-			break
+	s.stepWithSnapshot(func() {
+		for i := 0; i < guardSteps; i++ {
+			s.cpu.Step()
+			if s.cpu.Halted {
+				break
+			}
+			if s.cpu.SP > startSP {
+				break
+			}
 		}
-		if s.cpu.SP > startSP {
-			break
-		}
-	}
+	})
 	s.sendResponse(req, nil)
 	s.sendEvent("stopped", StoppedEventBody{Reason: "step", ThreadID: 1, AllThreadsStopped: true})
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -163,6 +163,7 @@ type disasmCacheEntry struct {
 }
 
 func New(c *cpu.CPU, r *cpu.RAM) Model {
+	r.EnableShadow() // CoW page tracking powers the rewind ring (issue #66).
 	return Model{
 		CPU:           c,
 		RAM:           r,
@@ -473,7 +474,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.Running {
 			budget := m.runBudget()
 			for i := 0; i < budget; i++ {
-				m.CPU.Step()
+				m.step()
 				if m.CPU.Halted {
 					m.Running = false
 					m.Status = fmt.Sprintf("halted at $%04X", m.CPU.PC)
@@ -547,18 +548,22 @@ func keyMsgToByte(msg tea.KeyMsg) (byte, bool) {
 	return 0, false
 }
 
-// step takes one CPU instruction *and* records a rewind snapshot first so
-// `<` can undo it. Use this in all explicit-step keypaths (`s` / `S` / `n` /
-// `f` and the inner loops of stepOver / runToNextLine). The tickMsg
-// free-run loop calls m.CPU.Step() directly to avoid the 64 KiB snapshot
-// cost per cycle at multi-MHz throughput.
+// step takes one CPU instruction *and* records a rewind snapshot so `<`
+// can undo it. Use this in all explicit-step keypaths (`s` / `S` / `n` /
+// `f` and the inner loops of stepOver / runToNextLine). Snapshots are
+// page-level CoW deltas (issue #66) — typical cost is hundreds of bytes,
+// so the tickMsg free-run loop snapshots per step too.
 func (m *Model) step() int {
-	if m.Rewind != nil {
-		s := m.CPU.Snapshot(m.RAM)
-		m.captureperipherals(&s)
-		m.Rewind.Push(s)
+	if m.Rewind == nil {
+		return m.CPU.Step()
 	}
-	return m.CPU.Step()
+	snap := m.CPU.Snapshot(m.RAM)
+	m.captureperipherals(&snap)
+	m.RAM.ResetShadow()
+	n := m.CPU.Step()
+	snap.Pages = m.RAM.TakeShadow()
+	m.Rewind.Push(snap)
+	return n
 }
 
 // captureperipherals fills the snapshot's Peripherals map with the


### PR DESCRIPTION
## Summary
- Closes #66. `cpu.Snapshot.RAM [0x10000]byte` is replaced by `Pages map[byte][256]byte` — only the 256-byte pages an instruction actually writes are captured (as before-images), so a typical 1-instr snap is ~hundreds of bytes instead of 64 KiB.
- New opt-in page-level write barrier on `cpu.RAM`: `EnableShadow` / `TakeShadow` / `ResetShadow`. TUI's `New(c, r)` and DAP's launch/attach paths call `EnableShadow` so rewind works; other callers (Klaus harness, decimal exhaustive test) pay zero overhead.
- Two-phase capture protocol: caller snapshots regs before the step, resets the shadow, runs the step (or multi-step sweep — next-over-JSR, stepOut), then claims `snap.Pages = ram.TakeShadow()` and pushes. One snap can wrap any sweep.
- TUI `tickMsg` free-run loop and DAP `runLoop` now push a snapshot per step, so reverse-step works across an unattended continue (previously deliberately skipped per #54's perf note).

## Test plan
- [x] `TestSnapshotCoW_TightLoopRingFitsInMemoryBudget` — 1000-iter loop stays under 1 MiB of total ring memory (acceptance criterion from #66).
- [x] `TestSnapshotCoW_TwoPagesInOneStep` — a cross-page store captures both pages' before-images.
- [x] `TestSnapshotCoW_ShadowDisabledByDefault` — non-rewind RAM allocations stay zero-overhead.
- [x] `TestStepBack_FreeRunRecordsDeltas` — DAP runLoop pushes during free-run and stepBack walks back across the captured instructions.
- [x] All other DAP stepBack tests pass with the new internal representation.
- [x] `go test -race ./...` green.
- [x] `go test -tags=klaus,decimal,integration ./...` green — no regressions in the legacy harnesses.
- [x] `golangci-lint run` — 0 issues.