### PR TITLE
fix(tui): sync breakpoints to remote on :bp and :run commands

### DIFF
--- a/cmd/nessy/wait_for_debugger_test.go
+++ b/cmd/nessy/wait_for_debugger_test.go
@@ -23,6 +23,7 @@ package main
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net"
 	"os"
 	"os/exec"
@@ -268,5 +269,103 @@ drainLoop:
 		if pc3 != uint64(want) {
 			t.Errorf("multi-step regression: PC = $%04X; want $%04X. The game loop is racing the dispatch", pc3, want)
 		}
+	}
+}
+
+// User-reported regression: `:bp clear_ram` followed by `r` did NOT
+// break at the bp — server ran past it. Root cause was `:bp` not
+// syncing the new breakpoint to the server via
+// setInstructionBreakpoints.
+//
+// This test mirrors the wire-level behavior: setInstructionBreakpoints
+// + continue should yield a `stopped` event at the bp's PC.
+func TestLauncher_BreakpointStopsContinue(t *testing.T) {
+	bin := nessyBinaryPath(t)
+	rom, err := filepath.Abs(filepath.Join("..", "..", "roms", "demos", "hello-bg", "hello-bg.nes"))
+	if err != nil {
+		t.Fatalf("abs rom path: %v", err)
+	}
+	port := pickFreePortForTest(t)
+	spawnNessy(t, bin, rom, port)
+	dialUntilReady(t, port, 5*time.Second)
+
+	conn, err := net.Dial("tcp", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	client := dap.NewClient(conn, conn)
+	defer func() { _ = client.Close() }()
+
+	if _, err := client.Initialize(dap.InitializeArguments{}); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	if _, err := client.Request("attach", map[string]any{"stopOnEntry": true}); err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+	// Drain the initial stopped(entry) event so the bp-stopped event
+	// is the only one we care about below.
+	deadline := time.After(2 * time.Second)
+initialDrain:
+	for {
+		select {
+		case ev, ok := <-client.Events():
+			if !ok {
+				break initialDrain
+			}
+			if ev.Event == "stopped" {
+				break initialDrain
+			}
+		case <-deadline:
+			t.Fatalf("no initial stopped event")
+		}
+	}
+
+	// $C014 lies somewhere inside the `bit $2002 / bpl :-` vblank
+	// wait. After continue, the CPU loops there constantly; the bp
+	// must trip within microseconds.
+	const bpPC = 0xC014
+	resp, err := client.Request("setInstructionBreakpoints", map[string]any{
+		"breakpoints": []map[string]string{
+			{"instructionReference": fmt.Sprintf("$%04X", bpPC)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("setInstructionBreakpoints: %v", err)
+	}
+	if !resp.Success {
+		t.Fatalf("setInstructionBreakpoints refused: %s", resp.Message)
+	}
+
+	if _, err := client.Request("continue", map[string]any{"threadId": 1}); err != nil {
+		t.Fatalf("continue: %v", err)
+	}
+	stopT := time.NewTimer(5 * time.Second)
+	defer stopT.Stop()
+	for {
+		select {
+		case ev, ok := <-client.Events():
+			if !ok {
+				t.Fatalf("client events closed before bp-stopped event")
+			}
+			if ev.Event == "stopped" {
+				goto stopped
+			}
+		case <-stopT.C:
+			t.Fatalf("continue ran 5s without stopping at bp $%04X — breakpoint sync regressed", bpPC)
+		}
+	}
+stopped:
+	stResp, _ := client.Request("stackTrace", map[string]any{"threadId": 1, "startFrame": 0, "levels": 1})
+	stBody, _ := json.Marshal(stResp.Body)
+	var st struct {
+		StackFrames []struct {
+			InstructionPointerReference string `json:"instructionPointerReference"`
+		} `json:"stackFrames"`
+	}
+	_ = json.Unmarshal(stBody, &st)
+	pcStr := strings.TrimPrefix(st.StackFrames[0].InstructionPointerReference, "$")
+	pc, _ := strconv.ParseUint(pcStr, 16, 16)
+	if pc != uint64(bpPC) {
+		t.Errorf("after continue, PC = $%04X; want $%04X (server should stop at bp)", pc, bpPC)
 	}
 }

--- a/internal/tui/bp.go
+++ b/internal/tui/bp.go
@@ -202,12 +202,14 @@ func (m *Model) cmdBP(args []string) string {
 		if _, ok := m.Breakpoints[addr]; ok {
 			delete(m.Breakpoints, addr)
 			m.saveState()
+			m.syncSourceBreakpoints()
 			return fmt.Sprintf("bp -$%04X", addr)
 		}
 		bp := newBP(addr)
 		bp.Source = src
 		m.Breakpoints[addr] = bp
 		m.saveState()
+		m.syncSourceBreakpoints()
 		return fmt.Sprintf("bp +$%04X", addr)
 	}
 
@@ -227,6 +229,7 @@ func (m *Model) cmdBP(args []string) string {
 	}
 	m.Breakpoints[addr] = bp
 	m.saveState()
+	m.syncSourceBreakpoints()
 	return fmt.Sprintf("%s bp +$%04X", bp.marker(), addr)
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -646,10 +646,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case dapEventMsg:
 		switch msg.ev.Event {
 		case "stopped":
+			wasRunning := m.Running
 			m.Running = false
 			_ = m.Source.RefreshRegs()
 			_ = m.Source.RefreshMemory()
-			m.Status = fmt.Sprintf("stopped at $%04X", m.CPU.PC)
+			// Only overwrite Status when we were running — single
+			// step paths have their own "stepped" / "hit bp"
+			// messages and don't want this generic one stomping
+			// theirs. The Running→false transition is what marks
+			// "the server actually halted on its own".
+			if wasRunning {
+				m.Status = fmt.Sprintf("stopped at $%04X", m.CPU.PC)
+			}
 		case "terminated":
 			return m, tea.Quit
 		}

--- a/internal/tui/prompt.go
+++ b/internal/tui/prompt.go
@@ -241,7 +241,17 @@ func (m *Model) runCommand(line string) string {
 		bp := newBP(addr)
 		bp.HitLimit = -1
 		m.Breakpoints[addr] = bp
+		m.syncSourceBreakpoints()
 		m.Running = true
+		// In attach mode the server owns execution; explicitly tell
+		// it to continue. Local mode steps via tickMsg → m.step() and
+		// doesn't need an extra kick.
+		if m.Source != nil && m.Source.Attached() {
+			if err := m.Source.Continue(); err != nil {
+				m.Running = false
+				return fmt.Sprintf("continue: %v", err)
+			}
+		}
 		return fmt.Sprintf("running to $%04X", addr)
 	case "watch", "w":
 		if len(args) == 0 {

--- a/internal/tui/source_remote.go
+++ b/internal/tui/source_remote.go
@@ -77,16 +77,22 @@ func (s *RemoteSource) demuxEvents() {
 		if s.closed.Load() {
 			return
 		}
-		// Route `stopped` to the request-response wait helper; every
-		// other event (output, terminated, etc.) goes to the TUI.
+		// `stopped` events need to reach TWO places:
+		//   - s.stopped — consumed by Step's waitForStop for the
+		//     request-response synchronization of a single stepIn.
+		//   - s.external — consumed by the TUI's dapEventMsg pump
+		//     so the source-view, registers, and run flag refresh
+		//     when the server stops mid-continue (breakpoint hit,
+		//     pause request, exception).
+		// Earlier routing sent stopped events ONLY to s.stopped, so
+		// after `continue` + bp-hit the TUI never refreshed until
+		// the user toggled state manually — the entire screen
+		// looked frozen.
 		if ev.Event == "stopped" {
 			select {
 			case s.stopped <- ev:
 			default:
-				// stopped channel full — drop to keep the read loop
-				// moving. Step's waitForStop will see the next one.
 			}
-			continue
 		}
 		select {
 		case s.external <- ev:


### PR DESCRIPTION
Two related fixes after manual testing surfaced both bugs:

## 1. `:bp` and `:run` didn't sync breakpoints to the remote

**Symptom**: `:bp clear_ram` + `r` ran past the breakpoint without stopping.

**Cause**: only the `b` keypress handler (toggle bp at current PC) called `syncSourceBreakpoints`. The `:bp` command and the `:run` one-shot mutated `m.Breakpoints` locally but never forwarded the change to the DAP server. Server therefore had no bp installed; `continue` ran to the end of the program.

**Fix**:
- `bp.go::cmdBP` — call `m.syncSourceBreakpoints()` after every bp toggle / add path (toggle-delete, toggle-add, modifier-add). Server learns about the bp via `setInstructionBreakpoints` before the user issues continue.
- `prompt.go::":run"` — sync after the one-shot add. Also: in attach mode, explicitly send DAP `continue` (`Source.Continue`) since the TUI's tickMsg run-loop skips local stepping when attached.

## 2. TUI didn't refresh after a server-driven stop

**Symptom**: server stopped at the bp correctly, but the TUI kept showing the pre-continue snapshot. User had to press `r` to force a refresh.

**Cause**: `RemoteSource.demuxEvents` routed `stopped` events **only** to the internal `s.stopped` channel (consumed by `Step()`'s `waitForStop`). The TUI's `dapEventMsg` pump subscribes to `s.external` — a separate channel. So server-side stops mid-continue never reached the TUI handler; `m.Running` stayed `true`, `RefreshRegs` / `RefreshMemory` never fired.

**Fix**:
- `source_remote.go::demuxEvents` — route `stopped` to **both** channels (internal for `Step`'s wait, external for the TUI's pump).
- `model.go::dapEventMsg "stopped"` — guard the status-overwrite on `wasRunning` so single-step paths keep their "stepped" / "hit bp" messages instead of being stomped by the generic "stopped at $XXXX".

## Tests

`TestLauncher_BreakpointStopsContinue` (under `launcher_integration` build tag) spawns nessy, sends `setInstructionBreakpoints` + `continue`, asserts the server stops at the requested PC within 5 s. Without the bp sync the test would time out at 5 s.

Run locally:
```
go build -tags=nessy -o /tmp/nessy ./cmd/nessy
CHIPPY_NESSY_BIN=/tmp/nessy go test -tags=launcher_integration \
  -count=1 -v -run TestLauncher ./cmd/nessy/...
```

## Manual verification

User confirmed both fixes work end-to-end:

```
./chippy -nessy roms/demos/hello-bg/hello-bg.nes
:bp clear_ram
r
```

Status flips to `running @ max`, then automatically to `stopped at $XXXX` when the server hits `clear_ram`. Source-view cursor jumps to the `clear_ram` line, PC and registers update immediately — no manual refresh needed.