### PR TITLE
feat(tui): :syms modal — browse loaded labels for breakpoints (#226)

### DIFF
--- a/internal/tui/complete.go
+++ b/internal/tui/complete.go
@@ -20,6 +20,7 @@ var defaultVerbs = func() []string {
 		"speed",
 		"bp", "bpr", "bpw", "bprw",
 		"rmbpr", "rmbpw", "rmbprw",
+		"syms", "symbols",
 		"trace",
 		"textsave",
 		"theme",

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -115,6 +115,15 @@ type Model struct {
 	ShowBPs  bool
 	BPCursor int // selected row in BP manager
 
+	// Symbols modal — paginated browser over the loaded `.dbg`
+	// label table. Opened via `:syms` (optionally `:syms PREFIX`
+	// for a pre-filter). Enter on a row toggles a breakpoint at
+	// that symbol. Esc / q closes.
+	ShowSyms   bool
+	SymsCursor int    // selected row
+	SymsFilter string // optional substring filter
+	SymsOffset int    // scroll offset within the filtered list
+
 	// Source view
 	ShowSource  bool                      // toggle source panel vs disassembly
 	SourceFiles map[string][]string       // filename -> lines (1-indexed via [i-1])
@@ -442,6 +451,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// BP manager modal.
 		if m.ShowBPs {
 			return m.updateBPManager(msg)
+		}
+		if m.ShowSyms {
+			return m.updateSymsManager(msg)
 		}
 		// Input mode: route most keys to the keyboard peripheral instead
 		// of debugger bindings. Ctrl+C always quits; Esc exits the mode.
@@ -1162,6 +1174,8 @@ func (m Model) View() string {
 		bodyBlock = lipgloss.Place(m.W, bodyHeight, lipgloss.Center, lipgloss.Center, m.helpModal())
 	case m.ShowBPs:
 		bodyBlock = lipgloss.Place(m.W, bodyHeight, lipgloss.Center, lipgloss.Center, m.bpModal())
+	case m.ShowSyms:
+		bodyBlock = lipgloss.Place(m.W, bodyHeight, lipgloss.Center, lipgloss.Center, m.symsModal())
 	case m.ImmediateActive:
 		bodyBlock = lipgloss.Place(m.W, bodyHeight, lipgloss.Center, lipgloss.Center, m.immediateModal())
 	default:
@@ -1222,6 +1236,7 @@ func helpPages() [][]helpSection {
 				{"R", "reset CPU"},
 				{"b", "toggle breakpoint at PC"},
 				{"B", "breakpoint manager"},
+				{":syms", "browse labels from the loaded .dbg (enter toggles bp)"},
 			}},
 			{"Speed", [][2]string{
 				{"+", "faster"},

--- a/internal/tui/prompt.go
+++ b/internal/tui/prompt.go
@@ -361,6 +361,19 @@ func (m *Model) runCommand(line string) string {
 			return fmt.Sprintf("%d breakpoints", len(m.Breakpoints))
 		}
 		return m.cmdBP(args)
+	case "syms", "symbols":
+		if m.Syms == nil || !m.Syms.Has() {
+			return "no symbols loaded (pass -dbg PATH or assemble with -g)"
+		}
+		m.ShowSyms = true
+		m.SymsCursor = 0
+		m.SymsOffset = 0
+		if len(args) > 0 {
+			m.SymsFilter = strings.Join(args, " ")
+		} else {
+			m.SymsFilter = ""
+		}
+		return "symbols"
 	case "bpr":
 		return m.cmdMemBP(args, MemBPRead)
 	case "bpw":

--- a/internal/tui/syms.go
+++ b/internal/tui/syms.go
@@ -1,0 +1,193 @@
+package tui
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// symEntry is one row in the symbols modal: a name + the address it
+// resolves to. Sorted by address (lowest first) so the list mirrors
+// how the program is laid out in memory; ties broken on name.
+type symEntry struct {
+	name string
+	addr uint16
+}
+
+// collectSymbols snapshots the loaded `.dbg` symbol table into a
+// sorted slice the modal can paginate. Applies the optional substring
+// filter case-insensitively against the symbol name. Returns nil if
+// no symbols are loaded.
+func (m *Model) collectSymbols() []symEntry {
+	if m.Syms == nil || !m.Syms.Has() {
+		return nil
+	}
+	filter := strings.ToLower(strings.TrimSpace(m.SymsFilter))
+	names := m.Syms.NamesWithPrefix("")
+	out := make([]symEntry, 0, len(names))
+	for _, n := range names {
+		if filter != "" && !strings.Contains(strings.ToLower(n), filter) {
+			continue
+		}
+		if addr, ok := m.Syms.LookupName(n); ok {
+			out = append(out, symEntry{name: n, addr: addr})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].addr != out[j].addr {
+			return out[i].addr < out[j].addr
+		}
+		return out[i].name < out[j].name
+	})
+	return out
+}
+
+// updateSymsManager handles input while the symbols modal is open.
+// Esc / q closes; j / k navigate; Enter toggles a breakpoint at the
+// highlighted address. `/` enters filter-edit mode, backspace clears
+// it character by character.
+func (m Model) updateSymsManager(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	entries := m.collectSymbols()
+	switch msg.String() {
+	case "esc", "q":
+		m.ShowSyms = false
+		m.SymsFilter = ""
+		m.SymsCursor = 0
+		m.SymsOffset = 0
+		m.Status = "ready"
+	case "j", "down":
+		if m.SymsCursor < len(entries)-1 {
+			m.SymsCursor++
+		}
+	case "k", "up":
+		if m.SymsCursor > 0 {
+			m.SymsCursor--
+		}
+	case "g", "home":
+		m.SymsCursor = 0
+	case "G", "end":
+		m.SymsCursor = len(entries) - 1
+		if m.SymsCursor < 0 {
+			m.SymsCursor = 0
+		}
+	case "enter":
+		if m.SymsCursor < len(entries) {
+			addr := entries[m.SymsCursor].addr
+			if _, ok := m.Breakpoints[addr]; ok {
+				delete(m.Breakpoints, addr)
+				m.Status = fmt.Sprintf("bp -$%04X %s", addr, entries[m.SymsCursor].name)
+			} else {
+				bp := newBP(addr)
+				m.Breakpoints[addr] = bp
+				m.Status = fmt.Sprintf("bp +$%04X %s", addr, entries[m.SymsCursor].name)
+			}
+			m.syncSourceBreakpoints()
+			m.saveState()
+		}
+	case "backspace":
+		if len(m.SymsFilter) > 0 {
+			m.SymsFilter = m.SymsFilter[:len(m.SymsFilter)-1]
+			m.SymsCursor = 0
+		}
+	case "ctrl+c":
+		return m, tea.Quit
+	default:
+		// Plain-character keys append to the filter.
+		if len(msg.Runes) == 1 && msg.Runes[0] >= 0x20 && msg.Runes[0] < 0x7F {
+			r := msg.Runes[0]
+			// Skip "vi"-style navigation chars that already have
+			// dedicated handlers above; appending them to the filter
+			// would be surprising.
+			if r != 'j' && r != 'k' && r != 'g' && r != 'G' && r != 'q' {
+				m.SymsFilter += string(r)
+				m.SymsCursor = 0
+			}
+		}
+	}
+	return m, m.scheduleTick()
+}
+
+// symsModal renders the symbols list. Pagination is automatic — the
+// cursor stays visible as the user navigates, with header info
+// showing the total count + filter state.
+func (m Model) symsModal() string {
+	headerStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("207")).Bold(true).Underline(true)
+	footerStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("244")).Italic(true)
+	selStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("213")).Bold(true)
+	addrStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("108"))
+	frame := lipgloss.NewStyle().
+		Border(lipgloss.DoubleBorder()).
+		BorderForeground(lipgloss.Color("213")).
+		Padding(1, 3)
+
+	if m.Syms == nil || !m.Syms.Has() {
+		body := headerStyle.Render("Symbols") + "\n\n" +
+			"No symbols loaded.\n\n" +
+			"Pass -dbg PATH on launch, or rebuild the ROM with\n" +
+			"`ca65 -g` + `ld65 --dbgfile` so a sibling .dbg ships\n" +
+			"alongside the .nes.\n\n" +
+			footerStyle.Render("esc/q close")
+		return frame.Render(body)
+	}
+
+	entries := m.collectSymbols()
+	rows := 16
+	totalRows := len(entries)
+	if m.SymsCursor >= totalRows {
+		m.SymsCursor = totalRows - 1
+		if m.SymsCursor < 0 {
+			m.SymsCursor = 0
+		}
+	}
+	start := m.SymsCursor - rows/2
+	if start < 0 {
+		start = 0
+	}
+	end := start + rows
+	if end > totalRows {
+		end = totalRows
+		start = end - rows
+		if start < 0 {
+			start = 0
+		}
+	}
+
+	var b strings.Builder
+	header := fmt.Sprintf("Symbols (%d", totalRows)
+	if m.SymsFilter != "" {
+		header += fmt.Sprintf(" matching %q", m.SymsFilter)
+	}
+	header += ")"
+	b.WriteString(headerStyle.Render(header))
+	b.WriteString("\n\n")
+
+	if totalRows == 0 {
+		b.WriteString("  (no matches)\n\n")
+	} else {
+		for i := start; i < end; i++ {
+			e := entries[i]
+			marker := "  "
+			if i == m.SymsCursor {
+				marker = "→ "
+			}
+			bpMarker := " "
+			if _, ok := m.Breakpoints[e.addr]; ok {
+				bpMarker = "●"
+			}
+			line := fmt.Sprintf("%s%s %s  %s", marker, bpMarker,
+				addrStyle.Render(fmt.Sprintf("$%04X", e.addr)), e.name)
+			if i == m.SymsCursor {
+				line = selStyle.Render(line)
+			}
+			b.WriteString(line)
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString(footerStyle.Render("enter: toggle bp · j/k: scroll · g/G: first/last · type: filter · esc/q: close"))
+	return frame.Render(b.String())
+}

--- a/internal/tui/syms_test.go
+++ b/internal/tui/syms_test.go
@@ -1,0 +1,113 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/nkane/chippy/internal/cpu"
+	"github.com/nkane/chippy/internal/symbols"
+)
+
+// buildModelWithSyms constructs a Model with a handful of fake
+// symbols so the modal has something to render. The exact addresses
+// don't matter — only the count + name ordering.
+func buildModelWithSyms(t *testing.T) Model {
+	t.Helper()
+	ram := cpu.NewRAM()
+	c := cpu.New(ram)
+	m := New(c, ram)
+	// Use the real hello-bg .dbg if available; it has the labels we
+	// want to exercise. Skip if not (e.g. running on a worktree
+	// without the demo artifacts).
+	tbl, err := symbols.LoadDbg("../../roms/demos/hello-bg/hello-bg.dbg")
+	if err != nil {
+		t.Skipf("hello-bg.dbg not present: %v", err)
+	}
+	m.Syms = tbl
+	return m
+}
+
+// collectSymbols sorts by address; first entry should be the lowest.
+// The hello-bg demo's reset label sits at $C000.
+func TestCollectSymbols_SortedByAddr(t *testing.T) {
+	m := buildModelWithSyms(t)
+	entries := m.collectSymbols()
+	if len(entries) == 0 {
+		t.Fatalf("collectSymbols returned empty list")
+	}
+	if entries[0].addr != 0xC000 || entries[0].name != "reset" {
+		t.Errorf("entries[0] = ($%04X, %s); want ($C000, reset)", entries[0].addr, entries[0].name)
+	}
+	for i := 1; i < len(entries); i++ {
+		if entries[i].addr < entries[i-1].addr {
+			t.Errorf("entries not sorted at %d: $%04X < $%04X", i, entries[i].addr, entries[i-1].addr)
+		}
+	}
+}
+
+// Filter narrows the visible set to entries containing the
+// substring (case-insensitive).
+func TestCollectSymbols_FilterSubstring(t *testing.T) {
+	m := buildModelWithSyms(t)
+	m.SymsFilter = "clear"
+	entries := m.collectSymbols()
+	for _, e := range entries {
+		if !strings.Contains(strings.ToLower(e.name), "clear") {
+			t.Errorf("filter %q allowed %q to slip through", m.SymsFilter, e.name)
+		}
+	}
+	if len(entries) == 0 {
+		t.Errorf("filter clear should match clear_ram + clear_nt; got 0 entries")
+	}
+}
+
+// Enter on a row toggles a breakpoint at the highlighted address.
+func TestSymsModal_EnterTogglesBreakpoint(t *testing.T) {
+	m := buildModelWithSyms(t)
+	m.ShowSyms = true
+	entries := m.collectSymbols()
+	if len(entries) == 0 {
+		t.Skip("no symbols loaded")
+	}
+	target := entries[0].addr
+
+	// Initially no bp.
+	if _, ok := m.Breakpoints[target]; ok {
+		t.Fatalf("pre-test: bp already exists at $%04X", target)
+	}
+
+	// Press enter — should toggle ON.
+	updated, _ := m.updateSymsManager(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+	if _, ok := m.Breakpoints[target]; !ok {
+		t.Errorf("enter should have created bp at $%04X", target)
+	}
+
+	// Press enter again — should toggle OFF.
+	updated, _ = m.updateSymsManager(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+	if _, ok := m.Breakpoints[target]; ok {
+		t.Errorf("second enter should have deleted bp at $%04X", target)
+	}
+}
+
+// Esc / q closes the modal and clears filter state.
+func TestSymsModal_EscClosesAndClearsState(t *testing.T) {
+	m := buildModelWithSyms(t)
+	m.ShowSyms = true
+	m.SymsFilter = "clear"
+	m.SymsCursor = 3
+	updated, _ := m.updateSymsManager(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(Model)
+	if m.ShowSyms {
+		t.Errorf("ShowSyms still true after esc")
+	}
+	if m.SymsFilter != "" {
+		t.Errorf("SymsFilter = %q; want empty", m.SymsFilter)
+	}
+	if m.SymsCursor != 0 {
+		t.Errorf("SymsCursor = %d; want 0", m.SymsCursor)
+	}
+}


### PR DESCRIPTION
User feedback during nessy attach testing: discovering available breakpoint targets required reading the `.s` source. Tab completion on `:bp <Tab>` already worked, but there was no listing.

## What's new

```
:syms              — open the modal; lists every symbol sorted by address
:syms PREFIX       — pre-filter on substring (case-insensitive)
```

Modal keys:
- `j` / `k` / arrows — scroll
- `g` / `G` — first / last
- enter — toggle breakpoint at highlighted symbol (live-syncs to remote DAP server)
- type — append to filter
- backspace — pop filter character
- esc / q — close + clear filter state

Lines show `addr name` with a `●` marker on symbols that already have a breakpoint set, so toggling is visible.

## Implementation
- `internal/tui/syms.go` (new): `collectSymbols` sorts + filters the `*symbols.Table`; `updateSymsManager` handles modal input; `symsModal` renders inline-styled lipgloss view.
- Model gains `ShowSyms` / `SymsCursor` / `SymsFilter` / `SymsOffset`. `Update` dispatches to `updateSymsManager` when `ShowSyms` is set (mirrors `ShowBPs`).
- `View` routes to `symsModal` in the bodyBlock switch.
- `prompt.go::runCommand` recognizes `"syms"` + `"symbols"`.
- `complete.go` adds both verbs to `defaultVerbs` for tab completion.
- Help modal gets a row pointing at the command.

## Tests
Cover sort-by-address, substring filter, enter-toggles-bp, esc-clears-state. Uses hello-bg's committed `.dbg` as the fixture (skips when not present).

## Test plan
- [x] `go build ./...`
- [x] `go test -race -count=1 ./...`
- [x] `golangci-lint run ./...`
- [ ] Manual: `chippy -nessy roms/demos/hello-bg/hello-bg.nes` → `:syms` → walk the list → press enter → `●` appears next to the row → `q` → `B` shows the bp manager with the new bp.

Closes #226