### PR TITLE
fix(web): align P-register legend with the live bit row

### DIFF
--- a/web/chippy.js
+++ b/web/chippy.js
@@ -47,8 +47,11 @@ function renderState() {
   document.getElementById('reg-sp').textContent = fmtHex(s.sp, 2);
   document.getElementById('reg-pc').textContent = fmtHex(s.pc, 4);
   document.getElementById('reg-cyc').textContent = s.cycles.toString();
-  document.getElementById('reg-flags').textContent = flagBits(s.p);
-  document.getElementById('reg-p').firstChild.textContent = fmtHex(s.p, 2) + ' NV-BDIZC';
+  // P pane renders as three rows in a monospace <pre>: hex value,
+  // legend, then live flag state — each row 8 chars wide so the
+  // letters line up under their bit positions.
+  document.getElementById('reg-p').textContent =
+    fmtHex(s.p, 2) + '\nNV-BDIZC\n' + flagBits(s.p);
 
   renderDisasm(s.pc);
   renderMemory();

--- a/web/index.html
+++ b/web/index.html
@@ -76,7 +76,9 @@
           <tbody>
             <tr><th>A</th><td id="reg-a">$00</td><th>X</th><td id="reg-x">$00</td><th>Y</th><td id="reg-y">$00</td></tr>
             <tr><th>SP</th><td id="reg-sp">$FF</td><th>PC</th><td colspan="3" id="reg-pc">$0000</td></tr>
-            <tr><th>P</th><td colspan="5" id="reg-p">$24 NV-BDIZC<br><span id="reg-flags">. . . . . . . .</span></td></tr>
+            <tr><th>P</th><td colspan="5"><pre id="reg-p" class="reg-p-stack">$24
+NV-BDIZC
+..-..I..</pre></td></tr>
             <tr><th>CYC</th><td colspan="5" id="reg-cyc">0</td></tr>
           </tbody>
         </table>

--- a/web/style.css
+++ b/web/style.css
@@ -100,8 +100,11 @@ button:disabled { opacity: 0.5; cursor: not-allowed; }
   max-height: 320px;
 }
 .regs table { border-collapse: collapse; font: 0.85rem ui-monospace, SFMono-Regular, Menlo, monospace; }
-.regs th, .regs td { padding: 0.2em 0.6em; text-align: left; }
+.regs th, .regs td { padding: 0.2em 0.6em; text-align: left; vertical-align: top; }
 .regs th { color: var(--muted); font-weight: normal; }
+/* P-register stack: 3 monospace rows (hex / legend / bits) so the
+   letter columns line up under their bit positions. */
+.reg-p-stack { margin: 0; font: inherit; white-space: pre; line-height: 1.2; }
 #key-capture {
   background: #1f2630;
   border: 1px dashed var(--border);


### PR DESCRIPTION
The WASM playground's P pane rendered `$24 NV-BDIZC` on one line and `..-..I..` on the next, so the legend was shifted right by 4 columns vs the live state. Stack hex / legend / bits in a monospace `<pre>` instead — every row aligns column-for-column.