### PR TITLE
fix(vscode-chippy): switch publisher to Hidden-Pixel

### DIFF
--- a/extension/vscode-chippy/package.json
+++ b/extension/vscode-chippy/package.json
@@ -3,7 +3,7 @@
   "displayName": "Chippy 6502 Debugger",
   "description": "VS Code debug adapter for chippy — the 6502 emulator + debugger.",
   "version": "0.1.0",
-  "publisher": "nkane",
+  "publisher": "Hidden-Pixel",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/extension/vscode-chippy/src/test/suite/extension.test.ts
+++ b/extension/vscode-chippy/src/test/suite/extension.test.ts
@@ -5,7 +5,7 @@ import * as vscode from 'vscode';
 // a typo in `contributes.debuggers[].type`, a removed activation event,
 // or a broken DebugAdapterDescriptorFactory factory function.
 
-const EXT_ID = 'nkane.vscode-chippy';
+const EXT_ID = 'Hidden-Pixel.vscode-chippy';
 
 suite('vscode-chippy', () => {
   test('extension is present', () => {


### PR DESCRIPTION
Marketplace publisher backing this extension is Hidden-Pixel (nkane wasn't claimable). Updates `package.json` + the extension-test `EXT_ID` accordingly. Marketplace install path becomes `code --install-extension Hidden-Pixel.vscode-chippy` once the first `vX.Y.Z` tag publishes via #114's release job.