### PR TITLE
fix(symbols): try multiple paths when resolving .dbg source files

### DIFF
--- a/cmd/nessy/debug_load_test.go
+++ b/cmd/nessy/debug_load_test.go
@@ -53,6 +53,17 @@ func TestDebug_AutoDetectAndLoadHelloBG(t *testing.T) {
 	if loc.Line == 0 {
 		t.Errorf("source mapping has line=0; expected a real line number")
 	}
+	// The Files map must contain the loaded source — `(file
+	// unavailable: hello-bg.s)` in the TUI source-view came from
+	// this map being empty because the resolver couldn't find the
+	// file on disk.
+	lines, ok := sm.Files[loc.File]
+	if !ok {
+		t.Fatalf("sm.Files[%q] missing — source resolver couldn't load the file from disk", loc.File)
+	}
+	if len(lines) < 10 {
+		t.Errorf("sm.Files[%q] has %d lines; expected the full source", loc.File, len(lines))
+	}
 	// `reset` is a documented exported symbol via ca65's `-g` debug
 	// output; the symbol table should resolve it.
 	if pc, ok := tbl.LookupName("reset"); !ok || pc != 0xC000 {

--- a/internal/symbols/symbols.go
+++ b/internal/symbols/symbols.go
@@ -280,6 +280,22 @@ func (sm *SourceMap) IsData(addr uint16) bool {
 	return false
 }
 
+// sourceFileCandidates lists the on-disk paths to try when locating
+// a source file recorded in a `.dbg`. Order is intentional: absolute
+// path → dbg-relative → basename-in-dbgdir → parent-of-dbgdir-relative.
+// First existing readable file wins; missing ones fall through.
+func sourceFileCandidates(dbgDir, recorded string) []string {
+	if filepath.IsAbs(recorded) {
+		return []string{recorded}
+	}
+	parent := filepath.Dir(dbgDir)
+	return []string{
+		filepath.Join(dbgDir, recorded),
+		filepath.Join(dbgDir, filepath.Base(recorded)),
+		filepath.Join(parent, recorded),
+	}
+}
+
 // LoadSourceMap parses a cc65 .dbg file and returns a SourceMap.
 //
 // cc65 emits records like:
@@ -432,7 +448,17 @@ func LoadSourceMap(dbgPath string) (*SourceMap, error) {
 		}
 	}
 
-	// Read source files (relative to the .dbg's directory if not absolute).
+	// Read source files. ca65 / ld65 records the path it was invoked
+	// with, so the on-disk location depends on the build's working
+	// directory. Try a few candidates to be robust to common build
+	// layouts:
+	//   1. Absolute path as recorded.
+	//   2. Relative to the .dbg's directory.
+	//   3. Just the basename, in the .dbg's directory (fixes the
+	//      "ld65 invoked from one-up dir" pattern where the .dbg ends
+	//      up with `subdir/file.s` and the loader's caller looked one
+	//      level too deep).
+	//   4. Walking up one directory from the .dbg.
 	dbgDir := filepath.Dir(dbgPath)
 	sources := map[string][]string{}
 	seen := map[string]bool{}
@@ -441,11 +467,14 @@ func LoadSourceMap(dbgPath string) (*SourceMap, error) {
 			continue
 		}
 		seen[fr.name] = true
-		path := fr.name
-		if !filepath.IsAbs(path) {
-			path = filepath.Join(dbgDir, fr.name)
+		var data []byte
+		var err error
+		for _, candidate := range sourceFileCandidates(dbgDir, fr.name) {
+			data, err = os.ReadFile(candidate)
+			if err == nil {
+				break
+			}
 		}
-		data, err := os.ReadFile(path)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
TUI source-view rendered \`(file unavailable: hello-bg/hello-bg.s)\` because ld65 records the path it was invoked with — not the path relative to the .dbg's location. Our demo Makefile runs ld65 from \`roms/demos/\` with input \`hello-bg/hello-bg.s\`, so the .dbg ends up with \`hello-bg/hello-bg.s\` as the file name. \`LoadSourceMap\` then joined that with the .dbg's directory producing \`roms/demos/hello-bg/hello-bg/hello-bg.s\` — doesn't exist.

## Fix
Try multiple candidate paths when resolving recorded source names:
1. Absolute (as recorded).
2. dbg-relative: \`<dbgDir>/<recorded>\`.
3. basename-in-dbgdir: \`<dbgDir>/<basename>\` — catches the subdir-prefix case we hit.
4. parent-of-dbgdir-relative: \`<parent>/<recorded>\` — mirror-image case.

First readable file wins.

## Test
Extended \`TestDebug_AutoDetectAndLoadHelloBG\` to assert \`sm.Files[loc.File]\` actually contains source lines — the existing assertions passed without catching the on-disk-resolution gap.

## Companion bug
Filed #220 for the \"disasm view shows BRK BRK BRK in attach mode\" issue (uninitialized local RAM mirror; needs DAP \`readMemory\` wiring). Out of scope here.