### PR TITLE
fix(docs): onboarding.tape viewport — smaller font, larger window

### DIFF
--- a/docs/media/onboarding.tape
+++ b/docs/media/onboarding.tape
@@ -10,10 +10,14 @@
 
 Output docs/media/onboarding.gif
 
-Set Shell "bash"
-Set FontSize 16
-Set Width 1280
-Set Height 800
+Set Shell "zsh"
+# chippy's TUI needs roughly 130 cols × 45 rows of cells to render
+# every panel without clipping. Smaller font + larger window gives
+# the layout room to breathe; the resulting GIF compresses fine.
+Set FontSize 12
+Set Width 1600
+Set Height 1000
+Set Padding 20
 Set Theme "Dracula"
 Set TypingSpeed 60ms
 


### PR DESCRIPTION
## Summary
- Default vhs window at FontSize 16 / 1280x800 clipped chippy's TUI panels.
- Drop to FontSize 12 + 1600x1000 so the ~130 cols × 45 rows of TUI layout fit.
- Adds 20 px padding so panel borders don't bleed to the GIF edge.

User re-recorded after #163 landed and reported the viewport was too tight.