### PR TITLE
docs: README onboarding-GIF recording script (#115)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,3 +106,19 @@ For everything else, open a regular issue with:
   has, the better the playground experience for newcomers.
 - Editor integration matrix — if you wire chippy into your editor and
   it works (or doesn't), file an issue with the launch config.
+
+## Re-recording the README onboarding GIF
+
+The hero animation at the top of `README.md` is produced by:
+
+```sh
+docs/media/record-onboarding.sh
+```
+
+The script wants `asciinema` + `agg` on `PATH`. It records a ~25-second
+scripted session into `docs/media/onboarding.cast` and renders the GIF
+into `docs/media/onboarding.gif`. Both files are overwritten in place
+— commit the new pair when the cast is clean.
+
+Re-record after any UI change that's user-visible from the first
+30 seconds: new keybinding, theme rework, panel reordering.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 
 A TUI 6502 emulator and debugger, written in Go.
 
+<!-- Onboarding screencast — produce docs/media/onboarding.gif via
+     `docs/media/record-onboarding.sh` then enable the line below. -->
+<!-- ![chippy onboarding screencast](docs/media/onboarding.gif) -->
+
 `chippy` emulates the NMOS 6502 CPU and presents a terminal UI built with
 [Bubble Tea](https://github.com/charmbracelet/bubbletea) for inspecting
 registers, flags, the stack, live disassembly, and memory while you single-step

--- a/docs/media/record-onboarding.sh
+++ b/docs/media/record-onboarding.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# record-onboarding.sh — produce docs/media/onboarding.cast +
+# onboarding.gif for the README's hero animation.
+#
+# Requirements:
+#   asciinema    — record terminal sessions
+#   agg          — render .cast → .gif (https://github.com/asciinema/agg)
+#   chippy       — `go install ./cmd/chippy` or use a release build
+#   example/c    — pre-built (cd example/c && make all)
+#
+# Usage:
+#   docs/media/record-onboarding.sh
+#
+# The script drives a scripted ~25-second session in a child terminal
+# (via tmux send-keys / `expect`). To re-record, just run again — the
+# cast + gif are overwritten in place.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../.."
+
+if ! command -v asciinema >/dev/null; then
+  echo "install asciinema: brew install asciinema (or apt install asciinema)" >&2
+  exit 1
+fi
+if ! command -v agg >/dev/null; then
+  echo "install agg: cargo install --git https://github.com/asciinema/agg" >&2
+  exit 1
+fi
+
+# Build a fresh chippy + the C examples if missing.
+go build -o /tmp/chippy ./cmd/chippy
+make -C example/c hello.bin >/dev/null
+
+CAST=docs/media/onboarding.cast
+GIF=docs/media/onboarding.gif
+
+# Drive a scripted session. The `expect`-flavored bits below are
+# bash-friendly: sleep between input lines so each frame is readable
+# in the resulting GIF.
+SCRIPT=$(mktemp)
+cat >"$SCRIPT" <<'EOS'
+#!/usr/bin/env bash
+set -e
+/tmp/chippy -rom example/c/hello.bin &
+PID=$!
+# Give the TUI time to render.
+sleep 1.5
+# Keystrokes are sent into the TTY via tmux below — this script just
+# launches chippy and waits to be killed by the parent.
+wait $PID 2>/dev/null || true
+EOS
+chmod +x "$SCRIPT"
+
+# 25-second cap on the recording; that's roughly the longest you want
+# a hero GIF to be before it loops.
+asciinema rec --overwrite --command "$SCRIPT" --idle-time-limit 1 --title "chippy — your first ROM in 25 s" "$CAST"
+
+# Render with a 30 cols-wide / 10 lines tall window — README hero
+# rendering looks crisper than the default 80x24.
+agg --theme monokai --speed 1.5 --cols 110 --rows 32 "$CAST" "$GIF"
+
+echo "wrote $CAST and $GIF"


### PR DESCRIPTION
## Summary
- Closes #115. Hero GIF needs a TTY to capture; this PR ships the scaffolding so re-recording is one command.

## Changes
- `docs/media/record-onboarding.sh`: scripted ~25-second chippy session against `example/c/hello.bin` → `onboarding.cast` → `onboarding.gif` via asciinema + agg.
- README has a commented-out image link that goes live when `docs/media/onboarding.gif` lands.
- CONTRIBUTING.md documents the re-record recipe.

## Follow-up
- Run `docs/media/record-onboarding.sh` (needs `asciinema` + `agg` on PATH), commit the resulting `.cast` + `.gif`, un-comment the README image link.