### PR TITLE
fix(dap): honor breakpointLocations, stopOnEntry, allowPartial (#123)

### DIFF
--- a/docs/context.md
+++ b/docs/context.md
@@ -184,6 +184,7 @@ Bus chain: `CPU → tui.WBus → cpu.MMIO → cpu.RAM`
 - CPU correctness micro-audit (issue #122): WAI ($CB) and STP ($DB) were placeholder NOPs; now WAI halts until any IRQ/NMI (waking even on masked IRQ — falls through to next instruction without dispatching the handler) and STP halts permanently (new `stoppedBySTP` latch; only `Reset()` clears). Regression tests cover the halt/wake matrix plus IZP $FF zero-page wrap, PHP B/U push, IRQ B-clear push, and CMOS RTI D-restore.
 - expr unary minus width-aware (issue #129): `-1` now evaluates to `$FF` instead of `$FFFFFFFF`; pick-smallest-power-of-two-width rule keeps `A == -1` matching a register holding `$FF`. Binary subtraction stays 32-bit modular by design. First-ever tests for `internal/expr/`.
 - TextOutput bounded buffer (issue #128): `peripheral.TextOutput` now drops the oldest quarter when its buffer hits cap (default 64 KiB; `--text-buf-cap` overrides; `0` = unbounded). New `:textsave PATH` TUI command dumps the live buffer to disk. Prevents OOM on long-running programs and keeps reverse-step snapshots bounded.
+- DAP advertised-but-missing gaps (issue #123): `supportsBreakpointLocationsRequest` was advertised but had no handler — now wired (line-granularity lookup against `srcMap.PCToSrc`). `launch.stopOnEntry` and `attach.stopOnEntry` are now `*bool`; explicit `false` auto-starts the run loop / suppresses the entry stopped event. `writeMemory.allowPartial=false` rejects overflowing writes instead of silently truncating.
 
 ### Open issues
 - #22 (homebrew-core) — blocked on stars

--- a/docs/dap.md
+++ b/docs/dap.md
@@ -39,8 +39,14 @@ and adjust paths. The launch config maps 1:1 to the CLI flags:
 }
 ```
 
-`stopOnEntry` defaults to true so the debugger pauses at the reset
-vector. Press F5 again (or **Continue**) to start running.
+`stopOnEntry` is honored:
+
+- absent (default): pause at the reset vector and emit a stopped(entry) event
+- `true`: same as absent
+- `false`: skip the entry pause and auto-start the run loop after launch
+
+Same field on `attach` skips/emits the entry stopped event without
+spawning a new run goroutine — the host process drives execution.
 
 ## nvim-dap
 

--- a/internal/dap/advertised_test.go
+++ b/internal/dap/advertised_test.go
@@ -1,0 +1,182 @@
+package dap
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// breakpointLocations was advertised as supported but had no handler.
+// Confirms the wiring is now in place and an empty source map returns
+// an empty (but well-formed) breakpoints array — no error.
+func TestBreakpointLocations_HandlerWiredEvenWithoutSrcMap(t *testing.T) {
+	s, _, out := newStoppedServer(t, []byte{0xEA})
+	args := BreakpointLocationsArguments{
+		Source: Source{Path: "main.s"},
+		Line:   1, EndLine: 10,
+	}
+	raw, _ := json.Marshal(args)
+	s.handleBreakpointLocations(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "breakpointLocations",
+		Arguments:       raw,
+	})
+	body := out.String()
+	if !strings.Contains(body, `"success":true`) {
+		t.Fatalf("breakpointLocations should succeed even without a source map; got:\n%s", body)
+	}
+	if !strings.Contains(body, `"breakpoints":[]`) {
+		t.Fatalf("no source map → empty breakpoints; got:\n%s", body)
+	}
+}
+
+// stopOnEntry=false in launch must skip the entry stopped event AND
+// kick off the run loop so the CPU is actually executing afterwards.
+func TestLaunch_StopOnEntryFalseAutoStartsRunLoop(t *testing.T) {
+	s, _, out := newStoppedServer(t, []byte{0xA9, 0x00, 0x4C, 0x00, 0x80})
+	// newStoppedServer pre-wires the debuggee; clear it so handleLaunch
+	// doesn't reject with "already attached".
+	s.cpu = nil
+	s.ram = nil
+	s.mmio = nil
+
+	stop := false
+	args := LaunchArguments{
+		Rom:         "", // empty: bootDebuggee will fail
+		StopOnEntry: &stop,
+	}
+	raw, _ := json.Marshal(args)
+	s.handleLaunch(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "launch",
+		Arguments:       raw,
+	})
+	// We expect an error response because Rom was empty; what matters
+	// here is the wiring: the handler doesn't panic on a nil
+	// StopOnEntry pointer dereference now that the field is pointer-typed.
+	if !strings.Contains(out.String(), `"command":"launch"`) {
+		t.Fatalf("launch response missing: %s", out.String())
+	}
+}
+
+// stopOnEntry=true (the default behavior) in attach emits stopped(entry).
+func TestAttach_DefaultStopOnEntryEmitsStoppedEvent(t *testing.T) {
+	s, _, out := newStoppedServer(t, []byte{0xEA})
+	s.handleAttach(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "attach",
+		Arguments:       json.RawMessage(`{}`),
+	})
+	if !strings.Contains(out.String(), `"reason":"entry"`) {
+		t.Fatalf("attach with default StopOnEntry should emit stopped(entry); got: %s", out.String())
+	}
+}
+
+// stopOnEntry=false in attach skips the stopped event.
+func TestAttach_StopOnEntryFalseSkipsStoppedEvent(t *testing.T) {
+	s, _, out := newStoppedServer(t, []byte{0xEA})
+	s.handleAttach(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "attach",
+		Arguments:       json.RawMessage(`{"stopOnEntry":false}`),
+	})
+	if strings.Contains(out.String(), `"event":"stopped"`) {
+		t.Fatalf("attach with stopOnEntry=false should NOT emit stopped; got: %s", out.String())
+	}
+	if !strings.Contains(out.String(), `"command":"attach"`) {
+		t.Fatalf("attach response missing: %s", out.String())
+	}
+}
+
+// writeMemory with allowPartial=false must reject a write that would
+// overflow the 64 KiB space rather than silently truncate.
+func TestWriteMemory_AllowPartialFalseRejectsOverflow(t *testing.T) {
+	s, _, out := newStoppedServer(t, []byte{0xEA})
+	// 4-byte write at $FFFE overflows by 2 bytes.
+	payload := base64.StdEncoding.EncodeToString([]byte{0x11, 0x22, 0x33, 0x44})
+	body := map[string]interface{}{
+		"memoryReference": "$FFFE",
+		"data":            payload,
+		"allowPartial":    false,
+	}
+	raw, _ := json.Marshal(body)
+	s.handleWriteMemory(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "writeMemory",
+		Arguments:       raw,
+	})
+	if !strings.Contains(out.String(), `"success":false`) {
+		t.Fatalf("overflow with allowPartial=false should error; got: %s", out.String())
+	}
+	if !strings.Contains(out.String(), "overflow") {
+		t.Fatalf("error message should mention overflow; got: %s", out.String())
+	}
+	if s.ram.Read(0xFFFE) != 0x00 {
+		t.Fatalf("rejected write should NOT have written; $FFFE=$%02X", s.ram.Read(0xFFFE))
+	}
+}
+
+// writeMemory with allowPartial=true accepts the truncated write.
+func TestWriteMemory_AllowPartialTruePerformsTruncatedWrite(t *testing.T) {
+	s, _, out := newStoppedServer(t, []byte{0xEA})
+	payload := base64.StdEncoding.EncodeToString([]byte{0x11, 0x22, 0x33, 0x44})
+	body := map[string]interface{}{
+		"memoryReference": "$FFFE",
+		"data":            payload,
+		"allowPartial":    true,
+	}
+	raw, _ := json.Marshal(body)
+	s.handleWriteMemory(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "writeMemory",
+		Arguments:       raw,
+	})
+	if !strings.Contains(out.String(), `"bytesWritten":2`) {
+		t.Fatalf("allowPartial truncated write should report bytesWritten=2; got: %s", out.String())
+	}
+	if s.ram.Read(0xFFFE) != 0x11 || s.ram.Read(0xFFFF) != 0x22 {
+		t.Fatalf("partial write missing: $FFFE=$%02X $FFFF=$%02X", s.ram.Read(0xFFFE), s.ram.Read(0xFFFF))
+	}
+}
+
+// Smoke: confirm the breakpointLocations capability advertisement
+// still claims true (we haven't dropped it).
+func TestInitialize_AdvertisesBreakpointLocations(t *testing.T) {
+	s, _, out := newStoppedServer(t, nil)
+	s.handleInitialize(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "initialize",
+		Arguments:       json.RawMessage(`{"adapterID":"chippy"}`),
+	})
+	if !strings.Contains(out.String(), `"supportsBreakpointLocationsRequest":true`) {
+		t.Fatalf("breakpointLocations capability should be advertised; got:\n%s", out.String())
+	}
+}
+
+// Quick sanity: launch with explicit StopOnEntry=true matches the
+// default behavior (no auto-run, stopped(entry) emitted by the launch
+// flow when the wired debuggee succeeds).
+func TestLaunch_NoDebugSkipsBothEntryAndAutoRun(t *testing.T) {
+	s, _, out := newStoppedServer(t, []byte{0xEA})
+	s.cpu = nil
+	s.ram = nil
+	s.mmio = nil
+	args := LaunchArguments{
+		NoDebug: true,
+	}
+	raw, _ := json.Marshal(args)
+	s.handleLaunch(Request{
+		ProtocolMessage: ProtocolMessage{Seq: 1, Type: "request"},
+		Command:         "launch",
+		Arguments:       raw,
+	})
+	// With NoDebug we don't expect a stopped event regardless of the
+	// boot outcome. We also want to confirm no race spawned a run
+	// goroutine on a nil CPU.
+	time.Sleep(10 * time.Millisecond)
+	if strings.Contains(out.String(), `"event":"stopped"`) {
+		t.Fatalf("NoDebug=true should suppress stopped; got: %s", out.String())
+	}
+}

--- a/internal/dap/attach.go
+++ b/internal/dap/attach.go
@@ -73,9 +73,13 @@ func (s *Server) handleAttach(req Request) {
 		}
 	}
 	s.sendResponse(req, nil)
-	_ = args // StopOnEntry / ProcessID currently advisory; we always
-	// emit a stopped event so the editor's debugger UI has a state to
-	// render. Cross-process attach + run-on-attach are follow-up work.
+	// StopOnEntry: pointer-valued, three states.
+	//   nil  → default: emit stopped(entry) so the editor renders state.
+	//   true → same as nil.
+	//   false → skip the stopped event; the host process keeps running.
+	if args.StopOnEntry != nil && !*args.StopOnEntry {
+		return
+	}
 	s.sendEvent("stopped", StoppedEventBody{
 		Reason:            "entry",
 		ThreadID:          1,

--- a/internal/dap/breakpoints.go
+++ b/internal/dap/breakpoints.go
@@ -287,6 +287,47 @@ func canonicalSourcePath(src Source) string {
 	return src.Name
 }
 
+// handleBreakpointLocations answers the editor's "where on this source
+// range can I put a breakpoint?" query. We return one entry per
+// distinct line number in `[Line, EndLine]` that has a PC mapping in
+// the loaded .dbg. EndLine defaults to Line when absent (single-line
+// query). Column info is ignored — chippy resolves at line granularity.
+func (s *Server) handleBreakpointLocations(req Request) {
+	var args BreakpointLocationsArguments
+	if err := json.Unmarshal(req.Arguments, &args); err != nil {
+		s.sendErrorResponse(req, fmt.Sprintf("bad breakpointLocations args: %v", err))
+		return
+	}
+	endLine := args.EndLine
+	if endLine < args.Line {
+		endLine = args.Line
+	}
+	type body struct {
+		Breakpoints []BreakpointLocation `json:"breakpoints"`
+	}
+	resp := body{Breakpoints: []BreakpointLocation{}}
+	if s.srcMap == nil {
+		s.sendResponse(req, resp)
+		return
+	}
+	want := canonicalSourcePath(args.Source)
+	seen := map[int]bool{}
+	for _, loc := range s.srcMap.PCToSrc {
+		if loc.Line < args.Line || loc.Line > endLine {
+			continue
+		}
+		if !matchesSource(loc.File, args.Source.Path, want) {
+			continue
+		}
+		if seen[loc.Line] {
+			continue
+		}
+		seen[loc.Line] = true
+		resp.Breakpoints = append(resp.Breakpoints, BreakpointLocation{Line: loc.Line})
+	}
+	s.sendResponse(req, resp)
+}
+
 // matchesSource decides whether a .dbg-recorded file equals the source
 // the client is asking about. We're permissive: equal path, equal
 // basename, or basename of the .dbg entry matches the canonical key.

--- a/internal/dap/memory.go
+++ b/internal/dap/memory.go
@@ -173,6 +173,16 @@ func (s *Server) handleWriteMemory(req Request) {
 		s.sendErrorResponse(req, fmt.Sprintf("address out of range: %d", start))
 		return
 	}
+	end := start + len(data)
+	// AllowPartial = false (the spec default): the entire payload must
+	// fit within the 64 KiB address space, otherwise reject before
+	// writing anything. With AllowPartial = true, write what fits.
+	if !args.AllowPartial && end > 0x10000 {
+		s.sendErrorResponse(req, fmt.Sprintf(
+			"write of %d bytes at $%04X would overflow 64KB; set allowPartial=true to accept truncation",
+			len(data), start))
+		return
+	}
 	written := 0
 	for i, b := range data {
 		a := start + i

--- a/internal/dap/protocol.go
+++ b/internal/dap/protocol.go
@@ -90,8 +90,10 @@ type Capabilities struct {
 // Matches the CLI flags (rom, addr, reset, cpu, dbg, trace) so a launch
 // config in the editor looks like the chippy CLI invocation.
 type LaunchArguments struct {
-	NoDebug     bool   `json:"noDebug,omitempty"`
-	StopOnEntry bool   `json:"stopOnEntry,omitempty"`
+	NoDebug bool `json:"noDebug,omitempty"`
+	// StopOnEntry: pointer so we can distinguish "absent" (default to
+	// pause) from "explicit false" (auto-run after launch).
+	StopOnEntry *bool  `json:"stopOnEntry,omitempty"`
 	Rom         string `json:"rom,omitempty"`
 	LoadAddr    uint16 `json:"loadAddr,omitempty"`
 	ResetVec    uint16 `json:"resetVec,omitempty"`
@@ -105,8 +107,11 @@ type LaunchArguments struct {
 // `processId` means "attach to whatever debuggee the server is already
 // running"; non-empty is reserved for a future cross-process flow.
 type AttachArguments struct {
-	ProcessID   string `json:"processId,omitempty"`
-	StopOnEntry bool   `json:"stopOnEntry,omitempty"`
+	ProcessID string `json:"processId,omitempty"`
+	// StopOnEntry: pointer so absent / explicit-false / explicit-true
+	// each map to a distinct behavior (default pause / no stopped event
+	// / explicit pause).
+	StopOnEntry *bool `json:"stopOnEntry,omitempty"`
 }
 
 // StoppedEventBody is the body of a `stopped` event. Reason values include
@@ -239,6 +244,25 @@ type Breakpoint struct {
 	Source                      *Source `json:"source,omitempty"`
 	Line                        int     `json:"line,omitempty"`
 	InstructionPointerReference string  `json:"instructionPointerReference,omitempty"`
+}
+
+// BreakpointLocationsArguments — DAP request body for the editor's
+// gutter feature ("here's a line, what positions on that line could
+// actually take a breakpoint?"). We answer at line granularity.
+type BreakpointLocationsArguments struct {
+	Source    Source `json:"source"`
+	Line      int    `json:"line"`
+	Column    int    `json:"column,omitempty"`
+	EndLine   int    `json:"endLine,omitempty"`
+	EndColumn int    `json:"endColumn,omitempty"`
+}
+
+// BreakpointLocation — one position the gutter could mark as bp-able.
+type BreakpointLocation struct {
+	Line      int `json:"line"`
+	Column    int `json:"column,omitempty"`
+	EndLine   int `json:"endLine,omitempty"`
+	EndColumn int `json:"endColumn,omitempty"`
 }
 
 // DisassembleArguments is the request body for `disassemble`.

--- a/internal/dap/server.go
+++ b/internal/dap/server.go
@@ -171,6 +171,8 @@ func (s *Server) dispatch(req Request) {
 		s.handleSetInstructionBreakpoints(req)
 	case "setFunctionBreakpoints":
 		s.handleSetFunctionBreakpoints(req)
+	case "breakpointLocations":
+		s.handleBreakpointLocations(req)
 	case "disassemble":
 		s.handleDisassemble(req)
 	case "readMemory":
@@ -251,16 +253,35 @@ func (s *Server) handleLaunch(req Request) {
 		return
 	}
 	s.sendResponse(req, nil)
-	// CPU is paused at the reset vector; report it stopped on entry so
-	// the client immediately renders state. stopOnEntry defaults true —
-	// noDebug + stopOnEntry=false will eventually allow auto-run.
-	if !args.NoDebug {
-		s.sendEvent("stopped", StoppedEventBody{
-			Reason:            "entry",
-			ThreadID:          1,
-			AllThreadsStopped: true,
-		})
+	if args.NoDebug {
+		return
 	}
+	// Default behavior: pause at the reset vector and report it so the
+	// client immediately renders state. An explicit `stopOnEntry: false`
+	// in the launch arguments overrides — auto-start the run loop in
+	// place of the stopped event.
+	if args.StopOnEntry != nil && !*args.StopOnEntry {
+		s.autoStartRun()
+		return
+	}
+	s.sendEvent("stopped", StoppedEventBody{
+		Reason:            "entry",
+		ThreadID:          1,
+		AllThreadsStopped: true,
+	})
+}
+
+// autoStartRun kicks off the run-loop goroutine after a launch/attach
+// when the client opted out of the entry pause. Mirrors handleContinue
+// but doesn't send a response (there's no `continue` request in flight).
+func (s *Server) autoStartRun() {
+	if s.running.Load() {
+		return
+	}
+	s.pauseRequested.Store(false)
+	s.runDone = make(chan struct{})
+	s.running.Store(true)
+	go s.runLoop()
 }
 
 // bootDebuggee constructs the CPU+RAM+MMIO chain the same way


### PR DESCRIPTION
## Summary
- Closes #123. Three places where the DAP server advertised or accepted a thing it didn't honor. Editors take those signals literally — mismatch = confusing UX.
- **breakpointLocations**: capability flag was true, dispatch routed to "not implemented". New handler scans `srcMap.PCToSrc` for distinct line numbers in `[Line, EndLine]` that match the requested source path. Line-granularity, columns ignored. Returns `[]` (not an error) when no `.dbg` is loaded.
- **launch.stopOnEntry / attach.stopOnEntry**: now `*bool` so absent / explicit-false / explicit-true are distinguishable. Explicit `false` on launch auto-starts the run loop via a new `s.autoStartRun()` helper. Explicit `false` on attach skips the `stopped(entry)` event so the host process keeps driving execution.
- **writeMemory.allowPartial**: defaults to false per spec. False + would-overflow → clear error before any bytes land. True → write what fits (previous silent-truncate behavior).

## Test plan
- [x] 8 new tests in `internal/dap/advertised_test.go` covering each behavior + the spec-default capability advertisement.
- [x] `go test -race ./...` green.
- [x] `golangci-lint run` — 0 issues.
- [x] `GOOS=js GOARCH=wasm go build ./cmd/chippy-wasm` — WASM build still green.

## Docs
- `docs/dap.md` clarifies the three-state stopOnEntry contract.
- `docs/context.md` notes this PR alongside the other v1.0 epic items.