### PR TITLE
ci(release): cross-compile darwin/amd64 from macos-latest (#208)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,6 +147,12 @@ jobs:
   # attach their artifacts via `gh release upload --clobber`. No
   # cosign / SBOM for nessy v0.1 alpha — those land when nessy
   # graduates.
+  #
+  # Both darwin targets build on `macos-latest` (Apple Silicon). The
+  # amd64 variant cross-compiles via clang's `-target x86_64-apple-macos`
+  # — the macOS SDK ships both arch slices, so CGO + Ebiten just
+  # work. Previously the matrix used `macos-13` for darwin/amd64, but
+  # that runner pool has unpredictable multi-hour queues (#208).
   nessy-build:
     if: startsWith(github.ref_name, 'nessy-v')
     strategy:
@@ -158,12 +164,12 @@ jobs:
             goarch: amd64
             binary: nessy
             archive_ext: tar.gz
-          - os: macos-latest      # arm64
+          - os: macos-latest      # arm64; native build
             goos: darwin
             goarch: arm64
             binary: nessy
             archive_ext: tar.gz
-          - os: macos-13          # x86_64
+          - os: macos-latest      # arm64 runner; cross-compile for amd64
             goos: darwin
             goarch: amd64
             binary: nessy
@@ -197,10 +203,23 @@ jobs:
 
       - name: Build nessy
         shell: bash
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: '1'
         run: |
+          # darwin/amd64 from an Apple Silicon runner needs an explicit
+          # clang -target so the linker pulls the x86_64 SDK slice. The
+          # macOS SDK on `macos-latest` ships both slices; this just
+          # tells CGO which to use.
+          if [ "${{ matrix.goos }}" = "darwin" ] && [ "${{ matrix.goarch }}" = "amd64" ] && [ "$(uname -m)" = "arm64" ]; then
+            export CC="cc -target x86_64-apple-macos"
+            export CXX="c++ -target x86_64-apple-macos"
+          fi
           mkdir -p dist
           go build -tags=nessy -trimpath -ldflags="-s -w" \
             -o "dist/${{ matrix.binary }}" ./cmd/nessy
+          file "dist/${{ matrix.binary }}" || true
 
       - name: Package
         shell: bash


### PR DESCRIPTION
The release matrix used `macos-13` (Intel Mac) runners for the darwin/amd64 nessy binary. That runner pool has unpredictable multi-hour queues — `nessy-v0.1.0` and `nessy-v0.1.2` both shipped with 3/4 binaries because macos-13 never picked up the job.

## Fix

Apple Silicon's `macos-latest` runners ship the macOS SDK with both arch slices. clang cross-compiles to x86_64 via `-target x86_64-apple-macos`; CGO + Ebiten link the right slice.

Matrix:
- drop `macos-13` entry
- add a second `macos-latest` entry with `goarch: amd64`
- build step sets `CC` / `CXX` conditionally when the runner is arm64 and the target is darwin/amd64

## Verified locally

```
GOOS=darwin GOARCH=amd64 CGO_ENABLED=1 \
  CC="cc -target x86_64-apple-macos" \
  CXX="c++ -target x86_64-apple-macos" \
  go build -tags=nessy ./cmd/nessy
file /tmp/nessy
# → /tmp/nessy: Mach-O 64-bit executable x86_64
```

Native arm64 path unchanged. Build step also adds a `file` diagnostic so CI logs show each runner's output arch at a glance.

## Test plan
- [x] `go build ./...`
- [x] `go test -race -count=1 ./...`
- [x] `golangci-lint run ./...`
- [x] Local cross-compile produces a valid x86_64 Mach-O.
- [ ] Real verification lands the next time a `nessy-v*` tag is pushed — workflow change can't be exercised on PR CI.

Closes #208