### PR TITLE
chore: pre-tag polish — CI nessy build canary + README demos section

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,26 @@ jobs:
         with:
           version: v2.12.2
 
+  nessy-build:
+    # Validates the `-tags=nessy` build on every PR so regressions in
+    # the cmd/nessy / Ebiten coupling surface before release time.
+    # darwin is the cheapest runner (no apt-get X11 deps), so we use
+    # it as the canary; the release workflow exercises every platform
+    # on tag.
+    name: nessy tagged build (darwin)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: 'stable'
+          cache: true
+
+      - name: Build nessy (-tags=nessy)
+        run: go build -tags=nessy -o /tmp/nessy ./cmd/nessy
+
   klaus:
     name: klaus functional test
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -144,6 +144,32 @@ the v0.2+ roadmap.
 
 Controls: Arrows = D-pad, Z = A, X = B, Enter = Start, Right Shift = Select.
 
+#### Demos
+
+Three homemade demos ship under [`roms/demos/`](roms/demos/) — hand-rolled
+ca65 sources + checked-in `.nes` artifacts. Each doubles as a framebuffer-hash
+regression test under `cmd/nessy/demo_*_test.go`:
+
+| Demo | What it tests | Source |
+|---|---|---|
+| [`hello-bg`](roms/demos/hello-bg/) | PPU bg renderer + palette + nametable + reset path | Static "HELLO NESSY" title screen |
+| [`input-echo`](roms/demos/input-echo/) | $4016 joypad strobe + serial shift + per-frame VRAM writes | 8 indicator boxes light up under live joypad input |
+| [`vblank-bounce`](roms/demos/vblank-bounce/) | PPU NMI line + CPU NMI service + `JMP self` idle | Single tile bounces inside the playfield |
+
+Run any of them:
+
+```sh
+./nessy roms/demos/hello-bg/hello-bg.nes
+./nessy roms/demos/input-echo/input-echo.nes
+./nessy roms/demos/vblank-bounce/vblank-bounce.nes
+```
+
+Rebuild from ca65 source (requires `brew install cc65` / `apt-get install cc65`):
+
+```sh
+make -C roms/demos all
+```
+
 ---
 
 ## Quick start


### PR DESCRIPTION
## Summary
Two pre-tag adds before cutting `nessy-v0.1.0`:

- **CI nessy-build job** (macos-latest, runs `go build -tags=nessy ./cmd/nessy`) — catches Ebiten / cmd/nessy regressions per PR. darwin is cheapest; release workflow exercises every platform on tag.
- **README Demos section** — lists hello-bg / input-echo / vblank-bounce with run commands + make-target callout.

## Test plan
- [x] `go build ./...`
- [x] `go test -race -count=1 ./...`
- [x] `golangci-lint run ./...`