### PR TITLE
feat(chippy): -nessy ROM — one-shell launcher for nessy + paused TUI (#213)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,22 @@ the v0.2+ roadmap.
 
 Controls: Arrows = D-pad, Z = A, X = B, Enter = Start, Right Shift = Select.
 
+#### One-shell debug launch
+
+Skip the two-terminal dance. `chippy -nessy ROM` spawns nessy in the
+background, dials its DAP listener, and opens the TUI in attach mode
+paused at the reset vector:
+
+```sh
+chippy -nessy roms/demos/hello-bg/hello-bg.nes
+```
+
+Press `r` to run, `s` to step, `b` to toggle a breakpoint at the
+current PC, `q` to quit (also shuts down the nessy game window).
+
+If the chippy binary can't find `nessy` on `$PATH` or as a sibling,
+pass `-nessy-binary PATH`. Build a local nessy with `go build -tags=nessy -o nessy ./cmd/nessy`.
+
 #### Demos
 
 Three homemade demos ship under [`roms/demos/`](roms/demos/) — hand-rolled

--- a/cmd/chippy/dap_attach.go
+++ b/cmd/chippy/dap_attach.go
@@ -26,53 +26,85 @@ import (
 //	tcp:HOST:PORT      explicit transport
 //	HOST:PORT          tcp default
 //
-// Mutually exclusive with -rom and -dap (enforced in main).
+// Mutually exclusive with -rom, -dap, and -nessy (enforced in main).
 func runDAPAttach(addr string) {
+	client, err := dialAndHandshake(addr, false)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "dap-attach:", err)
+		os.Exit(1)
+	}
+	runAttachedTUI(client, addr, fmt.Sprintf("attached: %s", addr))
+}
+
+// dialAndHandshake opens a DAP connection and drives initialize +
+// attach. Returns the live client ready for the TUI to consume.
+// `stopOnEntry` controls whether to ask the server to emit a stopped
+// event immediately — `-nessy` wants that so the launched game pauses
+// at the reset vector; `-dap-attach` keeps the legacy "don't pause an
+// already-running session" default.
+func dialAndHandshake(addr string, stopOnEntry bool) (*dap.Client, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	client, err := dap.Dial(ctx, addr)
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "dap-attach:", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("dial %s: %w", addr, err)
 	}
-	defer func() { _ = client.Close() }()
 
 	if _, err := client.Initialize(dap.InitializeArguments{ClientID: "chippy", AdapterID: "chippy"}); err != nil {
-		fmt.Fprintln(os.Stderr, "dap-attach: initialize:", err)
-		os.Exit(1)
-	}
-	resp, err := client.Attach()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "dap-attach: attach:", err)
-		os.Exit(1)
-	}
-	if !resp.Success {
-		fmt.Fprintln(os.Stderr, "dap-attach: attach refused:", resp.Message)
-		os.Exit(1)
+		_ = client.Close()
+		return nil, fmt.Errorf("initialize: %w", err)
 	}
 
