### PR TITLE
fix(nessy): pause game loop on DAP attach — server owns CPU execution (#212)

### DIFF
--- a/cmd/nessy/dap.go
+++ b/cmd/nessy/dap.go
@@ -7,9 +7,21 @@ import (
 	"net"
 	"os"
 	"sync"
+	"sync/atomic"
 
 	"github.com/nkane/chippy/internal/dap"
 )
+
+// dapAttached counts active DAP sessions. The game loop checks this
+// before stepping the CPU — when one or more clients are attached,
+// the server's `continue` runLoop owns execution and the game loop
+// only paints frames. nil → no client → autonomous run.
+//
+// Package-level since there is one game per process. The counter is
+// atomic because OnAttached / OnDisconnected fire from the DAP
+// session goroutine while the game loop reads from the Ebiten Update
+// goroutine.
+var dapAttached atomic.Int32
 
 // runDAPListener accepts incoming DAP connections on the given TCP port
 // and serves each one against the live NES bus. The cpuMu is shared
@@ -18,12 +30,12 @@ import (
 // `:dap PORT` (internal/tui/dap_attach.go) — see issue #97 for design
 // notes.
 //
-// Currently the DAP server's own continue loop and nessy's game loop
-// will both call cpu.Step() under the same mutex once a client issues
-// `continue`. The mutex serializes them but they double-step the CPU.
-// For v0.1 this is acceptable (TUI `:dap` path has the same property);
-// real "pause" semantics that gate the game loop on a remote flag is a
-// v0.2 polish item.
+// OnAttached / OnDisconnected callbacks increment / decrement
+// `dapAttached`. The game loop checks that counter to decide whether
+// to step the CPU. When a client attaches, the server's runLoop (set
+// up by `continue`) becomes the sole stepper; the game loop yields.
+// When the last client disconnects, the game loop resumes its
+// autonomous run.
 func runDAPListener(port int, bus *nesBus, cpuMu *sync.Mutex) {
 	addr := fmt.Sprintf(":%d", port)
 	ln, err := net.Listen("tcp", addr)
@@ -46,6 +58,12 @@ func runDAPListener(port int, bus *nesBus, cpuMu *sync.Mutex) {
 				RAM:   bus.ram,
 				MMIO:  bus.mmio,
 				CPUMu: cpuMu,
+				OnAttached: func() {
+					dapAttached.Add(1)
+				},
+				OnDisconnected: func() {
+					dapAttached.Add(-1)
+				},
 			}
 			if err := s.AttachExisting(cfg); err != nil {
 				fmt.Fprintln(os.Stderr, "nessy: DAP attach:", err)

--- a/cmd/nessy/game.go
+++ b/cmd/nessy/game.go
@@ -51,6 +51,15 @@ func newGame(bus *nesBus, cpuMu *sync.Mutex) *game {
 
 func (g *game) Update() error {
 	g.pollInput()
+	// When a DAP client is attached, the server's `continue` runLoop
+	// (or its single-step requests) is the sole stepper. The game
+	// loop yields so the user can pause, single-step, set
+	// breakpoints, etc. without the game running away underneath
+	// them. Draw still fires every frame, so the screen reflects
+	// whatever framebuffer state the PPU has rendered up to now.
+	if dapAttached.Load() > 0 {
+		return nil
+	}
 	g.cpuMu.Lock()
 	defer g.cpuMu.Unlock()
 	target := g.bus.cpu.Cycles + cpuCyclesPerFrame

--- a/internal/dap/attach.go
+++ b/internal/dap/attach.go
@@ -34,6 +34,18 @@ type AttachConfig struct {
 	// concurrent access from the host (e.g. the TUI's `:dap` command).
 	// nil = no concurrent access; server runs unlocked.
 	CPUMu *sync.Mutex
+
+	// OnAttached fires once after the editor's `attach` request
+	// succeeds. Hosts use this to pause their own run loop while a
+	// client is driving the CPU — e.g. nessy gates its game loop on
+	// "has a client attached" so the only CPU stepper is the server's
+	// `continue` runLoop. Optional; nil means "do nothing".
+	OnAttached func()
+
+	// OnDisconnected mirrors OnAttached. Fires when the server tears
+	// down: either via a `disconnect` request or wire EOF in Serve().
+	// Hosts resume their autonomous run loop. Optional.
+	OnDisconnected func()
 }
 
 // AttachExisting wires an already-constructed debuggee into the server
@@ -57,6 +69,8 @@ func (s *Server) AttachExisting(cfg AttachConfig) error {
 	s.textOut = cfg.TextOut
 	s.keyIn = cfg.KeyIn
 	s.cpuMu = cfg.CPUMu
+	s.onAttached = cfg.OnAttached
+	s.onDisconnected = cfg.OnDisconnected
 	return nil
 }
 
@@ -82,6 +96,12 @@ func (s *Server) handleAttach(req Request) {
 		}
 	}
 	s.sendResponse(req, nil)
+	// Notify the host that a client has attached. Hosts use this to
+	// gate their own run loops (e.g. nessy pauses its game loop while
+	// the DAP server owns execution).
+	if s.onAttached != nil {
+		s.onAttached()
+	}
 	// StopOnEntry: pointer-valued, three states.
 	//   nil  → default: emit stopped(entry) so the editor renders state.
 	//   true → same as nil.

--- a/internal/dap/attach_callbacks_test.go
+++ b/internal/dap/attach_callbacks_test.go
@@ -1,0 +1,130 @@
+package dap
+
+import (
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nkane/chippy/internal/cpu"
+)
+
+// AttachConfig.OnAttached fires after the client's `attach` request
+// completes. OnDisconnected fires on `disconnect` or wire EOF.
+// Both are load-bearing for nessy's pause-on-attach semantics
+// (issue #212).
+func TestAttachConfig_OnAttachedAndOnDisconnected(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+
+	ram := cpu.NewRAM()
+	c := cpu.New(ram)
+
+	var attached, disconnected atomic.Int32
+
+	srv := NewServer(serverConn, serverConn)
+	cfg := AttachConfig{
+		CPU: c,
+		RAM: ram,
+		OnAttached: func() {
+			attached.Add(1)
+		},
+		OnDisconnected: func() {
+			disconnected.Add(1)
+		},
+	}
+	if err := srv.AttachExisting(cfg); err != nil {
+		t.Fatalf("AttachExisting: %v", err)
+	}
+	go func() {
+		_ = srv.Serve()
+		_ = serverConn.Close()
+	}()
+
+	client := NewClient(clientConn, clientConn)
+	defer func() { _ = client.Close() }()
+
+	if _, err := client.Initialize(InitializeArguments{}); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	if attached.Load() != 0 {
+		t.Errorf("OnAttached fired before attach request")
+	}
+
+	if _, err := client.Attach(); err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+
+	// Server fires the callback synchronously inside handleAttach
+	// before the response lands, but allow a brief settle for the
+	// JSON write to flush.
+	deadline := time.After(2 * time.Second)
+	for attached.Load() == 0 {
+		select {
+		case <-deadline:
+			t.Fatalf("OnAttached never fired after successful attach")
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	if disconnected.Load() != 0 {
+		t.Errorf("OnDisconnected fired before disconnect: count=%d", disconnected.Load())
+	}
+
+	if err := client.Disconnect(); err != nil {
+		t.Fatalf("disconnect: %v", err)
+	}
+
+	deadline = time.After(2 * time.Second)
+	for disconnected.Load() == 0 {
+		select {
+		case <-deadline:
+			t.Fatalf("OnDisconnected never fired after client.Disconnect()")
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	// OnDisconnected must fire exactly once even though Serve()'s
+	// EOF exit path and handleDisconnect both call fireDisconnected.
+	if got := disconnected.Load(); got != 1 {
+		t.Errorf("OnDisconnected fired %d times; want exactly 1", got)
+	}
+}
+
+// Wire EOF (client closes without sending disconnect) also fires
+// OnDisconnected — matches the nessy "user kills chippy TUI" path.
+func TestAttachConfig_OnDisconnected_FiresOnEOF(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+
+	ram := cpu.NewRAM()
+	c := cpu.New(ram)
+
+	var disconnected atomic.Int32
+
+	srv := NewServer(serverConn, serverConn)
+	if err := srv.AttachExisting(AttachConfig{
+		CPU: c, RAM: ram,
+		OnDisconnected: func() { disconnected.Add(1) },
+	}); err != nil {
+		t.Fatalf("AttachExisting: %v", err)
+	}
+	done := make(chan struct{})
+	go func() {
+		_ = srv.Serve()
+		close(done)
+	}()
+
+	// Close client side without sending disconnect. Server's read
+	// loop gets EOF and exits Serve(); deferred fireDisconnected
+	// runs.
+	_ = clientConn.Close()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Serve did not exit within 2s after client EOF")
+	}
+	if got := disconnected.Load(); got != 1 {
+		t.Errorf("OnDisconnected fired %d times after EOF; want 1", got)
+	}
+}

--- a/internal/dap/server.go
+++ b/internal/dap/server.go
@@ -86,6 +86,19 @@ type Server struct {
 	// RAM / peripheral access with a concurrently-running TUI. nil
 	// means single-surface mode; the locking helpers below are no-ops.
 	cpuMu *sync.Mutex
+
+	// onAttached / onDisconnected fire at the request lifecycle
+	// boundaries: handleAttach success + disconnect/EOF. Hosts use
+	// these to gate their own run loops (e.g. nessy pauses its game
+	// loop while a client is attached so the server's `continue`
+	// runLoop owns execution). nil = no-op. Set via AttachConfig.
+	onAttached     func()
+	onDisconnected func()
+
+	// disconnectedFired guards onDisconnected against double-fire
+	// when both Serve()'s EOF exit and a client-initiated disconnect
+	// race to invoke it.
+	disconnectedFired atomic.Bool
 }
 
 // lockCPU acquires s.cpuMu if present. Paired with unlockCPU. Used by
@@ -123,8 +136,11 @@ func NewServer(r io.Reader, w io.Writer) *Server {
 }
 
 // Serve runs the dispatch loop until EOF, write failure, or a successful
-// disconnect/terminate. Returns nil on a clean shutdown.
+// disconnect/terminate. Returns nil on a clean shutdown. Fires
+// OnDisconnected exactly once on exit so the host can resume its own
+// run loop.
 func (s *Server) Serve() error {
+	defer s.fireDisconnected()
 	for {
 		if s.terminated {
 			return nil
@@ -408,6 +424,7 @@ func (s *Server) handleDisconnect(req Request) {
 		_ = s.tracer.Close()
 	}
 	s.terminated = true
+	s.fireDisconnected()
 }
 
 func (s *Server) handleTerminate(req Request) {
@@ -418,6 +435,21 @@ func (s *Server) handleTerminate(req Request) {
 		_ = s.tracer.Close()
 	}
 	s.terminated = true
+	s.fireDisconnected()
+}
+
+// fireDisconnected invokes the host's OnDisconnected callback (if any)
+// exactly once per Server. The `disconnectedFired` guard handles the
+// case where Serve()'s EOF path and a client-initiated disconnect
+// request both try to fire it.
+func (s *Server) fireDisconnected() {
+	if s.onDisconnected == nil {
+		return
+	}
+	if s.disconnectedFired.Swap(true) {
+		return
+	}
+	s.onDisconnected()
 }
 
 // stopRunLoop signals the run-loop goroutine (if any) to exit and waits


### PR DESCRIPTION
## Summary
Closes #212. nessy's game loop no longer races chippy's DAP server. When a client attaches, the game loop yields; the server's `continue` run loop is the only stepper. Pressing `s` in the TUI now advances exactly one instruction; `r` runs / pauses cleanly.

## Mechanism
- `dap.AttachConfig` gains `OnAttached` / `OnDisconnected` callbacks. Server fires `OnAttached` from `handleAttach` after the attach response and `OnDisconnected` from a `defer` in `Serve()` + the explicit disconnect/terminate handlers. An atomic `disconnectedFired` guards against double-fire when the EOF path and a client `disconnect` race.
- `cmd/nessy` keeps a package-level `dapAttached atomic.Int32`. The accept loop's callbacks +/-1 it. `game.Update()` checks it at the top — if non-zero, return without stepping (still calls `pollInput` for joypad latency parity and lets Ebiten Draw paint the last-rendered frame).

## State matrix
| Attached | Server running | Stepper |
|---|---|---|
| 0 | — | Game loop (autonomous, ~30k cyc/frame) |
| ≥1 | no | Nobody (paused; framebuffer frozen) |
| ≥1 | yes (`continue` active) | DAP server `runLoop` |

## Tests
- `TestAttachConfig_OnAttachedAndOnDisconnected` — full handshake over `net.Pipe`; asserts callbacks fire in order, exactly once each.
- `TestAttachConfig_OnDisconnected_FiresOnEOF` — client closes without disconnect request; `Serve()` exits via EOF; deferred fire still runs.
- Existing dap + tui + nessy tests stay green.

## Test plan
- [x] `go build ./...`
- [x] `go build -tags=nessy ./cmd/nessy`
- [x] `go test -race -count=1 ./...`
- [x] `golangci-lint run ./...`
- [ ] (Manual) attach chippy TUI to nessy: game pauses immediately; `s` advances 1 instruction; `r` runs; `r` pauses; `q` disconnects → game resumes.

Closes #212