### PR TITLE
chore(web): bump SW cache for P-pane alignment fix

### DIFF
--- a/web/sw.js
+++ b/web/sw.js
@@ -1,7 +1,7 @@
 // Tiny service worker: cache-first for the static assets, network-first
 // for everything else. Bump CACHE_NAME when shipping a new build so
 // clients evict the stale wasm blob.
-const CACHE_NAME = 'chippy-v2'; // bumped: CSP needed wasm-unsafe-eval
+const CACHE_NAME = 'chippy-v3'; // bumped: P-register pane alignment fix
 const ASSETS = [
   './',
   './index.html',


### PR DESCRIPTION
SW v2 cached the old index.html / chippy.js with the misaligned P-register pane. Bump to v3 so returning visitors evict the stale entry on next load.