+	attachArgs := map[string]any{}
+	if stopOnEntry {
+		attachArgs["stopOnEntry"] = true
+	}
+	resp, err := client.Request("attach", attachArgs)
+	if err != nil {
+		_ = client.Close()
+		return nil, fmt.Errorf("attach: %w", err)
+	}
+	if !resp.Success {
+		_ = client.Close()
+		return nil, fmt.Errorf("attach refused: %s", resp.Message)
+	}
+	return client, nil
+}
+
+// runAttachedTUI builds the mirror CPU + RAM, wraps the live client in
+// a RemoteSource, refreshes initial register state, and runs the TUI
+// to completion. On exit (clean or error) the RemoteSource is closed
+// — which sends a DAP `disconnect` and tears down the wire.
+//
+// `onExit`, if non-nil, runs after RemoteSource.Close() and before
+// returning to the caller. The launcher uses it to SIGTERM the nessy
+// child process so the game window goes away when the TUI quits.
+func runAttachedTUI(client *dap.Client, addr, initialStatus string, onExit ...func()) {
 	// Mirror state. The TUI's display panels read these fields
 	// directly; RemoteSource writes them after every step / refresh.
-	// Initial values are placeholder zeros — refreshed before the TUI
-	// boots so the first frame renders the live remote PC + regs.
 	ram := cpu.NewRAM()
 	mirror := cpu.NewVariant(ram, cpu.VariantNMOS)
 
 	source := tui.NewRemoteSource(client, mirror, ram, addr)
 	if err := source.RefreshRegs(); err != nil {
-		fmt.Fprintln(os.Stderr, "dap-attach: initial register sync:", err)
+		fmt.Fprintln(os.Stderr, "chippy: initial register sync:", err)
 		// Continue anyway — the next stopped event will refresh.
 	}
 
 	model := tui.New(mirror, ram).WithSource(source)
-	model.Status = fmt.Sprintf("attached: %s", addr)
+	model.Status = initialStatus
 
 	p := tea.NewProgram(model, tea.WithAltScreen())
-	if _, err := p.Run(); err != nil {
-		fmt.Fprintln(os.Stderr, "dap-attach:", err)
-		_ = source.Close()
+	_, runErr := p.Run()
+	_ = source.Close()
+	for _, fn := range onExit {
+		if fn != nil {
+			fn()
+		}
+	}
+	if runErr != nil {
+		fmt.Fprintln(os.Stderr, "chippy:", runErr)
 		os.Exit(1)
 	}
-	_ = source.Close()
 }

--- a/cmd/chippy/main.go
+++ b/cmd/chippy/main.go
@@ -27,15 +27,26 @@ func main() {
 		tracePath   = flag.String("trace", "", "write per-instruction execution trace to this file")
 		runOnStart  = flag.Bool("run-on-start", false, "start the CPU running instead of paused (pair with -trace for non-interactive capture)")
 		dapMode     = flag.String("dap", "", "run as a Debug Adapter Protocol server instead of the TUI: 'stdio' or 'tcp:PORT'")
-		dapAttach   = flag.String("dap-attach", "", "connect out to a remote DAP server (tcp:HOST:PORT) — Phase A: handshake-only smoke test, see #180")
+		dapAttach   = flag.String("dap-attach", "", "connect out to a remote DAP server (tcp:HOST:PORT) and open the TUI in attach mode")
+		nessyROM    = flag.String("nessy", "", "spawn nessy with this iNES ROM + attach the TUI to it (paused at reset)")
+		nessyBinary = flag.String("nessy-binary", "", "path to the nessy binary (overrides $PATH lookup + chippy-sibling fallback)")
 		textBufCap  = flag.Int("text-buf-cap", peripheral.DefaultTextOutputCap, "TextOutput ($F001) buffer cap in bytes; 0 = unbounded")
 		theme       = flag.String("theme", "", "color palette: default | mono | protan | tritan. NO_COLOR=1 forces mono regardless.")
 		traceReplay = flag.String("trace-replay", "", "open a prior trace file in replay mode (step keys scroll through recorded frames; CPU stays paused)")
 	)
 	flag.Parse()
 
-	if *dapMode != "" && *dapAttach != "" {
-		fmt.Fprintln(os.Stderr, "chippy: -dap and -dap-attach are mutually exclusive")
+	// Mode-flag mutual-exclusion. The four entry points (TUI / -dap /
+	// -dap-attach / -nessy) each consume the whole process; pairing
+	// any two of them is a configuration error.
+	exclusive := 0
+	for _, set := range []bool{*dapMode != "", *dapAttach != "", *nessyROM != ""} {
+		if set {
+			exclusive++
+		}
+	}
+	if exclusive > 1 {
+		fmt.Fprintln(os.Stderr, "chippy: -dap, -dap-attach, and -nessy are mutually exclusive")
 		os.Exit(2)
 	}
 	if *dapMode != "" {
@@ -48,6 +59,14 @@ func main() {
 			os.Exit(2)
 		}
 		runDAPAttach(*dapAttach)
+		return
+	}
+	if *nessyROM != "" {
+		if *romPath != "" {
+			fmt.Fprintln(os.Stderr, "chippy: -rom and -nessy are mutually exclusive (the nessy ROM is the program)")
+			os.Exit(2)
+		}
+		runNessyLauncher(*nessyROM, *nessyBinary)
 		return
 	}
 

--- a/cmd/chippy/nessy_launcher.go
+++ b/cmd/chippy/nessy_launcher.go
@@ -1,0 +1,167 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"time"
+)
+
+// runNessyLauncher spawns a nessy child process, waits for its DAP
+// listener to come up, dials + handshakes with stopOnEntry=true so
+// the game is paused at the reset vector, then opens the TUI. On
+// TUI exit the child is signalled to shut down.
+//
+// One-shell UX:
+//
+//	chippy -nessy game.nes
+//
+// nessy's window opens; the chippy TUI opens in the same terminal
+// (alt-screen). User drives execution with `s` / `r` / `b`. Pressing
+// `q` quits the TUI and tears down the game window.
+func runNessyLauncher(romPath, nessyBin string) {
+	bin, err := resolveNessyBinary(nessyBin)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "chippy -nessy:", err)
+		os.Exit(1)
+	}
+
+	port, err := pickFreePort()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "chippy -nessy: pick port:", err)
+		os.Exit(1)
+	}
+
+	cmd := exec.Command(bin, "-rom", romPath, "-dap-port", strconv.Itoa(port))
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		fmt.Fprintln(os.Stderr, "chippy -nessy: spawn:", err)
+		os.Exit(1)
+	}
+
+	// If the child crashes or exits before we've cleaned up the TUI,
+	// the deferred kill should not error out — log and continue.
+	defer func() {
+		if cmd.Process != nil {
+			_ = killChild(cmd)
+		}
+	}()
+
+	addr := fmt.Sprintf("tcp:127.0.0.1:%d", port)
+	if err := waitForListener(port, 5*time.Second); err != nil {
+		_ = killChild(cmd)
+		fmt.Fprintln(os.Stderr, "chippy -nessy: nessy DAP listener never came up:", err)
+		os.Exit(1)
+	}
+
+	client, err := dialAndHandshake(addr, true)
+	if err != nil {
+		_ = killChild(cmd)
+		fmt.Fprintln(os.Stderr, "chippy -nessy:", err)
+		os.Exit(1)
+	}
+
+	runAttachedTUI(client, addr,
+		fmt.Sprintf("nessy: %s (paused — press r to run, s to step)", filepath.Base(romPath)),
+		func() { _ = killChild(cmd) },
+	)
+}
+
+// resolveNessyBinary picks the nessy executable. Search order:
+//
+//  1. explicit override (`-nessy-binary PATH`).
+//  2. `nessy` on $PATH.
+//  3. sibling of the running chippy executable (same directory).
+//
+// Returns an error with all three failures noted when none of the
+// candidates exist + execute.
+func resolveNessyBinary(override string) (string, error) {
+	if override != "" {
+		if _, err := os.Stat(override); err == nil {
+			return override, nil
+		}
+		return "", fmt.Errorf("-nessy-binary %q: %w", override, errors.New("not found"))
+	}
+	if p, err := exec.LookPath("nessy"); err == nil {
+		return p, nil
+	}
+	if self, err := os.Executable(); err == nil {
+		candidate := filepath.Join(filepath.Dir(self), nessyBaseName())
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		}
+	}
+	return "", errors.New(
+		"nessy binary not found — install via `go install -tags=nessy github.com/nkane/chippy/cmd/nessy@latest`, " +
+			"or pass `-nessy-binary PATH`")
+}
+
+func nessyBaseName() string {
+	if runtime.GOOS == "windows" {
+		return "nessy.exe"
+	}
+	return "nessy"
+}
+
+// pickFreePort grabs an ephemeral TCP port the kernel picks for us
+// and immediately closes the listener. There's a small race window
+// where another process could re-grab the port before nessy claims
+// it; in practice on a developer machine this is negligible.
+func pickFreePort() (int, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = ln.Close() }()
+	return ln.Addr().(*net.TCPAddr).Port, nil
+}
+
+// waitForListener polls localhost:port until a TCP dial succeeds or
+// the deadline expires. Used to gate the chippy-side DAP handshake on
+// nessy's listener being ready — without it the dial loses a race
+// with nessy's startup (open ROM, parse, build NES, start DAP
+// listener) which can take 50-200 ms on first run.
+func waitForListener(port int, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	target := fmt.Sprintf("127.0.0.1:%d", port)
+	for {
+		conn, err := net.DialTimeout("tcp", target, 250*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("dial %s: %w", target, err)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// killChild sends a graceful signal first and falls back to a hard
+// kill if the process doesn't exit within 2 s. On Windows there's no
+// SIGTERM; `Process.Kill()` is the only option.
+func killChild(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	if runtime.GOOS == "windows" {
+		return cmd.Process.Kill()
+	}
+	if err := cmd.Process.Signal(os.Interrupt); err != nil {
+		return cmd.Process.Kill()
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case <-done:
+		return nil
+	case <-time.After(2 * time.Second):
+		return cmd.Process.Kill()
+	}
+}

--- a/cmd/chippy/nessy_launcher_test.go
+++ b/cmd/chippy/nessy_launcher_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// resolveNessyBinary's explicit-override branch points at the path
+// caller supplied — verifies the file exists then returns it.
+func TestResolveNessyBinary_OverrideExists(t *testing.T) {
+	tmp := t.TempDir()
+	fake := filepath.Join(tmp, "fake-nessy")
+	if err := os.WriteFile(fake, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("create fake binary: %v", err)
+	}
+	got, err := resolveNessyBinary(fake)
+	if err != nil {
+		t.Fatalf("resolveNessyBinary(%s): %v", fake, err)
+	}
+	if got != fake {
+		t.Errorf("resolveNessyBinary = %q; want %q", got, fake)
+	}
+}
+
+// Override path that doesn't exist errors clearly.
+func TestResolveNessyBinary_OverrideMissing(t *testing.T) {
+	_, err := resolveNessyBinary("/no/such/path/nessy")
+	if err == nil {
+		t.Fatalf("resolveNessyBinary(missing) returned nil error")
+	}
+}
+
+// nessyBaseName picks the right extension for the host OS.
+func TestNessyBaseName(t *testing.T) {
+	got := nessyBaseName()
+	if runtime.GOOS == "windows" {
+		if got != "nessy.exe" {
+			t.Errorf("Windows base = %q; want nessy.exe", got)
+		}
+	} else {
+		if got != "nessy" {
+			t.Errorf("non-Windows base = %q; want nessy", got)
+		}
+	}
+}
+
+// pickFreePort returns a port the kernel just allocated. The port
+// number must be > 0 and re-listenable on the same address (no
+// already-bound TIME_WAIT residue).
+func TestPickFreePort(t *testing.T) {
+	port, err := pickFreePort()
+	if err != nil {
+		t.Fatalf("pickFreePort: %v", err)
+	}
+	if port <= 0 || port > 65535 {
+		t.Errorf("port = %d; want 1..65535", port)
+	}
+	ln, err := net.Listen("tcp", net.JoinHostPort("127.0.0.1", "0"))
+	if err != nil {
+		t.Fatalf("relisten: %v", err)
+	}
+	_ = ln.Close()
+}
+
+// waitForListener succeeds when a listener exists on the target
+// port. The 2-second deadline is enough for the loopback to settle.
+func TestWaitForListener_Found(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	if err := waitForListener(port, 2*time.Second); err != nil {
+		t.Errorf("waitForListener: %v", err)
+	}
+}
+
+// waitForListener times out when nothing's listening on the target.
+// 200 ms is fast enough to keep the test snappy.
+func TestWaitForListener_Timeout(t *testing.T) {
+	// Grab + release a port so we know nothing else is on it for the
+	// scope of this test.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	_ = ln.Close()
+
+	if err := waitForListener(port, 200*time.Millisecond); err == nil {
+		t.Errorf("waitForListener should have timed out")
+	}
+}


### PR DESCRIPTION
Closes #213. Replaces the two-terminal `nessy game.nes` + `chippy -dap-attach …` dance with a single command:

```sh
chippy -nessy roms/demos/hello-bg/hello-bg.nes
```

The game window opens, the TUI opens in the same terminal (alt-screen), CPU sits paused at the reset vector. Press `r` to run, `s` to step, `b` to breakpoint, `q` to quit (which also shuts down the nessy child).

## Launcher steps
1. Resolve nessy binary: `-nessy-binary` override → `$PATH` lookup → sibling of running chippy.
2. Pick a free ephemeral port from the kernel.
3. Spawn `nessy -rom ROM -dap-port PORT`, inheriting stdio.
4. Poll port until listener accepts (5 s deadline; 50 ms tick).
5. Dial DAP + `initialize` + `attach` with `stopOnEntry: true`. Combined with #212's real pause semantics, the game stays frozen until `r`.
6. Open TUI via shared `runAttachedTUI`.
7. On exit: SIGTERM child, fall back to SIGKILL after 2 s.

## Refactor
`runDAPAttach` split into two helpers:
- `dialAndHandshake(addr, stopOnEntry)` — dial + initialize + attach. Returns the live `*dap.Client`.
- `runAttachedTUI(client, addr, status, onExit...)` — mirror + RemoteSource + tea.NewProgram. Optional `onExit` hooks run after the source closes.

Both `-dap-attach` and `-nessy` now share that TUI startup.

## Mutex
The four entry-point flags (`-dap` / `-dap-attach` / `-nessy` / default-rom) are mutually exclusive. Setting more than one fails with a clear message.

## Tests
- `resolveNessyBinary`: override branch (existing + missing paths).
- `nessyBaseName`: per-OS extension.
- `pickFreePort`: kernel-allocated port is in range + re-listenable.
- `waitForListener`: success + timeout paths against a real local listener.

## Test plan
- [x] `go build ./...`
- [x] `go test -race -count=1 ./...`
- [x] `golangci-lint run ./...`
- [ ] (Manual) `chippy -nessy roms/demos/hello-bg/hello-bg.nes` — game window opens paused, TUI shows reset PC; `r` runs, `q` quits both.

Closes #213