### PR TITLE
fix(docs): swap onboarding capture to vhs (Bubble Tea-native)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,10 +115,14 @@ The hero animation at the top of `README.md` is produced by:
 docs/media/record-onboarding.sh
 ```
 
-The script wants `asciinema` + `agg` on `PATH`. It records a ~25-second
-scripted session into `docs/media/onboarding.cast` and renders the GIF
-into `docs/media/onboarding.gif`. Both files are overwritten in place
-— commit the new pair when the cast is clean.
+The script drives [vhs](https://github.com/charmbracelet/vhs) — same
+people as Bubble Tea, so altscreen + keystroke injection just work.
+Edit `docs/media/onboarding.tape` to change the session script (the
+DSL covers `Type`, `Sleep`, `Enter`, etc.).
 
-Re-record after any UI change that's user-visible from the first
-30 seconds: new keybinding, theme rework, panel reordering.
+Install: `brew install vhs` (or `go install
+github.com/charmbracelet/vhs@latest`). Output overwrites
+`docs/media/onboarding.gif`.
+
+Re-record after any UI change visible in the first 25 seconds — new
+keybinding, theme rework, panel reordering.

--- a/docs/media/onboarding.tape
+++ b/docs/media/onboarding.tape
@@ -1,0 +1,55 @@
+# onboarding.tape — vhs script for docs/media/onboarding.gif
+# https://github.com/charmbracelet/vhs
+#
+# Run from repo root:
+#   vhs docs/media/onboarding.tape
+#
+# Output lands at docs/media/onboarding.gif (set by `Output` below).
+# vhs handles altscreen + Bubble Tea cleanly where asciinema/agg
+# struggle — it drives the PTY directly with deterministic keystrokes.
+
+Output docs/media/onboarding.gif
+
+Set Shell "bash"
+Set FontSize 16
+Set Width 1280
+Set Height 800
+Set Theme "Dracula"
+Set TypingSpeed 60ms
+
+# Launch chippy on a small ca65 demo. The reset state is paused at $8000.
+Type "chippy -rom example/c/hello.bin"
+Enter
+Sleep 2s
+
+# Step through the first few instructions. Each `s` advances one
+# instruction; the reg pane updates in real time.
+Type "s"
+Sleep 600ms
+Type "s"
+Sleep 600ms
+Type "s"
+Sleep 600ms
+Type "s"
+Sleep 1s
+
+# Free-run until the program reaches the JMP halt, then pause.
+Type "r"
+Sleep 2s
+Type "r"
+Sleep 1s
+
+# Reverse-step once to demonstrate the rewind ring.
+Type "<"
+Sleep 1500ms
+
+# Pop the help modal so the keybinding surface is visible in the GIF.
+Type "?"
+Sleep 2s
+# Close the modal (any key).
+Space
+Sleep 500ms
+
+# Quit cleanly.
+Type "q"
+Sleep 500ms

--- a/docs/media/record-onboarding.sh
+++ b/docs/media/record-onboarding.sh
@@ -1,33 +1,31 @@
 #!/usr/bin/env bash
-# record-onboarding.sh — capture docs/media/onboarding.cast +
-# onboarding.gif for the README hero.
+# record-onboarding.sh — render docs/media/onboarding.gif via vhs.
 #
-# Wrapper around asciinema + agg. You drive the chippy session
-# yourself during the recording (Bubble Tea's altscreen and
-# scripted-keystroke shims don't cooperate cleanly — keys get
-# dropped or mis-ordered).
+# Why vhs (and not asciinema + agg): Bubble Tea uses altscreen mode,
+# which asciinema records as a sequence of ANSI control codes that
+# agg renders 1:1. Result: garbled or empty playback. vhs
+# (https://github.com/charmbracelet/vhs) was written by the same
+# people who wrote Bubble Tea — it drives the PTY directly with
+# scripted keystrokes from a declarative .tape file and produces a
+# clean GIF.
 #
-# Suggested session (~25 seconds, hero-GIF-friendly):
-#   chippy -rom example/c/hello.bin
-#   wait ~2s for the TUI to settle
-#   press `s` four times — watch the reg pane update
-#   press `r` to free-run, then `r` again to pause
-#   press `<` once to reverse-step
-#   press `q` to quit
+# Requirements: vhs, chippy on PATH, example/c/hello.bin built
+#   brew install vhs            (or: go install github.com/charmbracelet/vhs@latest)
+#   go install ./cmd/chippy
+#   make -C example/c hello.bin
 #
-# Requirements: asciinema, agg, chippy on PATH, example/c/hello.bin
-# built (cc65 needed; `make -C example/c hello.bin`).
+# Usage:
+#   docs/media/record-onboarding.sh
 
 set -euo pipefail
 cd "$(dirname "$0")/../.."
 
-for tool in asciinema agg chippy; do
+for tool in vhs chippy; do
   if ! command -v "$tool" >/dev/null; then
     echo "missing dependency: $tool" >&2
     case $tool in
-      asciinema) echo "  brew install asciinema   (or apt install asciinema)" >&2 ;;
-      agg)       echo "  cargo install --git https://github.com/asciinema/agg" >&2 ;;
-      chippy)    echo "  go install ./cmd/chippy" >&2 ;;
+      vhs)    echo "  brew install vhs   (or: go install github.com/charmbracelet/vhs@latest)" >&2 ;;
+      chippy) echo "  go install ./cmd/chippy" >&2 ;;
     esac
     exit 1
   fi
@@ -39,32 +37,7 @@ if [ ! -f example/c/hello.bin ]; then
   exit 1
 fi
 
-CAST=docs/media/onboarding.cast
-GIF=docs/media/onboarding.gif
+vhs docs/media/onboarding.tape
 
-cat <<EOF
-
-Recording $CAST. Drive the session yourself:
-
-  1. chippy -rom example/c/hello.bin
-  2. wait ~2 seconds (let the TUI settle)
-  3. press s s s s    (step four instructions)
-  4. press r          (free-run)
-  5. press r          (pause)
-  6. press <          (reverse-step once)
-  7. press q          (quit)
-
-Aim for ~25 seconds total. Ctrl-D when done.
-
-EOF
-
-asciinema rec --overwrite --idle-time-limit 1 \
-  --title "chippy — your first ROM in 25 s" \
-  --cols 110 --rows 32 \
-  "$CAST"
-
-echo "rendering $GIF..."
-agg --theme monokai --speed 1.5 --cols 110 --rows 32 "$CAST" "$GIF"
-
-echo "wrote $CAST and $GIF"
+echo "wrote docs/media/onboarding.gif"
 echo "uncomment the screencast line in README.md to surface it."


### PR DESCRIPTION
## Summary
- Original `record-onboarding.sh` drove `asciinema` + `agg`. Bubble Tea uses altscreen mode — asciinema records the ANSI control sequences, agg renders them 1:1, result is garbled / empty GIF.
- Switch to [vhs](https://github.com/charmbracelet/vhs). Same team as Bubble Tea; drives the PTY directly with a declarative `.tape` file.

## Changes
- `docs/media/onboarding.tape`: declarative session — launch, four single-steps, free-run + pause, reverse-step, help modal, quit. Adjust there to tune timing / content.
- `docs/media/record-onboarding.sh` becomes a thin wrapper: validate deps, run `vhs docs/media/onboarding.tape`.
- `CONTRIBUTING.md` points at vhs install + the tape file.

## How to use
```sh
brew install vhs   # or: go install github.com/charmbracelet/vhs@latest
docs/media/record-onboarding.sh
```

Output overwrites `docs/media/onboarding.gif`. Commit + un-comment the README image line when satisfied.