### PR TITLE
fix(nessy): -wait-for-debugger pauses game at boot for launcher (#220)

### DIFF
--- a/cmd/chippy/nessy_launcher.go
+++ b/cmd/chippy/nessy_launcher.go
@@ -131,14 +131,17 @@ func resolveNessyBinary(override string) (string, error) {
 		}
 		return "", fmt.Errorf("-nessy-binary %q: %w", override, errors.New("not found"))
 	}
-	if p, err := exec.LookPath("nessy"); err == nil {
-		return p, nil
-	}
+	// Prefer a sibling of the running chippy binary before falling back
+	// to $PATH. Stale system-wide nessy installs shouldn't shadow a
+	// fresh local build the user just produced from the same checkout.
 	if self, err := os.Executable(); err == nil {
 		candidate := filepath.Join(filepath.Dir(self), nessyBaseName())
 		if _, err := os.Stat(candidate); err == nil {
 			return candidate, nil
 		}
+	}
+	if p, err := exec.LookPath("nessy"); err == nil {
+		return p, nil
 	}
 	return "", errors.New(
 		"nessy binary not found — install via `go install -tags=nessy github.com/nkane/chippy/cmd/nessy@latest`, " +

--- a/cmd/chippy/nessy_launcher.go
+++ b/cmd/chippy/nessy_launcher.go
@@ -39,7 +39,12 @@ func runNessyLauncher(romPath, nessyBin string) {
 		os.Exit(1)
 	}
 
-	cmd := exec.Command(bin, "-rom", romPath, "-dap-port", strconv.Itoa(port))
+	// `-wait-for-debugger` keeps nessy's game loop paused at the reset
+	// vector until our attach lands. Without it the launcher's spawn
+	// + dial + handshake takes ~100 ms while the game loop races
+	// ahead, ending up past the reset routine before we can issue
+	// the first stopped event.
+	cmd := exec.Command(bin, "-rom", romPath, "-dap-port", strconv.Itoa(port), "-wait-for-debugger")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Start(); err != nil {

--- a/cmd/nessy/dap.go
+++ b/cmd/nessy/dap.go
@@ -24,6 +24,17 @@ import (
 // goroutine.
 var dapAttached atomic.Int32
 
+// waitForAttach blocks the game loop's CPU stepping at boot when
+// nessy was launched under `chippy -nessy …`. Set by main from the
+// -wait-for-debugger flag BEFORE the DAP listener starts so a fast
+// client attach can't lose the race. Cleared the first time a DAP
+// client actually attaches (OnAttached fires).
+//
+// Note this is a one-shot gate: once cleared we don't re-arm on
+// disconnect. The user has confirmed they're driving the debugger;
+// closing the TUI shouldn't suddenly restart the game.
+var waitForAttach atomic.Bool
+
 // runDAPListener accepts incoming DAP connections on the given TCP port
 // and serves each one against the live NES bus. The cpuMu is shared
 // with the Ebiten game loop so concurrent requests never observe a
@@ -62,6 +73,11 @@ func runDAPListener(port int, bus *nesBus, cpuMu *sync.Mutex, syms *symbols.Tabl
 				Syms:   syms,
 				SrcMap: srcMap,
 				OnAttached: func() {
+					// Lift the at-boot pause gate atomically so the
+					// game loop transitions cleanly from "waiting for
+					// debugger" to "debugger attached" without an
+					// instant of autonomous run between the two.
+					waitForAttach.Store(false)
 					dapAttached.Add(1)
 				},
 				OnDisconnected: func() {

--- a/cmd/nessy/dap.go
+++ b/cmd/nessy/dap.go
@@ -88,6 +88,7 @@ func runDAPListener(port int, bus *nesBus, cpuMu *sync.Mutex, syms *symbols.Tabl
 					// then drop the boot wait.
 					dapAttached.Add(1)
 					waitForAttach.Store(false)
+					fmt.Fprintln(os.Stderr, "nessy: DAP client attached — debugger has control of CPU execution")
 				},
 				OnDisconnected: func() {
 					dapAttached.Add(-1)

--- a/cmd/nessy/dap.go
+++ b/cmd/nessy/dap.go
@@ -73,12 +73,21 @@ func runDAPListener(port int, bus *nesBus, cpuMu *sync.Mutex, syms *symbols.Tabl
 				Syms:   syms,
 				SrcMap: srcMap,
 				OnAttached: func() {
-					// Lift the at-boot pause gate atomically so the
-					// game loop transitions cleanly from "waiting for
-					// debugger" to "debugger attached" without an
-					// instant of autonomous run between the two.
-					waitForAttach.Store(false)
+					// Order matters. The game loop checks
+					// `waitForAttach || dapAttached>0`. If we
+					// cleared waitForAttach first and the loop
+					// raced through Update before dapAttached
+					// incremented, both gates would briefly read
+					// "off" — the loop would fall through, block
+					// on cpuMu (held by the dispatch handling
+					// this very attach), and on cpuMu release
+					// step ~30k cycles right past reset.
+					//
+					// Increment dapAttached FIRST so at least one
+					// gate is always "on" during the transition,
+					// then drop the boot wait.
 					dapAttached.Add(1)
+					waitForAttach.Store(false)
 				},
 				OnDisconnected: func() {
 					dapAttached.Add(-1)

--- a/cmd/nessy/dap.go
+++ b/cmd/nessy/dap.go
@@ -91,7 +91,21 @@ func runDAPListener(port int, bus *nesBus, cpuMu *sync.Mutex, syms *symbols.Tabl
 					fmt.Fprintln(os.Stderr, "nessy: DAP client attached — debugger has control of CPU execution")
 				},
 				OnDisconnected: func() {
-					dapAttached.Add(-1)
+					// Clamp at zero. The dap.Server promises to
+					// pair OnAttached with OnDisconnected, but we
+					// keep the floor as defensive depth — a stray
+					// disconnect for an un-attached session would
+					// otherwise drop the gate even though the
+					// real session is still running.
+					for {
+						cur := dapAttached.Load()
+						if cur <= 0 {
+							return
+						}
+						if dapAttached.CompareAndSwap(cur, cur-1) {
+							return
+						}
+					}
 				},
 			}
 			if err := s.AttachExisting(cfg); err != nil {

--- a/cmd/nessy/game.go
+++ b/cmd/nessy/game.go
@@ -51,13 +51,16 @@ func newGame(bus *nesBus, cpuMu *sync.Mutex) *game {
 
 func (g *game) Update() error {
 	g.pollInput()
-	// When a DAP client is attached, the server's `continue` runLoop
-	// (or its single-step requests) is the sole stepper. The game
-	// loop yields so the user can pause, single-step, set
-	// breakpoints, etc. without the game running away underneath
-	// them. Draw still fires every frame, so the screen reflects
-	// whatever framebuffer state the PPU has rendered up to now.
-	if dapAttached.Load() > 0 {
+	// Gate the CPU stepping on two flags:
+	//   1. waitForAttach — at-boot pause when nessy was launched
+	//      under `chippy -nessy …` (-wait-for-debugger). Cleared on
+	//      first DAP attach.
+	//   2. dapAttached    — one or more DAP clients currently
+	//      attached; the server's `continue` runLoop is the sole
+	//      stepper, the game loop yields.
+	// Draw still fires every frame so the screen reflects whatever
+	// framebuffer state the PPU has rendered up to now.
+	if waitForAttach.Load() || dapAttached.Load() > 0 {
 		return nil
 	}
 	g.cpuMu.Lock()

--- a/cmd/nessy/game.go
+++ b/cmd/nessy/game.go
@@ -3,7 +3,10 @@
 package main
 
 import (
+	"fmt"
+	"os"
 	"sync"
+	"sync/atomic"
 
 	"github.com/hajimehoshi/ebiten/v2"
 
@@ -49,6 +52,13 @@ func newGame(bus *nesBus, cpuMu *sync.Mutex) *game {
 	return &game{bus: bus, cpuMu: cpuMu}
 }
 
+// loopSteppedBanner is a one-shot diagnostic: prints to stderr the
+// first time the game loop actually advances the CPU (gates released).
+// Catches "gate races" — if this prints with PC=$C000 right after a
+// DAP attach, the wait gate worked. If it prints earlier with no
+// "debugger attached" line printed, the gate failed to engage.
+var loopSteppedBanner atomic.Bool
+
 func (g *game) Update() error {
 	g.pollInput()
 	// Gate the CPU stepping on two flags:
@@ -62,6 +72,11 @@ func (g *game) Update() error {
 	// framebuffer state the PPU has rendered up to now.
 	if waitForAttach.Load() || dapAttached.Load() > 0 {
 		return nil
+	}
+	if !loopSteppedBanner.Swap(true) {
+		fmt.Fprintf(os.Stderr,
+			"nessy: game loop entering autonomous-step mode at PC=$%04X cycles=%d (waitForAttach=%v dapAttached=%d)\n",
+			g.bus.cpu.PC, g.bus.cpu.Cycles, waitForAttach.Load(), dapAttached.Load())
 	}
 	g.cpuMu.Lock()
 	defer g.cpuMu.Unlock()

--- a/cmd/nessy/main.go
+++ b/cmd/nessy/main.go
@@ -17,14 +17,15 @@ import (
 
 func main() {
 	var (
-		romPath = flag.String("rom", "", "iNES ROM path (positional arg also accepted)")
-		dbgPath = flag.String("dbg", "", "cc65/ld65 .dbg symbol file (auto-detected as <rom>.dbg if omitted)")
-		dapPort = flag.Int("dap-port", 14785, "DAP server TCP port; 0 disables the listener")
-		scale   = flag.Int("scale", 3, "integer window scale (3 → 768x720)")
-		mute    = flag.Bool("mute", false, "disable audio (no-op in v0.1, APU lands in v0.2)")
+		romPath   = flag.String("rom", "", "iNES ROM path (positional arg also accepted)")
+		dbgPath   = flag.String("dbg", "", "cc65/ld65 .dbg symbol file (auto-detected as <rom>.dbg if omitted)")
+		dapPort   = flag.Int("dap-port", 14785, "DAP server TCP port; 0 disables the listener")
+		scale     = flag.Int("scale", 3, "integer window scale (3 → 768x720)")
+		mute      = flag.Bool("mute", false, "disable audio (no-op in v0.1, APU lands in v0.2)")
+		waitDbg   = flag.Bool("wait-for-debugger", false, "pause the CPU at boot until a DAP client attaches (set by `chippy -nessy`)")
 	)
 	flag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "usage: nessy [-rom PATH | PATH] [-dbg PATH] [-dap-port N] [-scale N] [-mute]\n\n")
+		fmt.Fprintf(os.Stderr, "usage: nessy [-rom PATH | PATH] [-dbg PATH] [-dap-port N] [-scale N] [-mute] [-wait-for-debugger]\n\n")
 		flag.PrintDefaults()
 	}
 	flag.Parse()
@@ -84,6 +85,18 @@ func main() {
 		} else {
 			srcMap = sm
 		}
+	}
+
+	// If launched under `chippy -nessy …`, the user wants to attach
+	// before the game runs. Set the gate flag BEFORE starting the
+	// DAP listener so we can't race against an instant client
+	// connection.
+	if *waitDbg {
+		if *dapPort <= 0 {
+			fmt.Fprintln(os.Stderr, "nessy: -wait-for-debugger requires -dap-port > 0")
+			os.Exit(2)
+		}
+		waitForAttach.Store(true)
 	}
 
 	// CPUMu serializes the game loop's per-frame stepping with any DAP

--- a/cmd/nessy/main.go
+++ b/cmd/nessy/main.go
@@ -97,6 +97,7 @@ func main() {
 			os.Exit(2)
 		}
 		waitForAttach.Store(true)
+		fmt.Fprintln(os.Stderr, "nessy: -wait-for-debugger active — CPU paused at boot until a DAP client attaches")
 	}
 
 	// CPUMu serializes the game loop's per-frame stepping with any DAP

--- a/cmd/nessy/wait_for_debugger_test.go
+++ b/cmd/nessy/wait_for_debugger_test.go
@@ -1,0 +1,231 @@
+//go:build launcher_integration
+
+// Build-tag-gated end-to-end test that exercises the full
+// `chippy -nessy ROM` flow: spawn a real `nessy` binary with
+// -wait-for-debugger, dial its DAP listener, attach with
+// stopOnEntry, and assert the CPU is paused at the cart's reset
+// vector (NOT in the `forever: JMP forever` spin past it).
+//
+// Run with the nessy binary built at /tmp/nessy (or set
+// CHIPPY_NESSY_BIN to a path):
+//
+//	go build -tags=nessy -o /tmp/nessy ./cmd/nessy
+//	go test -tags=launcher_integration -v ./cmd/nessy/... \
+//	  -run TestLauncher_PausesAtResetVector
+//
+// Tagged because the default CI build doesn't produce a `nessy`
+// binary (Ebiten + X11 deps). Run locally before tagging a release
+// or merging changes that touch the launcher / wait-for-debugger
+// path.
+
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nkane/chippy/internal/dap"
+)
+
+func nessyBinaryPath(t *testing.T) string {
+	t.Helper()
+	if p := os.Getenv("CHIPPY_NESSY_BIN"); p != "" {
+		return p
+	}
+	candidates := []string{"/tmp/nessy", "./nessy", "/usr/local/bin/nessy"}
+	for _, c := range candidates {
+		if _, err := os.Stat(c); err == nil {
+			return c
+		}
+	}
+	t.Skipf("nessy binary not found; build with `go build -tags=nessy -o /tmp/nessy ./cmd/nessy` or set CHIPPY_NESSY_BIN")
+	return ""
+}
+
+func pickFreePortForTest(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = ln.Close() }()
+	return ln.Addr().(*net.TCPAddr).Port
+}
+
+func spawnNessy(t *testing.T, bin, romPath string, port int) *exec.Cmd {
+	t.Helper()
+	cmd := exec.Command(bin, "-rom", romPath, "-dap-port", strconv.Itoa(port), "-wait-for-debugger")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("spawn nessy: %v", err)
+	}
+	t.Cleanup(func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Signal(os.Interrupt)
+			done := make(chan error, 1)
+			go func() { done <- cmd.Wait() }()
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				_ = cmd.Process.Kill()
+			}
+		}
+	})
+	return cmd
+}
+
+func dialUntilReady(t *testing.T, port int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	target := net.JoinHostPort("127.0.0.1", strconv.Itoa(port))
+	for {
+		conn, err := net.DialTimeout("tcp", target, 250*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("nessy never opened DAP listener on :%d within %s: %v", port, timeout, err)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+}
+
+// The integration check. Spawn nessy with -wait-for-debugger, attach,
+// inspect PC + first instruction bytes. Without the wait flag the CPU
+// would race past reset to the JMP-self spin at ~$C097.
+func TestLauncher_PausesAtResetVector(t *testing.T) {
+	bin := nessyBinaryPath(t)
+	rom, err := filepath.Abs(filepath.Join("..", "..", "roms", "demos", "hello-bg", "hello-bg.nes"))
+	if err != nil {
+		t.Fatalf("abs rom path: %v", err)
+	}
+	port := pickFreePortForTest(t)
+	spawnNessy(t, bin, rom, port)
+	dialUntilReady(t, port, 5*time.Second)
+
+	// 250 ms sleep AFTER listener accepts — gives the game loop
+	// plenty of opportunity to misbehave if the wait gate is broken.
+	// With wait-for-debugger working, PC stays at $C000.
+	time.Sleep(250 * time.Millisecond)
+
+	conn, err := net.Dial("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	client := dap.NewClient(conn, conn)
+	defer func() { _ = client.Close() }()
+
+	if _, err := client.Initialize(dap.InitializeArguments{ClientID: "test", AdapterID: "chippy"}); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	resp, err := client.Request("attach", map[string]any{"stopOnEntry": true})
+	if err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	if !resp.Success {
+		t.Fatalf("attach refused: %s", resp.Message)
+	}
+
+	// Pull PC + first 8 bytes from $C000.
+	stResp, err := client.Request("stackTrace", map[string]any{"threadId": 1, "startFrame": 0, "levels": 1})
+	if err != nil {
+		t.Fatalf("stackTrace: %v", err)
+	}
+	if !stResp.Success {
+		t.Fatalf("stackTrace failed: %s", stResp.Message)
+	}
+	stBody, _ := json.Marshal(stResp.Body)
+	var st struct {
+		StackFrames []struct {
+			InstructionPointerReference string `json:"instructionPointerReference"`
+		} `json:"stackFrames"`
+	}
+	_ = json.Unmarshal(stBody, &st)
+	if len(st.StackFrames) == 0 {
+		t.Fatalf("stackTrace returned no frames")
+	}
+	pcStr := strings.TrimPrefix(st.StackFrames[0].InstructionPointerReference, "$")
+	pc, err := strconv.ParseUint(pcStr, 16, 16)
+	if err != nil {
+		t.Fatalf("parse PC: %v", err)
+	}
+	if pc != 0xC000 {
+		t.Errorf("PC = $%04X; want $C000 (reset vector). Game loop ran past reset before attach — wait-for-debugger gate is broken", pc)
+	}
+
+	// First 8 bytes at $C000 must be reset routine, not BRK fill.
+	memResp, err := client.Request("readMemory", map[string]any{
+		"memoryReference": "$C000",
+		"offset":          0,
+		"count":           8,
+	})
+	if err != nil {
+		t.Fatalf("readMemory: %v", err)
+	}
+	if !memResp.Success {
+		t.Fatalf("readMemory failed: %s", memResp.Message)
+	}
+	memBody, _ := json.Marshal(memResp.Body)
+	var mem struct {
+		Data string `json:"data"`
+	}
+	_ = json.Unmarshal(memBody, &mem)
+	decoded, err := base64.StdEncoding.DecodeString(mem.Data)
+	if err != nil {
+		t.Fatalf("base64 decode: %v", err)
+	}
+	// hello-bg.s reset:  SEI / CLD / LDX #$FF / TXS / INX / STX $2000
+	wantPrefix := []byte{0x78, 0xD8, 0xA2, 0xFF, 0x9A, 0xE8, 0x8E, 0x00}
+	for i, want := range wantPrefix {
+		if decoded[i] != want {
+			t.Errorf("readMemory[$C00%X] = $%02X; want $%02X (reset routine bytes)", i, decoded[i], want)
+		}
+	}
+
+	// Step once. Expect PC to advance by exactly the SEI instruction
+	// width (1 byte).
+	if _, err := client.Request("stepIn", map[string]any{"threadId": 1}); err != nil {
+		t.Fatalf("stepIn: %v", err)
+	}
+	// Drain events briefly so the server's stopped event lands.
+	timer := time.NewTimer(2 * time.Second)
+	defer timer.Stop()
+	gotStop := false
+drainLoop:
+	for {
+		select {
+		case ev, ok := <-client.Events():
+			if !ok {
+				break drainLoop
+			}
+			if ev.Event == "stopped" {
+				gotStop = true
+				break drainLoop
+			}
+		case <-timer.C:
+			t.Fatalf("no stopped event 2s after stepIn")
+		}
+	}
+	if !gotStop {
+		t.Fatal("no stopped event")
+	}
+
+	stResp2, _ := client.Request("stackTrace", map[string]any{"threadId": 1, "startFrame": 0, "levels": 1})
+	stBody2, _ := json.Marshal(stResp2.Body)
+	_ = json.Unmarshal(stBody2, &st)
+	pcStr2 := strings.TrimPrefix(st.StackFrames[0].InstructionPointerReference, "$")
+	pc2, _ := strconv.ParseUint(pcStr2, 16, 16)
+	if pc2 != 0xC001 {
+		t.Errorf("PC after stepIn = $%04X; want $C001 (SEI is 1 byte). Game loop racing the step request", pc2)
+	}
+}

--- a/cmd/nessy/wait_for_debugger_test.go
+++ b/cmd/nessy/wait_for_debugger_test.go
@@ -228,4 +228,45 @@ drainLoop:
 	if pc2 != 0xC001 {
 		t.Errorf("PC after stepIn = $%04X; want $C001 (SEI is 1 byte). Game loop racing the step request", pc2)
 	}
+
+	// Step several more times. The hello-bg reset routine is:
+	//   $C000 78        SEI       → next $C001 (1 byte)
+	//   $C001 D8        CLD       → next $C002
+	//   $C002 A2 FF     LDX #$FF  → next $C004
+	//   $C004 9A        TXS       → next $C005
+	//   $C005 E8        INX       → next $C006
+	// Each stepIn must advance by exactly the instruction width.
+	// If the game loop is racing the dispatch, we'd see PCs leap by
+	// ~30k cycles ($C000 → $C097-ish).
+	wantPCs := []uint16{0xC002, 0xC004, 0xC005, 0xC006}
+	for _, want := range wantPCs {
+		if _, err := client.Request("stepIn", map[string]any{"threadId": 1}); err != nil {
+			t.Fatalf("stepIn: %v", err)
+		}
+		stopTimer := time.NewTimer(2 * time.Second)
+	stepDrain:
+		for {
+			select {
+			case ev, ok := <-client.Events():
+				if !ok {
+					stopTimer.Stop()
+					break stepDrain
+				}
+				if ev.Event == "stopped" {
+					stopTimer.Stop()
+					break stepDrain
+				}
+			case <-stopTimer.C:
+				t.Fatalf("no stopped event 2s after stepIn (target PC $%04X)", want)
+			}
+		}
+		st3Resp, _ := client.Request("stackTrace", map[string]any{"threadId": 1, "startFrame": 0, "levels": 1})
+		st3Body, _ := json.Marshal(st3Resp.Body)
+		_ = json.Unmarshal(st3Body, &st)
+		pcStr3 := strings.TrimPrefix(st.StackFrames[0].InstructionPointerReference, "$")
+		pc3, _ := strconv.ParseUint(pcStr3, 16, 16)
+		if pc3 != uint64(want) {
+			t.Errorf("multi-step regression: PC = $%04X; want $%04X. The game loop is racing the dispatch", pc3, want)
+		}
+	}
 }

--- a/internal/dap/attach.go
+++ b/internal/dap/attach.go
@@ -96,6 +96,11 @@ func (s *Server) handleAttach(req Request) {
 		}
 	}
 	s.sendResponse(req, nil)
+	// Record that a paired attach happened so fireDisconnected
+	// later can decide whether to invoke the host's OnDisconnected
+	// callback. Probe connections that never reach this point won't
+	// see OnDisconnected either.
+	s.attachedFired.Store(true)
 	// Notify the host that a client has attached. Hosts use this to
 	// gate their own run loops (e.g. nessy pauses its game loop while
 	// the DAP server owns execution).

--- a/internal/dap/attach_callbacks_test.go
+++ b/internal/dap/attach_callbacks_test.go
@@ -91,19 +91,23 @@ func TestAttachConfig_OnAttachedAndOnDisconnected(t *testing.T) {
 	}
 }
 
-// Wire EOF (client closes without sending disconnect) also fires
-// OnDisconnected — matches the nessy "user kills chippy TUI" path.
-func TestAttachConfig_OnDisconnected_FiresOnEOF(t *testing.T) {
+// Probe-style connections that open + close without sending an attach
+// request must NOT fire OnDisconnected. The launcher's waitForListener
+// dial-and-close was leaving nessy's dapAttached counter at -1, which
+// then offset the real attach to 0 (instead of 1) — game loop fell
+// through both gates and stepped the CPU autonomously past reset.
+func TestAttachConfig_ProbeConnectionDoesNotFireOnDisconnected(t *testing.T) {
 	clientConn, serverConn := net.Pipe()
 
 	ram := cpu.NewRAM()
 	c := cpu.New(ram)
 
-	var disconnected atomic.Int32
+	var attached, disconnected atomic.Int32
 
 	srv := NewServer(serverConn, serverConn)
 	if err := srv.AttachExisting(AttachConfig{
 		CPU: c, RAM: ram,
+		OnAttached:     func() { attached.Add(1) },
 		OnDisconnected: func() { disconnected.Add(1) },
 	}); err != nil {
 		t.Fatalf("AttachExisting: %v", err)
@@ -114,9 +118,70 @@ func TestAttachConfig_OnDisconnected_FiresOnEOF(t *testing.T) {
 		close(done)
 	}()
 
-	// Close client side without sending disconnect. Server's read
-	// loop gets EOF and exits Serve(); deferred fireDisconnected
-	// runs.
+	// Close the client end immediately — no Initialize, no Attach.
+	// This is the shape of the launcher's listener-probe dial.
+	_ = clientConn.Close()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Serve did not exit within 2s after probe close")
+	}
+	if got := attached.Load(); got != 0 {
+		t.Errorf("OnAttached fired %d times for probe-only connection; want 0", got)
+	}
+	if got := disconnected.Load(); got != 0 {
+		t.Errorf("OnDisconnected fired %d times for probe-only connection; want 0 — host counters must stay balanced", got)
+	}
+}
+
+// Wire EOF AFTER a successful attach (e.g. user kills the chippy TUI)
+// fires OnDisconnected so the host can rebalance any counters.
+func TestAttachConfig_OnDisconnected_FiresOnEOF(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+
+	ram := cpu.NewRAM()
+	c := cpu.New(ram)
+
+	var attached, disconnected atomic.Int32
+
+	srv := NewServer(serverConn, serverConn)
+	if err := srv.AttachExisting(AttachConfig{
+		CPU: c, RAM: ram,
+		OnAttached:     func() { attached.Add(1) },
+		OnDisconnected: func() { disconnected.Add(1) },
+	}); err != nil {
+		t.Fatalf("AttachExisting: %v", err)
+	}
+	done := make(chan struct{})
+	go func() {
+		_ = srv.Serve()
+		close(done)
+	}()
+
+	// Drive a real attach first so the OnAttached/OnDisconnected
+	// pairing is satisfied. Without this, fireDisconnected (per the
+	// pairing guard) wouldn't fire on EOF — see the probe-only test
+	// above.
+	client := NewClient(clientConn, clientConn)
+	if _, err := client.Initialize(InitializeArguments{}); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	if _, err := client.Attach(); err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	deadline := time.After(2 * time.Second)
+	for attached.Load() == 0 {
+		select {
+		case <-deadline:
+			t.Fatalf("OnAttached never fired")
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+
+	// Now close the client side without a disconnect request —
+	// Serve's read loop sees EOF, exits, fireDisconnected runs.
 	_ = clientConn.Close()
 
 	select {

--- a/internal/dap/server.go
+++ b/internal/dap/server.go
@@ -95,6 +95,17 @@ type Server struct {
 	onAttached     func()
 	onDisconnected func()
 
+	// attachedFired records whether handleAttach completed
+	// successfully. fireDisconnected uses this to guarantee the host
+	// only sees `OnDisconnected` when a paired `OnAttached` actually
+	// happened — a probe TCP connection (e.g. the launcher's
+	// listener-ready check that dials + closes without sending any
+	// DAP traffic) opens a Server, never attaches, and gets EOF.
+	// Without this guard the host would see a stray disconnect for a
+	// session that never started, dropping any counters into negative
+	// territory.
+	attachedFired atomic.Bool
+
 	// disconnectedFired guards onDisconnected against double-fire
 	// when both Serve()'s EOF exit and a client-initiated disconnect
 	// race to invoke it.
@@ -439,11 +450,17 @@ func (s *Server) handleTerminate(req Request) {
 }
 
 // fireDisconnected invokes the host's OnDisconnected callback (if any)
-// exactly once per Server. The `disconnectedFired` guard handles the
+// exactly once per Server, AND only if a paired OnAttached has
+// actually fired. The `disconnectedFired` guard handles the
 // case where Serve()'s EOF path and a client-initiated disconnect
-// request both try to fire it.
+// request both try to fire it; the `attachedFired` guard skips the
+// callback entirely for probe-style connections that never sent an
+// attach request.
 func (s *Server) fireDisconnected() {
 	if s.onDisconnected == nil {
+		return
+	}
+	if !s.attachedFired.Load() {
 		return
 	}
 	if s.disconnectedFired.Swap(true) {


### PR DESCRIPTION
Multiple-fix patch after several rounds of manual testing. Closes the gap between `chippy -nessy ROM` opening and the user being able to actually drive the game.

## 1. `-wait-for-debugger` pauses nessy's game loop at boot

When `chippy -nessy ROM` spawned the nessy child, there was a ~100 ms race between nessy's game loop starting and the launcher's dial+handshake+attach completing. By the time OnAttached fired and dapAttached engaged, the CPU had already run thousands of instructions through reset and was sitting in `forever: JMP forever` at $C097.

Symptoms before:
- PC parked at $C097 (not $C000 reset vector).
- Disasm showed `BRK BRK BRK` (post-program $00 fill bytes).
- Game window already displayed the rendered "HELLO NESSY" title screen.

**Fix**: nessy gets a `-wait-for-debugger` flag. When set, an atomic `waitForAttach` gate is armed **before** the DAP listener starts. The game loop checks it in addition to `dapAttached` and skips `Step` until the first DAP attach fires `OnAttached` (which atomically clears the gate). One-shot — once cleared, the normal `dapAttached` counter takes over.

Launcher passes the flag automatically. Plain `nessy game.nes` is unaffected.

## 2. Gate-transition race in `OnAttached`

After fix (1), manual testing still showed step jumping ~30k cycles past reset. The OnAttached callback was clearing `waitForAttach` first, then incrementing `dapAttached`. Between those two writes, both gates briefly read "off" — Ebiten's Update fired in that window, blocked on `cpuMu` held by the dispatch processing the attach, and on cpuMu release stepped 29830 cycles in one go.

**Fix**: invert the order. `dapAttached.Add(1)` first, then `waitForAttach.Store(false)`. At least one gate is always "on" during the transition.

## 3. Stale system-wide nessy shadowing the local build

Launcher's binary search was `-nessy-binary → $PATH → sibling`. A stale `/usr/local/bin/nessy` from a previous experiment would shadow the freshly-built local binary, so users iterating on the launcher would unknowingly run an old nessy.

**Fix**: reorder to `-nessy-binary → sibling-of-chippy → $PATH`. Local rebuild always wins.

## 4. Probe connection corrupting `dapAttached` counter

User's diagnostic with `nessy: game loop entering autonomous-step mode at PC=$C000 cycles=7 (waitForAttach=false dapAttached=0)` revealed the root cause: launcher's `waitForListener` opens a TCP probe connection, closes it without sending any DAP messages. On nessy's side:

1. `ln.Accept()` returns the probe conn.
2. Goroutine builds dap.Server, registers `OnAttached` / `OnDisconnected` callbacks, calls `Serve()`.
3. Chippy closes the probe.
4. `Serve()` sees EOF, returns. Deferred `fireDisconnected` runs.
5. `OnAttached` **never** fired (no attach request), but `OnDisconnected` fired → `dapAttached.Add(-1)` → **-1**.
6. Real attach: `OnAttached` → `dapAttached.Add(1)` → **0** (not 1).
7. Game loop check: `waitForAttach=false`, `dapAttached=0` → BOTH off → falls through, steps CPU.

**Fix**:
- `internal/dap/server.go` — new `attachedFired atomic.Bool`. Set inside `handleAttach` before invoking the host's `OnAttached`. `fireDisconnected` checks it — probe-style connections that never sent an attach request skip `OnDisconnected` entirely. Keeps host counters balanced.
- `cmd/nessy/dap.go` — `OnDisconnected` callback CAS-clamps `dapAttached` at zero. Defensive depth.

## Diagnostics

Three one-shot stderr breadcrumbs make future regressions easy to spot:
- `nessy: -wait-for-debugger active —` — boot gate armed.
- `nessy: DAP client attached — debugger has control` — `OnAttached` fired.
- `nessy: game loop entering autonomous-step mode at PC=$XXXX …` — failure marker. Should NEVER appear when the launcher attaches cleanly. If it does, PC + cycle count + gate values point at which assumption broke.

## Tests

End-to-end integration tests under the `launcher_integration` build tag:

```
go build -tags=nessy -o /tmp/nessy ./cmd/nessy
CHIPPY_NESSY_BIN=/tmp/nessy go test -tags=launcher_integration \
  -count=1 -v -run TestLauncher ./cmd/nessy/...
```

- **`TestLauncher_PausesAtResetVector`** — spawns nessy with `-wait-for-debugger`, sleeps 250 ms, attaches with `stopOnEntry`. Asserts PC=$C000, first 8 bytes are the reset routine (SEI / CLD / LDX #$FF / TXS / INX / STX $2000), then walks 5 stepIns and verifies PC matches the instruction-width-aware sequence ($C001 → $C002 → $C004 → $C005 → $C006).

Plus DAP package unit tests:
- **`TestAttachConfig_ProbeConnectionDoesNotFireOnDisconnected`** — opens + closes a server conn without sending any DAP traffic. Asserts neither callback fires. Fails without the `attachedFired` guard.
- **`TestAttachConfig_OnAttachedAndOnDisconnected`** — full happy-path round-trip.
- **`TestAttachConfig_OnDisconnected_FiresOnEOF`** — paired attach + EOF.

## Manual verification

User confirmed working end-to-end:
- nessy window stays blank until user presses `r`.
- TUI source view shows the SEI line at $C000, cursor follows PC on `s` presses.
- Disasm shows real opcodes (SEI / CLD / LDX) — not BRK.