### PR TITLE
fix(peripheral): bound TextOutput buffer + :textsave (#128)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Flags:
 | `-trace` | —       | Write per-instruction execution trace to this file. Also toggleable at runtime via `:trace PATH \| :trace on \| :trace off`. |
 | `-run-on-start` | `false` | Start the CPU running instead of paused. Pair with `-trace` for non-interactive capture (`chippy -rom prog.bin -trace t.log -run-on-start`). |
 | `-dap`  | —       | Run as a [Debug Adapter Protocol](https://microsoft.github.io/debug-adapter-protocol/) server instead of the TUI. Accepts `stdio` (editor pipes stdin/stdout) or `tcp:PORT` (server listens, editor connects out). See [`docs/dap.md`](docs/dap.md) for the request list, supported launch arguments, and VS Code / nvim-dap onboarding. |
+| `-text-buf-cap` | `65536` | TextOutput ($F001) buffer cap in bytes. Older bytes are evicted when full. `0` disables the bound. Dump the live buffer with `:textsave PATH`. |
 
 Examples:
 

--- a/cmd/chippy/main.go
+++ b/cmd/chippy/main.go
@@ -26,6 +26,7 @@ func main() {
 		tracePath  = flag.String("trace", "", "write per-instruction execution trace to this file")
 		runOnStart = flag.Bool("run-on-start", false, "start the CPU running instead of paused (pair with -trace for non-interactive capture)")
 		dapMode    = flag.String("dap", "", "run as a Debug Adapter Protocol server instead of the TUI: 'stdio' or 'tcp:PORT'")
+		textBufCap = flag.Int("text-buf-cap", peripheral.DefaultTextOutputCap, "TextOutput ($F001) buffer cap in bytes; 0 = unbounded")
 	)
 	flag.Parse()
 
@@ -123,7 +124,7 @@ func main() {
 	// program loaded at $F001 would land in RAM and never reach the
 	// peripheral — peripherals live in addresses no ROM should occupy.
 	mmio := cpu.NewMMIO(ram)
-	textOut := peripheral.NewTextOutput(0xF001)
+	textOut := peripheral.NewTextOutputWithCap(0xF001, *textBufCap)
 	keyIn := peripheral.NewKeyboardInput(0xF004, 0xF005)
 	if err := mmio.Register(textOut); err != nil {
 		fmt.Fprintln(os.Stderr, "register text output:", err)

--- a/docs/context.md
+++ b/docs/context.md
@@ -182,6 +182,8 @@ Bus chain: `CPU → tui.WBus → cpu.MMIO → cpu.RAM`
 - WebAssembly playground (issue #67): `cmd/chippy-wasm/` builds a `js/wasm` binary that installs a `window.chippy` global (load / step / run / state / disasm / readMem / textOutput / pushKey / setVariant). `web/` ships the HTML/JS shell — `make -C web serve` builds + serves on :8080. Demos copy from `example/`. ld65/.o pipeline is explicitly out of scope (no shell-out in the browser); .bin / .prg / .hex parsing is inlined in the WASM main. New `wasm` CI job keeps the build target green. GitHub Pages auto-deploy via `pages.yml`.
 - v0.4.0 — release cut after #62 / #66 / #88 / #67 ship.
 - CPU correctness micro-audit (issue #122): WAI ($CB) and STP ($DB) were placeholder NOPs; now WAI halts until any IRQ/NMI (waking even on masked IRQ — falls through to next instruction without dispatching the handler) and STP halts permanently (new `stoppedBySTP` latch; only `Reset()` clears). Regression tests cover the halt/wake matrix plus IZP $FF zero-page wrap, PHP B/U push, IRQ B-clear push, and CMOS RTI D-restore.
+- expr unary minus width-aware (issue #129): `-1` now evaluates to `$FF` instead of `$FFFFFFFF`; pick-smallest-power-of-two-width rule keeps `A == -1` matching a register holding `$FF`. Binary subtraction stays 32-bit modular by design. First-ever tests for `internal/expr/`.
+- TextOutput bounded buffer (issue #128): `peripheral.TextOutput` now drops the oldest quarter when its buffer hits cap (default 64 KiB; `--text-buf-cap` overrides; `0` = unbounded). New `:textsave PATH` TUI command dumps the live buffer to disk. Prevents OOM on long-running programs and keeps reverse-step snapshots bounded.
 
 ### Open issues
 - #22 (homebrew-core) — blocked on stars

--- a/internal/peripheral/textoutput.go
+++ b/internal/peripheral/textoutput.go
@@ -3,6 +3,13 @@
 // space; reads and writes to that region are routed to the device.
 package peripheral
 
+// DefaultTextOutputCap caps the live TextOutput buffer at 64 KiB by
+// default. A long-running program that loops writes to $F001 would
+// otherwise grow the slice without bound (and inflate every reverse-step
+// snapshot along with it). 64 KiB is enough to hold a full screen of
+// output many times over while keeping memory predictable.
+const DefaultTextOutputCap = 64 * 1024
+
 // TextOutput is an Apple-1-style write-only console at a single address
 // (conventionally $F001). Each byte written is appended to an internal
 // buffer that the TUI can render.
@@ -11,13 +18,31 @@ package peripheral
 // lower bits; for chippy we accept the raw byte and let the renderer
 // decide. CR (0x0D) is translated to LF (0x0A) so naive monitor programs
 // produce the line breaks a Unix terminal expects.
+//
+// The buffer is bounded by Cap (zero means unbounded, mostly useful for
+// tests). When a write would overflow, the oldest quarter of the buffer
+// is dropped — amortizing the shift cost across many writes while
+// keeping reverse-step snapshots small.
 type TextOutput struct {
 	Addr uint16
+	Cap  int // 0 = unbounded
 	buf  []byte
 }
 
-// NewTextOutput creates a TextOutput peripheral at addr.
-func NewTextOutput(addr uint16) *TextOutput { return &TextOutput{Addr: addr} }
+// NewTextOutput creates a TextOutput peripheral at addr with the default
+// 64 KiB buffer cap. Use NewTextOutputWithCap to override.
+func NewTextOutput(addr uint16) *TextOutput {
+	return &TextOutput{Addr: addr, Cap: DefaultTextOutputCap}
+}
+
+// NewTextOutputWithCap creates a TextOutput at addr with an explicit
+// buffer cap. cap <= 0 disables bounding.
+func NewTextOutputWithCap(addr uint16, cap int) *TextOutput {
+	if cap < 0 {
+		cap = 0
+	}
+	return &TextOutput{Addr: addr, Cap: cap}
+}
 
 func (t *TextOutput) Range() (uint16, uint16) { return t.Addr, t.Addr }
 
@@ -36,6 +61,15 @@ func (t *TextOutput) Write(addr uint16, v byte) {
 	}
 	// Apple-1 conventions: bit 7 set on the high ASCII. Strip it so the
 	// buffer carries plain 7-bit text.
+	if t.Cap > 0 && len(t.buf) >= t.Cap {
+		// Drop the oldest quarter so the next batch of writes is O(1)
+		// again instead of triggering this shift every byte.
+		drop := t.Cap / 4
+		if drop < 1 {
+			drop = 1
+		}
+		t.buf = append(t.buf[:0], t.buf[drop:]...)
+	}
 	t.buf = append(t.buf, v&0x7F)
 }
 

--- a/internal/peripheral/textoutput_test.go
+++ b/internal/peripheral/textoutput_test.go
@@ -73,3 +73,42 @@ func TestTextOutputBytesIsCopy(t *testing.T) {
 		t.Fatalf("Bytes() must return a copy; internal buffer mutated")
 	}
 }
+
+// Cap=0 keeps the unbounded legacy behavior for tests that want it.
+func TestTextOutputUnboundedWhenCapZero(t *testing.T) {
+	out := NewTextOutputWithCap(0xF001, 0)
+	for i := 0; i < 1<<17; i++ { // 128 KiB — exceeds default cap
+		out.Write(0xF001, byte('A'+i%26))
+	}
+	if out.Len() != 1<<17 {
+		t.Fatalf("Cap=0 should not bound; len=%d", out.Len())
+	}
+}
+
+// Cap bounds the buffer; writes past Cap evict oldest bytes. Confirms
+// total length stays under Cap and the most-recent writes are retained.
+func TestTextOutputCapBoundsLength(t *testing.T) {
+	const cap = 16
+	out := NewTextOutputWithCap(0xF001, cap)
+	for i := 0; i < 1000; i++ {
+		out.Write(0xF001, byte('A'+i%26))
+	}
+	if out.Len() > cap {
+		t.Fatalf("len exceeded cap: %d > %d", out.Len(), cap)
+	}
+	if out.Len() < cap/2 {
+		t.Fatalf("len below half-cap after many writes: %d", out.Len())
+	}
+	// Final byte must be the last one we wrote (i=999, 999%26 = 11, 'A'+11 = 'L').
+	if last := out.Bytes()[out.Len()-1]; last != 'L' {
+		t.Fatalf("tail byte want 'L'; got %q", last)
+	}
+}
+
+// Default constructor picks the 64 KiB cap.
+func TestTextOutputDefaultCap(t *testing.T) {
+	out := NewTextOutput(0xF001)
+	if out.Cap != DefaultTextOutputCap {
+		t.Fatalf("default Cap want %d; got %d", DefaultTextOutputCap, out.Cap)
+	}
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1069,6 +1069,10 @@ func helpPages() [][]helpSection {
 				{"--trace", "CLI flag: enable at startup with given path"},
 				{"--run-on-start", "start running immediately (pair with --trace)"},
 			}},
+			{"Text output ($F001)", [][2]string{
+				{":textsave PATH", "dump TextOutput buffer to a file"},
+				{"--text-buf-cap N", "TextOutput buffer cap in bytes (default 64 KiB; 0 = unbounded)"},
+			}},
 		},
 	}
 }

--- a/internal/tui/prompt.go
+++ b/internal/tui/prompt.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
@@ -372,6 +373,8 @@ func (m *Model) runCommand(line string) string {
 		return fmt.Sprintf("mem bp -$%04X", addr)
 	case "trace":
 		return m.cmdTrace(args)
+	case "textsave":
+		return m.cmdTextSave(args)
 	case "help", "?":
 		m.ShowHelp = true
 		return "help"
@@ -473,4 +476,22 @@ func (m Model) promptLine(width int) string {
 	}
 	text := ":" + m.PromptBuf + cursor
 	return promptStyle.Width(width).Render(text)
+}
+
+// cmdTextSave dumps the TextOutput buffer to a file. Use case: a
+// long-running demo whose output keeps wrapping past the buffer cap.
+//
+//	:textsave PATH
+func (m *Model) cmdTextSave(args []string) string {
+	if m.TextOut == nil {
+		return "textsave: no TextOutput peripheral"
+	}
+	if len(args) == 0 {
+		return "usage: :textsave PATH"
+	}
+	path := args[0]
+	if err := os.WriteFile(path, m.TextOut.Bytes(), 0o644); err != nil {
+		return fmt.Sprintf("textsave: %v", err)
+	}
+	return fmt.Sprintf("textsave -> %s (%d bytes)", path, m.TextOut.Len())
 }


### PR DESCRIPTION
## Summary
- Closes #128. `peripheral.TextOutput.buf` grew unbounded — a runaway program at $F001 inflated the slice without limit, and every reverse-step snapshot deep-copied it. A few seconds of busy output and the ring buffer's memory cost grew linearly with output volume.
- New `DefaultTextOutputCap = 64 KiB`. `NewTextOutput` adopts it; `NewTextOutputWithCap(addr, cap)` overrides; `cap <= 0` disables bounding for tests.
- `Write` drops the oldest quarter when at cap — amortizes the shift cost so steady-state writes stay O(1).
- `--text-buf-cap` CLI flag exposes the override at runtime.
- New `:textsave PATH` TUI command dumps the live buffer to disk.
- README + help-modal updated.

## Test plan
- [x] New peripheral tests: cap-bounds-length (1000 writes against cap=16 keeps len <= cap and preserves tail byte), unbounded-when-cap-zero (128 KiB writes pass through), default-cap (constructor picks 64 KiB).
- [x] `go test -race ./...` green.
- [x] `golangci-lint run` — 0 issues.
- [x] `GOOS=js GOARCH=wasm go build ./cmd/chippy-wasm` — WASM build still green.