### PR TITLE
chore(release): monorepo-aware release split for chippy + nessy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,19 +1,31 @@
 name: release
 
+# Tag scheme:
+#   vX.Y.Z         → chippy release. Goreleaser flow: homebrew tap,
+#                    AUR, .deb / .rpm / .apk, VS Code marketplace,
+#                    cosign signatures, SPDX SBOMs.
+#   nessy-vX.Y.Z   → nessy alpha. Custom per-OS build jobs produce
+#                    darwin (amd64+arm64), linux (amd64), windows
+#                    (amd64) binaries bundled with demo ROMs. No
+#                    homebrew / AUR / marketplace yet (alpha-only).
+#
+# See `docs/RELEASE.md` for the full release-cutting playbook.
 on:
   push:
     tags:
       - 'v*'
+      - 'nessy-v*'
 
 # id-token: write lets cosign mint a keyless OIDC certificate bound to
-# this workflow. contents: write is required for the release-asset
-# uploads goreleaser performs.
+# this workflow. contents: write is required for release-asset uploads.
 permissions:
   contents: write
   id-token: write
 
 jobs:
+  # ----- chippy release (goreleaser flow) -----
   goreleaser:
+    if: startsWith(github.ref_name, 'v')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -37,7 +49,7 @@ jobs:
         with:
           distribution: goreleaser
           version: '~> v2'
-          args: release --clean
+          args: release --clean --config .goreleaser.chippy.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
@@ -48,8 +60,9 @@ jobs:
     needs: goreleaser
     runs-on: ubuntu-latest
     # Skip prereleases (rc / beta tags); marketplace can't unpublish a
-    # released version. Tag a normal `vX.Y.Z` to ship.
-    if: github.ref_type == 'tag' && !contains(github.ref_name, '-')
+    # released version. Only fires on stable chippy releases (bare
+    # `vX.Y.Z` with no prerelease suffix).
+    if: startsWith(github.ref_name, 'v') && !contains(github.ref_name, '-')
     defaults:
       run:
         working-directory: extension/vscode-chippy
@@ -80,3 +93,118 @@ jobs:
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
         run: npx vsce publish --pat "$VSCE_PAT" --no-dependencies
