### PR TITLE
fix(chippy -nessy): load sibling .dbg locally for source view + symbol names

### DIFF
--- a/cmd/chippy/dap_attach.go
+++ b/cmd/chippy/dap_attach.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/nkane/chippy/internal/cpu"
 	"github.com/nkane/chippy/internal/dap"
+	"github.com/nkane/chippy/internal/symbols"
 	"github.com/nkane/chippy/internal/tui"
 )
 
@@ -33,7 +34,11 @@ func runDAPAttach(addr string) {
 		fmt.Fprintln(os.Stderr, "dap-attach:", err)
 		os.Exit(1)
 	}
-	runAttachedTUI(client, addr, fmt.Sprintf("attached: %s", addr))
+	runAttachedTUI(attachedTUIConfig{
+		client: client,
+		addr:   addr,
+		status: fmt.Sprintf("attached: %s", addr),
+	})
 }
 
 // dialAndHandshake opens a DAP connection and drives initialize +
@@ -72,33 +77,65 @@ func dialAndHandshake(addr string, stopOnEntry bool) (*dap.Client, error) {
 	return client, nil
 }
 
+// attachedTUIConfig bundles every knob runAttachedTUI accepts so
+// adding new optional knobs doesn't keep ballooning the function
+// signature.
+type attachedTUIConfig struct {
+	client *dap.Client
+	addr   string
+	status string
+
+	// syms / srcMap (optional) populate the TUI's symbol-name +
+	// PC→source-line maps so the disasm panel renders names and `v`
+	// can switch to the source panel. Both processes (this chippy +
+	// the remote nessy) run on the same machine, so loading the
+	// `.dbg` locally is the cheapest path to source-view.
+	syms   *symbols.Table
+	srcMap *symbols.SourceMap
+
+	// showSource defaults the panel to source-view on startup (vs
+	// disasm). `-nessy` flips this on so the user sees ca65 lines
+	// immediately; `-dap-attach` keeps the disasm-first default
+	// since the attached process may not have local source.
+	showSource bool
+
+	// onExit hooks run after RemoteSource.Close() and before this
+	// helper returns. Launcher uses it to SIGTERM the nessy child.
+	onExit []func()
+}
+
 // runAttachedTUI builds the mirror CPU + RAM, wraps the live client in
 // a RemoteSource, refreshes initial register state, and runs the TUI
 // to completion. On exit (clean or error) the RemoteSource is closed
 // — which sends a DAP `disconnect` and tears down the wire.
