### PR TITLE
fix(dap): route readMemory through MMIO.Peek so nessy cart bytes show (#220)

### DIFF
--- a/cmd/nessy/dap_readmemory_test.go
+++ b/cmd/nessy/dap_readmemory_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"os"
+
+	"github.com/nkane/chippy/internal/dap"
+	"github.com/nkane/chippy/internal/nes"
+)
+
+// readMemory must return cart PRG bytes, not the underlying ram
+// (which is zero for the cart range on a NES bus). Without the
+// MMIO.Peek routing this test fails: PRG bytes don't live in
+// ram.Data, they live in the cart object behind the MMIO peripheral.
+// See #220.
+func TestDAP_ReadMemory_ReachesCartBytes(t *testing.T) {
+	romPath := filepath.Join("..", "..", "roms", "demos", "hello-bg", "hello-bg.nes")
+	data, err := os.ReadFile(romPath)
+	if err != nil {
+		t.Fatalf("read rom: %v", err)
+	}
+	rom, err := nes.ParseBytes(data)
+	if err != nil {
+		t.Fatalf("parse rom: %v", err)
+	}
+	bus, err := buildNES(rom)
+	if err != nil {
+		t.Fatalf("buildNES: %v", err)
+	}
+
+	clientConn, serverConn := net.Pipe()
+	srv := dap.NewServer(serverConn, serverConn)
+	if err := srv.AttachExisting(dap.AttachConfig{
+		CPU:  bus.cpu,
+		RAM:  bus.ram,
+		MMIO: bus.mmio,
+	}); err != nil {
+		t.Fatalf("AttachExisting: %v", err)
+	}
+	go func() {
+		_ = srv.Serve()
+		_ = serverConn.Close()
+	}()
+	t.Cleanup(func() { _ = serverConn.Close() })
+
+	client := dap.NewClient(clientConn, clientConn)
+	defer func() { _ = client.Close() }()
+	if _, err := client.Initialize(dap.InitializeArguments{}); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	if _, err := client.Attach(); err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	// Drain the initialized + stopped(entry) events.
+	deadline := time.After(500 * time.Millisecond)
+drain:
+	for {
+		select {
+		case _, ok := <-client.Events():
+			if !ok {
+				break drain
+			}
+		case <-deadline:
+			break drain
+		}
+	}
+
+	// Read 16 bytes at $C000 (the cart's reset routine start).
+	resp, err := client.Request("readMemory", map[string]any{
+		"memoryReference": "$C000",
+		"offset":          0,
+		"count":           16,
+	})
+	if err != nil {
+		t.Fatalf("readMemory: %v", err)
+	}
+	if !resp.Success {
+		t.Fatalf("readMemory failed: %s", resp.Message)
+	}
+	raw, err := json.Marshal(resp.Body)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	var body struct {
+		Address string `json:"address"`
+		Data    string `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(body.Data)
+	if err != nil {
+		t.Fatalf("base64 decode: %v", err)
+	}
+	if len(decoded) != 16 {
+		t.Fatalf("decoded length = %d; want 16", len(decoded))
+	}
+	// hello-bg.s reset starts with SEI ($78), CLD ($D8), LDX #$FF
+	// ($A2 $FF). If readMemory was still reading raw `ram` we'd see
+	// all zeros.
+	if decoded[0] != 0x78 {
+		t.Errorf("readMemory[$C000] = $%02X; want $78 (SEI)", decoded[0])
+	}
+	if decoded[1] != 0xD8 {
+		t.Errorf("readMemory[$C001] = $%02X; want $D8 (CLD)", decoded[1])
+	}
+	if decoded[2] != 0xA2 || decoded[3] != 0xFF {
+		t.Errorf("readMemory[$C002..$C003] = $%02X $%02X; want $A2 $FF (LDX #$FF)",
+			decoded[2], decoded[3])
+	}
+}

--- a/cmd/nessy/wiring.go
+++ b/cmd/nessy/wiring.go
@@ -98,5 +98,14 @@ func (w *cartPeripheral) Write(addr uint16, v byte) {
 	w.cart.CPUWrite(addr, v)
 }
 
+// Peek surfaces cart bytes without side effects. NROM's CPURead is
+// already side-effect-free (just a slice index); future bank-switching
+// mappers (MMC1+) should keep this contract — Peek returns whatever
+// the currently-mapped bank shows.
+func (w *cartPeripheral) Peek(addr uint16) byte { return w.cart.CPURead(addr) }
+
 // compile-time check.
-var _ cpu.Peripheral = (*cartPeripheral)(nil)
+var (
+	_ cpu.Peripheral = (*cartPeripheral)(nil)
+	_ cpu.Peeker     = (*cartPeripheral)(nil)
+)

--- a/internal/cpu/decimal_exhaustive_test.go
+++ b/internal/cpu/decimal_exhaustive_test.go
@@ -31,7 +31,7 @@ func referenceADC(n1, n2, cin uint8, cmos bool) (a uint8, c, n, v, z bool) {
 	binByte := byte(bin)
 	flagNbin := binByte&0x80 != 0
 	flagZbin := binByte == 0
-	flagV := ((^(uint16(n1)^uint16(n2)))&(uint16(n1)^bin))&0x80 != 0
+	flagV := ((^(uint16(n1) ^ uint16(n2)))&(uint16(n1)^bin))&0x80 != 0
 
 	al := uint16(n1&0x0F) + uint16(n2&0x0F) + uint16(cin)
 	if al >= 0x0A {
@@ -63,7 +63,7 @@ func referenceSBC(n1, n2, cin uint8, cmos bool) (a uint8, c, n, v, z bool) {
 	bin := uint16(n1) + w + uint16(cin)
 	binByte := byte(bin)
 	flagC := bin > 0xFF
-	flagV := ((^(uint16(n1)^w))&(uint16(n1)^bin))&0x80 != 0
+	flagV := ((^(uint16(n1) ^ w))&(uint16(n1)^bin))&0x80 != 0
 	flagNbin := binByte&0x80 != 0
 	flagZbin := binByte == 0
 

--- a/internal/cpu/peek_test.go
+++ b/internal/cpu/peek_test.go
@@ -1,0 +1,84 @@
+package cpu
+
+import "testing"
+
+// peekablePeripheral implements both Peripheral and Peeker; Peek
+// returns the same bytes regardless of how many times Read is
+// called (Read counts invocations so the test can prove Peek
+// avoided it).
+type peekablePeripheral struct {
+	lo, hi uint16
+	value  byte
+	reads  int
+	writes int
+}
+
+func (p *peekablePeripheral) Range() (uint16, uint16) { return p.lo, p.hi }
+func (p *peekablePeripheral) Read(addr uint16) byte {
+	p.reads++
+	return p.value
+}
+func (p *peekablePeripheral) Write(addr uint16, v byte) { p.writes++; p.value = v }
+func (p *peekablePeripheral) Peek(addr uint16) byte     { return p.value }
+
+// readOnlyPeripheral implements Peripheral but NOT Peeker. Memory
+// inspectors hitting its range fall back to MMIO.Inner.
+type readOnlyPeripheral struct {
+	lo, hi uint16
+	reads  int
+}
+
+func (p *readOnlyPeripheral) Range() (uint16, uint16)   { return p.lo, p.hi }
+func (p *readOnlyPeripheral) Read(addr uint16) byte     { p.reads++; return 0xAB }
+func (p *readOnlyPeripheral) Write(addr uint16, v byte) {}
+
+// MMIO.Peek prefers a peripheral's Peek over Read so inspectors
+// don't trigger Read side effects.
+func TestMMIOPeek_RoutesThroughPeeker(t *testing.T) {
+	ram := NewRAM()
+	mmio := NewMMIO(ram)
+	p := &peekablePeripheral{lo: 0xF000, hi: 0xF00F, value: 0x42}
+	if err := mmio.Register(p); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	got := mmio.Peek(0xF000)
+	if got != 0x42 {
+		t.Errorf("Peek = $%02X; want $42", got)
+	}
+	if p.reads != 0 {
+		t.Errorf("Peek triggered Read %d times; want 0", p.reads)
+	}
+}
+
+// Peripheral without Peeker → fall through to Inner.Read at that
+// address (returns 0 for unmapped RAM). Does NOT invoke the
+// peripheral's Read.
+func TestMMIOPeek_FallsThroughOnNonPeeker(t *testing.T) {
+	ram := NewRAM()
+	ram.Load(0xF000, []byte{0x99})
+	mmio := NewMMIO(ram)
+	p := &readOnlyPeripheral{lo: 0xF000, hi: 0xF00F}
+	if err := mmio.Register(p); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	got := mmio.Peek(0xF000)
+	if got != 0x99 {
+		t.Errorf("Peek = $%02X; want $99 (Inner.Read for peripheral that doesn't implement Peeker)", got)
+	}
+	if p.reads != 0 {
+		t.Errorf("Peek triggered Read on non-Peeker peripheral %d times; want 0", p.reads)
+	}
+}
+
+// Addresses outside any peripheral range fall through to Inner.Read.
+func TestMMIOPeek_UnmappedAddrReadsInner(t *testing.T) {
+	ram := NewRAM()
+	ram.Load(0x0200, []byte{0x77})
+	mmio := NewMMIO(ram)
+
+	if got := mmio.Peek(0x0200); got != 0x77 {
+		t.Errorf("Peek($0200) = $%02X; want $77", got)
+	}
+}

--- a/internal/cpu/peripheral.go
+++ b/internal/cpu/peripheral.go
@@ -87,3 +87,42 @@ func (m *MMIO) Tick(cycles int) {
 		t.Tick(cycles)
 	}
 }
+
+// Peeker is the optional "side-effect-free read" interface a
+// peripheral may implement so memory inspectors (DAP `readMemory`,
+// the TUI memory panel) can sample its state without driving the
+// register's normal Read side effects (e.g. PPU's $2002 clears
+// vblank, joypad's $4016 shifts the register, keyboard's $F004
+// clears the data-ready flag).
+//
+// Peripherals where Read is already side-effect-free should still
+// implement Peek as `return p.Read(addr)` so memory inspection
+// works consistently. Peripherals that DON'T implement Peeker fall
+// back to MMIO.Inner.Read at the requested address — typically
+// zero, which is the "no observable state" answer for an MMIO
+// inspector.
+type Peeker interface {
+	Peek(addr uint16) byte
+}
+
+// Peek is the side-effect-free counterpart to Read. Used by memory
+// inspectors. Falls back to MMIO.Inner.Read for peripherals that
+// don't implement Peeker — that's better than calling Read and
+// triggering side effects the inspector shouldn't.
+func (m *MMIO) Peek(addr uint16) byte {
+	for _, p := range m.peripherals {
+		lo, hi := p.Range()
+		if addr >= lo && addr <= hi {
+			if pk, ok := p.(Peeker); ok {
+				return pk.Peek(addr)
+			}
+			// Peripheral exists at this address but doesn't expose a
+			// side-effect-free read. Returning Inner.Read is the
+			// conservative choice — it's whatever the underlying bus
+			// has there (typically zero for unmapped peripheral
+			// addresses), not the live device state.
+			return m.Inner.Read(addr)
+		}
+	}
+	return m.Inner.Read(addr)
+}

--- a/internal/dap/memory.go
+++ b/internal/dap/memory.go
@@ -96,7 +96,7 @@ func (s *Server) disasmOne(addr uint16) DisassembledInstruction {
 	text, n := cpu.DisasmCPU(s.cpu, addr)
 	bytesHex := make([]string, n)
 	for j := 0; j < n; j++ {
-		bytesHex[j] = fmt.Sprintf("%02X", s.ram.Read(addr+uint16(j)))
+		bytesHex[j] = fmt.Sprintf("%02X", s.peekByte(addr+uint16(j)))
 	}
 	ins := DisassembledInstruction{
 		Address:          fmt.Sprintf("$%04X", addr),
@@ -115,10 +115,27 @@ func (s *Server) disasmOne(addr uint16) DisassembledInstruction {
 	return ins
 }
 
+// peekByte is the side-effect-free byte read used by readMemory and
+// disassemble. When MMIO is wired, we consult it so peripherals (like
+// the NES cart's PRG-ROM at $C000-$FFFF) surface their bytes; the
+// MMIO.Peek path uses each peripheral's Peeker interface if it
+// implements one and falls back to Inner.Read otherwise — which keeps
+// memory inspection side-effect-free even for peripherals (PPU,
+// joypad, keyboard) whose Read mutates state.
+//
+// When MMIO is nil (older test fixtures, headless paths), we read
+// ram directly — same behavior as before.
+func (s *Server) peekByte(addr uint16) byte {
+	if s.mmio != nil {
+		return s.mmio.Peek(addr)
+	}
+	return s.ram.Read(addr)
+}
+
 // handleReadMemory returns a byte window starting at MemoryReference (+
-// Offset). Reads go directly through cpu.RAM, bypassing MMIO peripherals
-// whose Read may have side effects (e.g. clearing keyboard status). This
-// matches DAP's expectation that memory inspection is side-effect-free.
+// Offset). Reads go through MMIO.Peek (or ram directly when no MMIO is
+// wired) so peripherals' state shows up to inspectors without
+// triggering Read side effects.
 func (s *Server) handleReadMemory(req Request) {
 	if s.cpu == nil {
 		s.sendErrorResponse(req, "no debuggee — send launch first")
@@ -149,7 +166,7 @@ func (s *Server) handleReadMemory(req Request) {
 	}
 	raw := make([]byte, n)
 	for i := 0; i < n; i++ {
-		raw[i] = s.ram.Read(uint16(start + i))
+		raw[i] = s.peekByte(uint16(start + i))
 	}
 
 	type body struct {


### PR DESCRIPTION
PR #222 added DAP \`readMemory\` plumbing on chippy's side, but the **server's** \`handleReadMemory\` still read from \`s.ram.Read(addr)\`. For nessy that returned zeros for the cart range (\$4020-\$FFFF) — PRG-ROM lives in the cart object behind MMIO, NOT in \`cpu.RAM.Data\`. The TUI disasm faithfully showed the server's zeros (BRK BRK BRK).

## Fix
New \`cpu.Peeker\` interface + \`MMIO.Peek(addr)\` — side-effect-free read for memory inspectors.

- PPU \$2002 Read clears vblank; Peek should not.
- joypad \$4016 Read shifts the register; Peek should not.
- keyboard \$F004 Read clears data-ready; Peek should not.
- cart \$C000-\$FFFF Read is already side-effect-free; Peek = Read.

Peripherals that don't implement \`Peeker\` fall back to \`MMIO.Inner.Read\` — typically zero, the conservative \"no observable state\" answer.

\`handleReadMemory\` + the \`disassemble\` bytes-render path now use a shared \`s.peekByte\` helper. When MMIO is nil (headless test fixtures), falls back to \`ram.Read\` — same as before, no breakage.

\`cmd/nessy\`'s \`cartPeripheral\` implements \`Peek = cart.CPURead\`. NROM is a slice index; future bank-switching mappers (MMC1+) keep the contract by returning the currently-mapped bank.

## Tests
- \`internal/cpu/peek_test.go\` — \`MMIO.Peek\` routes through Peeker, falls through to Inner for non-Peekers, walks Inner for unmapped addresses.
- \`cmd/nessy/dap_readmemory_test.go\` — end-to-end via \`net.Pipe\`. \`readMemory\` at \$C000 returns actual cart PRG bytes (\`SEI\`, \`CLD\`, \`LDX #\$FF\`) instead of zeros. **Fails without the Peek routing** — that's the regression closed.

## Test plan
- [x] \`go build ./...\`
- [x] \`go test -race -count=1 ./...\`
- [x] \`golangci-lint run ./...\`
- [ ] (Manual) \`chippy -nessy roms/demos/hello-bg/hello-bg.nes\` → press \`v\` → disasm shows real opcodes at \$C000 (\`SEI\`, \`CLD\`, …), not BRK.

Closes #220 (for real this time).