### PR TITLE
fix(web): CSP needs wasm-unsafe-eval; bump SW cache

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -4,9 +4,13 @@
   <meta charset="UTF-8" />
   <title>chippy — 6502 debugger in the browser</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <!-- CSP: self only. WASM lives at /chippy.wasm; no third-party scripts. -->
+  <!-- CSP: self only. `wasm-unsafe-eval` is required for
+       WebAssembly.instantiate*; without it modern browsers refuse to
+       compile the wasm blob (silent error / blank register pane).
+       https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_webassembly_execution
+       No remote scripts; no inline scripts; no third-party fetches. -->
   <meta http-equiv="Content-Security-Policy"
-        content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'" />
+        content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'" />
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>

--- a/web/sw.js
+++ b/web/sw.js
@@ -1,7 +1,7 @@
 // Tiny service worker: cache-first for the static assets, network-first
 // for everything else. Bump CACHE_NAME when shipping a new build so
 // clients evict the stale wasm blob.
-const CACHE_NAME = 'chippy-v1';
+const CACHE_NAME = 'chippy-v2'; // bumped: CSP needed wasm-unsafe-eval
 const ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
## Summary
- Deployed playground shipped with `script-src 'self'` (from #132 / PR #150). Modern browsers refuse to compile WebAssembly under that CSP without `'wasm-unsafe-eval'`, so the page boots, fetches `chippy.wasm`, and then silently fails inside `WebAssembly.instantiate` — register pane stays blank.
- Adds `'wasm-unsafe-eval'` to `script-src`. Rest of the CSP unchanged.
- Bumps service-worker `CACHE_NAME` to `chippy-v2` so the SW evicts the stale `index.html`.

## Verification
- Repro: load https://nkane.dev/chippy/playground/ — wasm doesn't initialize.
- Fix: `wasm-unsafe-eval` is the documented CSP escape hatch for self-hosted wasm modules (MDN).
- SW bump ensures returning users don't keep serving the broken page from cache after deploy.

## Test plan
- [x] No Go change — `go test ./...` unaffected.
- [x] `golangci-lint run` — 0 issues.
- [ ] Pages deploy on merge; verify live URL boots cleanly.