+
+  # ----- nessy release (custom multi-OS build) -----
+  # Four parallel build jobs produce native binaries via CGO + each
+  # platform's graphics dev libs. First runner reaches `gh release
+  # create` and wins the release-creation race; subsequent runners
+  # attach their artifacts via `gh release upload --clobber`. No
+  # cosign / SBOM for nessy v0.1 alpha — those land when nessy
+  # graduates.
+  nessy-build:
+    if: startsWith(github.ref_name, 'nessy-v')
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            goos: linux
+            goarch: amd64
+            binary: nessy
+            archive_ext: tar.gz
+          - os: macos-latest      # arm64
+            goos: darwin
+            goarch: arm64
+            binary: nessy
+            archive_ext: tar.gz
+          - os: macos-13          # x86_64
+            goos: darwin
+            goarch: amd64
+            binary: nessy
+            archive_ext: tar.gz
+          - os: windows-latest
+            goos: windows
+            goarch: amd64
+            binary: nessy.exe
+            archive_ext: zip
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: 'stable'
+          cache: true
+
+      # Ebiten on Linux pulls in X11 / GL / audio dev headers at build
+      # time. macOS + Windows runners bundle their equivalents.
+      - name: Install Linux build dependencies
+        if: matrix.goos == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgl1-mesa-dev xorg-dev libasound2-dev \
+            libxcursor-dev libxinerama-dev libxi-dev libxrandr-dev
+
+      - name: Build nessy
+        shell: bash
+        run: |
+          mkdir -p dist
+          go build -tags=nessy -trimpath -ldflags="-s -w" \
+            -o "dist/${{ matrix.binary }}" ./cmd/nessy
+
+      - name: Package
+        shell: bash
+        run: |
+          ver="${GITHUB_REF_NAME#nessy-v}"
+          stage="nessy_${ver}_${{ matrix.goos }}_${{ matrix.goarch }}"
+          mkdir -p "$stage"
+          cp "dist/${{ matrix.binary }}" "$stage/"
+          cp README.md LICENSE "$stage/" 2>/dev/null || true
+          # Bundle every demo so users can verify the install with a
+          # known-good payload.
+          mkdir -p "$stage/demos"
+          for d in roms/demos/*/; do
+            name=$(basename "$d")
+            cp -r "$d" "$stage/demos/$name"
+          done
+          if [ "${{ matrix.archive_ext }}" = "zip" ]; then
+            # PowerShell is the most portable cross-platform zip on
+            # Windows runners.
+            powershell -Command "Compress-Archive -Path '$stage' -DestinationPath '${stage}.zip'"
+          else
+            tar -czf "${stage}.tar.gz" "$stage"
+          fi
+          ls -la "${stage}".*
+
+      - name: Generate checksum
+        shell: bash
+        run: |
+          ver="${GITHUB_REF_NAME#nessy-v}"
+          archive="nessy_${ver}_${{ matrix.goos }}_${{ matrix.goarch }}.${{ matrix.archive_ext }}"
+          if command -v sha256sum >/dev/null; then
+            sha256sum "$archive" > "$archive.sha256"
+          else
+            shasum -a 256 "$archive" > "$archive.sha256"
+          fi
+
+      - name: Create or update GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          ver="${GITHUB_REF_NAME#nessy-v}"
+          archive="nessy_${ver}_${{ matrix.goos }}_${{ matrix.goarch }}.${{ matrix.archive_ext }}"
+          # First runner here creates the release; subsequent runners
+          # fall through to upload. `gh release view` exits non-zero
+          # only when the release doesn't exist, so we `|| true` the
+          # create when the view succeeds.
+          gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1 || \
+            gh release create "$GITHUB_REF_NAME" \
+              --title "$GITHUB_REF_NAME" \
+              --notes "nessy alpha release. NROM-only, background-only PPU, no audio. Source-build is the supported path on every platform; the attached binaries are convenience artifacts." \
+              --prerelease
+          gh release upload "$GITHUB_REF_NAME" "$archive" "$archive.sha256" --clobber

--- a/.goreleaser.chippy.yml
+++ b/.goreleaser.chippy.yml
@@ -1,5 +1,11 @@
-# goreleaser config for chippy
+# goreleaser config for chippy.
 # https://goreleaser.com
+#
+# Tag scheme: chippy keeps the bare `vX.Y.Z` scheme it shipped with at
+# v1.0.0. nessy ships under `nessy-vX.Y.Z` via a custom workflow path —
+# goreleaser OSS doesn't support monorepo tag prefixes (pro-only), so
+# the workflow gates jobs on `startsWith(github.ref_name, 'nessy-')`
+# instead. See `docs/RELEASE.md`.
 version: 2
 
 project_name: chippy

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,14 @@ Go-based TUI 6502 emulator + debugger (Bubble Tea, Lipgloss). Targets ca65/cc65 
 
 ## Branch & PR flow
 - One GitHub issue → branch `feat/<short-name>` off `main`.
-- Conventional Commits: `feat:`, `fix:`, `docs:`, `ci:`, `test:`, `refactor:`, `chore:` — these feed `.goreleaser.yml` changelog grouping.
+- Conventional Commits: `feat:`, `fix:`, `docs:`, `ci:`, `test:`, `refactor:`, `chore:` — these feed `.goreleaser.chippy.yml` changelog grouping.
 - PR body ends with `Closes #N`.
 - Squash-merge with `--delete-branch`. Defer follow-ups by filing new issues.
+
+## Release tag scheme
+- chippy ships under bare `vX.Y.Z` tags. Goreleaser via `.goreleaser.chippy.yml` (last released: `v1.0.0`).
+- nessy ships under `nessy-vX.Y.Z` tags. Custom multi-OS workflow (no goreleaser; alpha-only).
+- Full process in [`docs/RELEASE.md`](docs/RELEASE.md).
 
 ## Docs are part of every PR (not a follow-up)
 Every PR ships with the documentation changes its diff implies. Update **in the same PR**, never as a separate cleanup:

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,81 @@
+# Release process
+
+chippy is a monorepo with two shippable binaries (`chippy`, `nessy`). Each project tags independently:
+
+| Project | Tag pattern | Trigger |
+|---|---|---|
+| chippy | `vX.Y.Z`        | goreleaser flow → homebrew tap, AUR, .deb / .rpm / .apk, VS Code marketplace, cosign signatures, SPDX SBOM |
+| nessy  | `nessy-vX.Y.Z`  | Custom per-OS build → darwin (amd64+arm64), linux (amd64), windows (amd64) binaries bundled with demo ROMs |
+
+Both share `.github/workflows/release.yml`; the workflow gates each job on the tag prefix.
+
+chippy uses the bare `vX.Y.Z` scheme it shipped with at `v1.0.0`. Goreleaser OSS doesn't support monorepo tag prefixes (pro-only), so the workflow distinguishes by `startsWith(github.ref_name, 'nessy-')` rather than per-project goreleaser configs.
+
+## Cutting a chippy release
+
+```sh
+git checkout main && git pull
+git tag v1.1.0     # follow semver — chippy starts at v1.0.0
+git push origin v1.1.0
+```
+
+The release workflow:
+1. Runs goreleaser via `.goreleaser.chippy.yml`.
+2. Builds linux/darwin/windows × amd64/arm64 binaries (CGO off — pure Go chippy core).
+3. Generates SPDX SBOMs via syft + cosign-signs every artifact via keyless OIDC.
+4. Pushes Homebrew formula, AUR PKGBUILD, .deb / .rpm / .apk packages.
+5. Publishes the VS Code extension (skipped for `-rc` / `-beta` / `-alpha` suffixes).
+
+Verify a chippy artifact:
+```sh
+cosign verify-blob \
+  --certificate-identity=https://github.com/nkane/chippy/.github/workflows/release.yml@refs/tags/v1.1.0 \
+  --certificate-oidc-issuer=https://token.actions.githubusercontent.com \
+  --bundle chippy_1.1.0_linux_x86_64.tar.gz.cosign.bundle \
+  chippy_1.1.0_linux_x86_64.tar.gz
+```
+
+## Cutting a nessy release
+
+```sh
+git checkout main && git pull
+git tag nessy-v0.1.0
+git push origin nessy-v0.1.0
+```
+
+The release workflow:
+1. Spawns 4 parallel build jobs (ubuntu / macos-13 / macos-latest / windows-latest).
+2. Each runner installs platform graphics dev libs as needed and runs `go build -tags=nessy -o nessy ./cmd/nessy`.
+3. Packages the binary + LICENSE + README + every demo under `roms/demos/` into a per-OS archive.
+4. First job to finish creates the GitHub release (marked prerelease); the rest attach their artifacts.
+
+Linux build deps the workflow installs:
+```sh
+sudo apt-get install -y \
+  libgl1-mesa-dev xorg-dev libasound2-dev \
+  libxcursor-dev libxinerama-dev libxi-dev libxrandr-dev
+```
+
+nessy releases are intentionally minimal for the v0.1 alpha — no homebrew tap, no AUR, no cosign / SBOM. Those land when nessy graduates (likely v0.2 once sprites + audio are real).
+
+## Pre-tag checklist
+
+For chippy:
+- `go build ./...`
+- `go test -race -count=1 ./...`
+- `golangci-lint run ./...`
+- README + docs/context.md current
+- CHANGELOG implied via conventional-commit log; verify the auto-grouped sections look right by running `goreleaser release --snapshot --clean --config .goreleaser.chippy.yml` locally
+
+For nessy:
+- `make -C roms/demos all` (rebuild every demo from source)
+- `go test -race -count=1 ./...` (demo SHA tests stay green)
+- `go build -tags=nessy ./cmd/nessy` on darwin (cheapest check)
+- Eyeball at least one demo via `CHIPPY_DEMO_INSPECT=1 go test ./cmd/nessy/... -v`
+- Tag is `nessy-vX.Y.Z`, never bare `vX.Y.Z` (that's reserved for chippy)
+
+## Future: the v0.3 monorepo split
+
+`docs/plans/nessy.md` documents the planned chippy / nessy repo split at v0.3. The current scheme is already split-friendly:
+- chippy stays on `vX.Y.Z`. Post-split chippy repo keeps its history and tag scheme unchanged.
+- nessy's `nessy-vX.Y.Z` tags get rewritten to bare `vX.Y.Z` in the new nessy repo via `git filter-repo --tag-rename nessy-v:v`.


### PR DESCRIPTION
## Summary
Splits the release workflow so chippy and nessy can ship on independent cadences without blocking each other. Required prep before tagging nessy v0.1.0.

## Tag scheme

| Project | Tag pattern | Trigger |
|---|---|---|
| chippy | `vX.Y.Z` (bare, continues from `v1.0.0`) | Goreleaser → homebrew tap, AUR, .deb/.rpm/.apk, VS Code marketplace, cosign signatures, SPDX SBOMs |
| nessy  | `nessy-vX.Y.Z`                            | Custom per-OS build matrix → darwin (amd64+arm64), linux (amd64), windows (amd64) binaries bundled with demo ROMs |

Goreleaser OSS doesn't support monorepo tag prefixes (pro-only), so the workflow distinguishes by `startsWith(github.ref_name, 'nessy-')` rather than maintaining two goreleaser configs.

## Changes
- `.goreleaser.yml` → `.goreleaser.chippy.yml` (rename). Header updated.
- `.github/workflows/release.yml`:
  - Triggers on `v*` + `nessy-v*`.
  - chippy job + VS Code publish gate on `startsWith(github.ref_name, 'v')`.
  - New `nessy-build` matrix job (4 runners) builds with `-tags=nessy`, installs platform deps (Linux: X11/GL/audio dev libs), packages binary + LICENSE + README + every demo, sha256s the archive, uses `gh release create` (idempotent precheck) + `gh release upload --clobber` to attach. First runner wins the create race.
- `docs/RELEASE.md` (new): playbook covering tag commands, verify examples, pre-tag checklist per project, future-split migration.
- `CLAUDE.md`: tag-scheme rule + link.

## Future repo split
chippy stays at `v*` — post-split it just keeps its scheme. nessy's `nessy-v*` tags rewrite to bare `v*` via `git filter-repo --tag-rename nessy-v:v`.

## Test plan
- [x] `goreleaser check --config .goreleaser.chippy.yml` passes (only pre-existing `brews` deprecation warning).
- [x] `go build ./...`
- [x] `go test -race -count=1 ./...`
- [x] `golangci-lint run ./...`
- [ ] (Live) End-to-end verified by the first `nessy-v0.1.0` push.