### PR TITLE
fix(tui/dap): sync remote RAM into mirror via DAP readMemory (#220)

### DIFF
--- a/cmd/chippy/dap_attach.go
+++ b/cmd/chippy/dap_attach.go
@@ -119,6 +119,10 @@ func runAttachedTUI(c attachedTUIConfig) {
 		fmt.Fprintln(os.Stderr, "chippy: initial register sync:", err)
 		// Continue anyway — the next stopped event will refresh.
 	}
+	if err := source.RefreshMemory(); err != nil {
+		fmt.Fprintln(os.Stderr, "chippy: initial memory sync:", err)
+		// Continue anyway — disasm shows zeros until next stop.
+	}
 
 	model := tui.New(mirror, ram).WithSource(source)
 	if c.syms != nil {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -648,6 +648,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "stopped":
 			m.Running = false
 			_ = m.Source.RefreshRegs()
+			_ = m.Source.RefreshMemory()
 			m.Status = fmt.Sprintf("stopped at $%04X", m.CPU.PC)
 		case "terminated":
 			return m, tea.Quit

--- a/internal/tui/source.go
+++ b/internal/tui/source.go
@@ -82,6 +82,14 @@ type Source interface {
 	// the DAP requests to pull PC + regs and writes them into the
 	// mirror.
 	RefreshRegs() error
+
+	// RefreshMemory forces a mirror-sync of CPU bus memory.
+	// LocalSource is a no-op (mirror IS live RAM); RemoteSource
+	// issues a DAP `readMemory` request and writes the bytes into
+	// the mirror's RAM so display panels (disasm, memory) render
+	// correct values instead of zero-byte BRK chains. Called on
+	// every `stopped` event + once on attach.
+	RefreshMemory() error
 }
 
 // LocalSource is the in-process Source backing the default TUI mode.
@@ -154,6 +162,9 @@ func (s *LocalSource) Events() <-chan dap.Event { return nil }
 
 // RefreshRegs is a no-op for LocalSource — the mirror IS the live CPU.
 func (s *LocalSource) RefreshRegs() error { return nil }
+
+// RefreshMemory is a no-op for LocalSource — the mirror IS the live RAM.
+func (s *LocalSource) RefreshMemory() error { return nil }
 
 // Compile-time check.
 var _ Source = (*LocalSource)(nil)

--- a/internal/tui/source_remote.go
+++ b/internal/tui/source_remote.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -106,6 +107,7 @@ func (s *RemoteSource) Step() int {
 		return 0
 	}
 	_ = s.refreshRegs()
+	_ = s.RefreshMemory()
 	return 0
 }
 
@@ -127,6 +129,7 @@ func (s *RemoteSource) StepBack() bool {
 		return false
 	}
 	_ = s.refreshRegs()
+	_ = s.RefreshMemory()
 	return true
 }
 