-//
-// `onExit`, if non-nil, runs after RemoteSource.Close() and before
-// returning to the caller. The launcher uses it to SIGTERM the nessy
-// child process so the game window goes away when the TUI quits.
-func runAttachedTUI(client *dap.Client, addr, initialStatus string, onExit ...func()) {
+func runAttachedTUI(c attachedTUIConfig) {
 	// Mirror state. The TUI's display panels read these fields
 	// directly; RemoteSource writes them after every step / refresh.
 	ram := cpu.NewRAM()
 	mirror := cpu.NewVariant(ram, cpu.VariantNMOS)
 
-	source := tui.NewRemoteSource(client, mirror, ram, addr)
+	source := tui.NewRemoteSource(c.client, mirror, ram, c.addr)
 	if err := source.RefreshRegs(); err != nil {
 		fmt.Fprintln(os.Stderr, "chippy: initial register sync:", err)
 		// Continue anyway — the next stopped event will refresh.
 	}
 
 	model := tui.New(mirror, ram).WithSource(source)
-	model.Status = initialStatus
+	if c.syms != nil {
+		model = model.WithSymbols(c.syms)
+	}
+	if c.srcMap != nil {
+		model = model.WithSourceMap(c.srcMap)
+	}
+	if c.showSource {
+		model.ShowSource = true
+	}
+	model.Status = c.status
 
 	p := tea.NewProgram(model, tea.WithAltScreen())
 	_, runErr := p.Run()
 	_ = source.Close()
-	for _, fn := range onExit {
+	for _, fn := range c.onExit {
 		if fn != nil {
 			fn()
 		}

--- a/cmd/chippy/nessy_launcher.go
+++ b/cmd/chippy/nessy_launcher.go
@@ -10,6 +10,8 @@ import (
 	"runtime"
 	"strconv"
 	"time"
+
+	"github.com/nkane/chippy/internal/symbols"
 )
 
 // runNessyLauncher spawns a nessy child process, waits for its DAP
@@ -67,10 +69,46 @@ func runNessyLauncher(romPath, nessyBin string) {
 		os.Exit(1)
 	}
 
-	runAttachedTUI(client, addr,
-		fmt.Sprintf("nessy: %s (paused — press r to run, s to step)", filepath.Base(romPath)),
-		func() { _ = killChild(cmd) },
-	)
+	// Source view + symbol resolution. Both processes run on the
+	// same machine and the .dbg references local file paths, so the
+	// cheapest path is to load it ourselves rather than wire DAP
+	// `source` / `loadedSources` requests just yet. nessy already
+	// loaded the same file on its side; the redundancy is fine.
+	syms, srcMap := loadSiblingDbg(romPath)
+
+	runAttachedTUI(attachedTUIConfig{
+		client:     client,
+		addr:       addr,
+		status:     fmt.Sprintf("nessy: %s (paused — press r to run, s to step)", filepath.Base(romPath)),
+		syms:       syms,
+		srcMap:     srcMap,
+		showSource: srcMap != nil, // source-view first if we have line info
+		onExit:     []func(){func() { _ = killChild(cmd) }},
+	})
+}
+
+// loadSiblingDbg auto-detects a `.dbg` next to the ROM and loads the
+// symbol table + source map. Missing or unparseable files surface as
+// warnings, not fatal errors — the launcher still opens the TUI,
+// just without source-view.
+func loadSiblingDbg(romPath string) (*symbols.Table, *symbols.SourceMap) {
+	dbg := symbols.SiblingDbg(romPath)
+	if dbg == "" {
+		return nil, nil
+	}
+	var syms *symbols.Table
+	var srcMap *symbols.SourceMap
+	if t, err := symbols.LoadDbg(dbg); err != nil {
+		fmt.Fprintln(os.Stderr, "chippy -nessy: load dbg:", err)
+	} else {
+		syms = t
+	}
+	if sm, err := symbols.LoadSourceMap(dbg); err != nil {
+		fmt.Fprintln(os.Stderr, "chippy -nessy: load source map:", err)
+	} else {
+		srcMap = sm
+	}
+	return syms, srcMap
 }
 
 // resolveNessyBinary picks the nessy executable. Search order:


### PR DESCRIPTION
After landing #213, the launcher attached cleanly but pressing `v` didn't reveal source. Root cause: chippy's TUI populates `PCToSrc` only via `WithSourceMap`; the launcher passed the live RemoteSource but no symbol/source data, so the view fell through to disasm regardless of toggle.

## Fix
The launcher now loads the sibling `.dbg` locally (same logic nessy uses for its DAP server-side wiring) and threads `*symbols.Table` + `*symbols.SourceMap` into the Model via `WithSymbols` + `WithSourceMap`. Both processes run on the same machine; the redundancy is cheap.

Bonus: defaults `ShowSource = true` when a source map loads, so the user sees ca65 lines on first paint without needing the `v` keystroke.

## Refactor
`runAttachedTUI` takes an `attachedTUIConfig` struct so future knobs (syms / srcMap / showSource / onExit) don't keep ballooning the positional signature.

## Test plan
- [x] `go build ./...`
- [x] `go test -race -count=1 ./...`
- [x] `golangci-lint run ./...`
- [ ] (Manual) `chippy -nessy roms/demos/hello-bg/hello-bg.nes` shows the ca65 source in the panel immediately; `v` toggles to disasm; PC cursor follows in source view as `s` steps.