@@ -165,6 +168,50 @@ func (s *RemoteSource) SetBreakpoints(pcs []uint16) error {
 // event arrives via Events() so the mirror catches up with the new
 // PC.
 func (s *RemoteSource) RefreshRegs() error { return s.refreshRegs() }
+
+// RefreshMemory pulls the full CPU-bus memory ($0000-$FFFF) via DAP
+// `readMemory` and writes it into the mirror's RAM so display panels
+// (disasm, memory) render correct values. Called once on attach and
+// then on every `stopped` event (CPU may have written RAM between
+// stops).
+//
+// 64 KiB per fetch is small enough to feel instant over localhost
+// (~64 KiB / 100+ MB/s = <1 ms); over a real network the request
+// would benefit from a per-page lazy cache, but that's a v0.x
+// refinement.
+//
+// For NROM cartridges the $8000-$FFFF range never changes after
+// reset; for bank-switching mappers (MMC1+, v0.3+ work) this
+// per-stop refresh keeps the mirror current automatically.
+func (s *RemoteSource) RefreshMemory() error {
+	resp, err := s.client.Request("readMemory", map[string]any{
+		"memoryReference": "$0000",
+		"offset":          0,
+		"count":           0x10000,
+	})
+	if err != nil {
+		return fmt.Errorf("readMemory: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("readMemory: %s", resp.Message)
+	}
+	var body struct {
+		Address string `json:"address"`
+		Data    string `json:"data"`
+	}
+	if err := remarshal(resp.Body, &body); err != nil {
+		return fmt.Errorf("readMemory body: %w", err)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(body.Data)
+	if err != nil {
+		return fmt.Errorf("readMemory base64 decode: %w", err)
+	}
+	if len(decoded) > 0x10000 {
+		decoded = decoded[:0x10000]
+	}
+	s.ram.Load(0, decoded)
+	return nil
+}
 
 // Attached returns true for RemoteSource.
 func (s *RemoteSource) Attached() bool { return true }

--- a/internal/tui/source_remote_test.go
+++ b/internal/tui/source_remote_test.go
@@ -138,6 +138,39 @@ func TestRemoteSource_AttachedAndAddress(t *testing.T) {
 	}
 }
 
+// RefreshMemory pulls the full $0000-$FFFF window from the server
+// and writes it into the mirror's RAM. Without this, the TUI's
+// disasm view in attach mode renders all $00 (BRK) — see #220.
+func TestRemoteSource_RefreshMemory_PopulatesMirror(t *testing.T) {
+	conn, serverCPU := spinUpServerCPU(t)
+	client := initAttachedClient(t, conn)
+
+	mirrorRAM := cpu.NewRAM()
+	mirrorCPU := cpu.New(mirrorRAM)
+	src := NewRemoteSource(client, mirrorCPU, mirrorRAM, "tcp:test")
+	defer func() { _ = src.Close() }()
+
+	// Pre-RefreshMemory: mirror is all zeros even though the server
+	// has a program at $C000.
+	if mirrorRAM.Read(0xC000) != 0x00 {
+		t.Fatalf("pre-refresh mirror $C000 = $%02X; want $00 (uninitialized)", mirrorRAM.Read(0xC000))
+	}
+
+	if err := src.RefreshMemory(); err != nil {
+		t.Fatalf("RefreshMemory: %v", err)
+	}
+
+	// Mirror now reflects the server's program bytes.
+	for i, want := range []byte{0xA9, 0x42, 0x8D, 0x00, 0x02, 0x4C, 0x05, 0xC0} {
+		addr := uint16(0xC000 + i)
+		got := mirrorRAM.Read(addr)
+		serverGot := serverCPU.Bus.Read(addr)
+		if got != want {
+			t.Errorf("mirror $%04X = $%02X; want $%02X (server has $%02X)", addr, got, want, serverGot)
+		}
+	}
+}
+
 // LocalSource is the boring case but worth pinning down: Step should
 // advance the CPU's PC by the instruction size.
 func TestLocalSource_StepAdvancesPC(t *testing.T) {


### PR DESCRIPTION
Closes #220. Disasm + memory panels in attach mode no longer render \`BRK BRK BRK\` everywhere.

## Root cause
TUI displays read bytes via the local \`m.RAM\` mirror. In attach mode it started zeroed and was never populated from the remote. Source view dodged this because it reads loaded source files, not RAM.

## Fix
- New \`Source.RefreshMemory()\`. \`LocalSource\` is a no-op (mirror IS live RAM); \`RemoteSource\` sends DAP \`readMemory\` for \$0000-\$FFFF, decodes base64, loads into the mirror.
- Hooked at three points:
  1. \`runAttachedTUI\` initial sync — first frame paints correctly.
  2. \`Step\` / \`StepBack\` after \`refreshRegs\` — single-stepping keeps disasm current.
  3. TUI's \`dapEventMsg\` \`stopped\` handler — server-driven stops (continue → bp, pause, exception) refresh too.

## Cost
64 KiB per fetch over localhost is sub-ms. Per-page lazy caching would be more efficient over real network attach; v0.x refinement.

## NROM vs banked mappers
NROM never bank-switches, so \$8000-\$FFFF is stable. For MMC1+ (v0.3 work) the per-stop refresh keeps the mirror current without special casing.

## Test
\`TestRemoteSource_RefreshMemory_PopulatesMirror\`: drives an in-process server with a known program at \$C000, asserts mirror is zero before refresh and matches server bytes after.

## Test plan
- [x] \`go build ./...\`
- [x] \`go test -race -count=1 ./...\`
- [x] \`golangci-lint run ./...\`
- [ ] (Manual) \`chippy -nessy roms/demos/hello-bg/hello-bg.nes\` → press \`v\` → disasm shows real opcodes (SEI, CLD, LDX, etc.) at \$C000, not BRK.

Closes #220