### PR TITLE
test(nes): OAMDMA + cpu.Stall regression coverage

### DIFF
--- a/cmd/nessy/wiring_test.go
+++ b/cmd/nessy/wiring_test.go
@@ -57,6 +57,157 @@ func TestBuildNES_ResetVectorWiredThroughCart(t *testing.T) {
 	}
 }
 
+// buildiNESLayout is the explicit-bank variant of buildiNES — caller
+// supplies the full 16 KiB PRG bank so a sprite table or other PRG
+// payload can be packed at a known offset. Reset vector still points
+// at $8000.
+func buildiNESLayout(prgBank []byte) []byte {
+	if len(prgBank) != 16*1024 {
+		panic("prgBank must be exactly 16 KiB")
+	}
+	var b bytes.Buffer
+	b.Write([]byte{'N', 'E', 'S', 0x1A})
+	b.WriteByte(1)
+	b.WriteByte(1)
+	b.WriteByte(0)
+	b.WriteByte(0)
+	for range 8 {
+		b.WriteByte(0)
+	}
+	bank := make([]byte, 16*1024)
+	copy(bank, prgBank)
+	bank[0x3FFC] = 0x00
+	bank[0x3FFD] = 0x80
+	b.Write(bank)
+	chrBank := make([]byte, 8*1024)
+	b.Write(chrBank)
+	return b.Bytes()
+}
+
+// OAMDMA reading from a PRG-ROM page (page = $81 → $8100-$81FF) must
+// route through cart.CPURead, not RAM. Seeds the cart bank with a
+// distinct value at offset $100..$1FF; verifies OAM matches after a
+// DMA write of $81.
+func TestBuildNES_OAMDMA_SourcesFromPRGROM(t *testing.T) {
+	prg := make([]byte, 16*1024)
+	for i := range prg {
+		prg[i] = 0xEA
+	}
+	// Program at $8000: LDA #$81 ; STA $4014.
+	copy(prg, []byte{0xA9, 0x81, 0x8D, 0x14, 0x40})
+	// Sprite table at PRG offset $100 (CPU $8100). Each byte = index
+	// XOR $C3 so off-by-one routing surfaces cleanly.
+	for i := range 256 {
+		prg[0x100+i] = byte(i) ^ 0xC3
+	}
+	rom, err := nes.ParseBytes(buildiNESLayout(prg))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	bus, err := buildNES(rom)
+	if err != nil {
+		t.Fatalf("buildNES: %v", err)
+	}
+
+	bus.cpu.Step() // LDA #$81
+	bus.cpu.Step() // STA $4014
+
+	for i := range 256 {
+		want := byte(i) ^ 0xC3
+		if got := bus.ppu.OAM(byte(i)); got != want {
+			t.Fatalf("OAM[$%02X] from PRG = $%02X; want $%02X", i, got, want)
+		}
+	}
+}
+
+// Two consecutive OAMDMA writes in the same "frame" — each must
+// queue its own 513-cycle stall and each drain independently. Games
+// typically DMA once per frame; back-to-back DMA from a transient
+// hits a less common but valid path.
+func TestBuildNES_OAMDMA_RepeatedWrites(t *testing.T) {
+	prog := []byte{
+		0xA9, 0x02, // LDA #$02
+		0x8D, 0x14, 0x40, // STA $4014   (DMA #1 from $0200)
+		0xA9, 0x03, // LDA #$03
+		0x8D, 0x14, 0x40, // STA $4014   (DMA #2 from $0300)
+	}
+	rom, err := nes.ParseBytes(buildiNES(prog))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	bus, err := buildNES(rom)
+	if err != nil {
+		t.Fatalf("buildNES: %v", err)
+	}
+
+	// Seed RAM pages $02 + $03 with distinct patterns.
+	for i := range 256 {
+		bus.ram.Write(0x0200+uint16(i), 0x11)
+		bus.ram.Write(0x0300+uint16(i), 0x22)
+	}
+
+	bus.cpu.Step() // LDA #$02
+	bus.cpu.Step() // STA $4014 → DMA #1 (OAM all $11), queue 513 stall
+	stalled := bus.cpu.Step()
+	if stalled != 513 {
+		t.Fatalf("stall #1 cycles = %d; want 513", stalled)
+	}
+	// After first DMA, OAM has wrapped (oamAddr ticked 256 → back to 0
+	// since byte counter overflows). So the second DMA overwrites
+	// from the top with the $03 page contents.
+	bus.cpu.Step() // LDA #$03
+	bus.cpu.Step() // STA $4014 → DMA #2 (OAM all $22), queue 513 stall
+	stalled = bus.cpu.Step()
+	if stalled != 513 {
+		t.Fatalf("stall #2 cycles = %d; want 513", stalled)
+	}
+	for i := range 256 {
+		if got := bus.ppu.OAM(byte(i)); got != 0x22 {
+			t.Fatalf("OAM[$%02X] after 2nd DMA = $%02X; want $22", i, got)
+		}
+	}
+}
+
+// Stall cycles MUST flow to the PPU's bus-ticker hook — sprites
+// depend on accurate vblank timing, so a 513-cycle stall has to
+// advance the PPU dot counter by 513 * 3 = 1539 dots. Catches a
+// regression where Step()'s stall drain skips the busTicker.Tick
+// fan-out.
+func TestBuildNES_OAMDMA_StallTicksPPU(t *testing.T) {
+	prog := []byte{
+		0xA9, 0x02, // LDA #$02
+		0x8D, 0x14, 0x40, // STA $4014
+	}
+	rom, err := nes.ParseBytes(buildiNES(prog))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	bus, err := buildNES(rom)
+	if err != nil {
+		t.Fatalf("buildNES: %v", err)
+	}
+	bus.cpu.Step() // LDA #$02 → 2 cyc → 6 dots
+	bus.cpu.Step() // STA $4014 → 4 cyc → 12 dots
+	preDots := absoluteDot(bus.ppu)
+	bus.cpu.Step() // drain 513-cyc stall → 1539 dots
+	postDots := absoluteDot(bus.ppu)
+	if got := postDots - preDots; got != 513*3 {
+		t.Fatalf("PPU dot delta during stall = %d; want %d (513 cyc * 3 dots/cyc)", got, uint64(513*3))
+	}
+}
+
+// absoluteDot collapses (frame, scanline, dot) into a monotonic dot
+// index so stall-cycle tests can subtract without scanline- or
+// frame-rollover headaches. 341 dots × 262 scanlines = 89342 dots per
+// frame.
+func absoluteDot(p interface {
+	Scanline() int
+	Dot() int
+	FrameCount() uint64
+}) uint64 {
+	return p.FrameCount()*89342 + uint64(p.Scanline())*341 + uint64(p.Dot())
+}
+
 // $4014 OAMDMA wiring end-to-end: seed CPU RAM page $02 with a known
 // pattern, execute STA $4014 with A=$02 through the real CPU, then
 // verify the PPU's OAM is populated and the next Step drains the 513

--- a/internal/cpu/stall_test.go
+++ b/internal/cpu/stall_test.go
@@ -83,6 +83,75 @@ func TestStall_RejectsNonPositive(t *testing.T) {
 	}
 }
 
+// STP-halt traps the CPU at the top of Step() before any other
+// state machine runs. A queued stall stays queued forever; only
+// Reset clears the latch. Models real CMOS silicon behavior.
+func TestStall_BlockedByStpHalt(t *testing.T) {
+	ram := NewRAM()
+	ram.Load(0x8000, []byte{0xEA}) // NOP filler
+	ram.Write(VecReset, 0x00)
+	ram.Write(VecReset+1, 0x80)
+	bus := &fakeTicker{ram: ram}
+	c := NewVariant(bus, VariantCMOS65C02)
+
+	// Force STP halt directly via the unexported latch (the test
+	// lives in package cpu, so this is fine).
+	c.Halted = true
+	c.stoppedBySTP = true
+
+	c.Stall(513)
+	got := c.Step()
+	if got != 0 {
+		t.Fatalf("STP-halted Step returned %d cycles; want 0 (stall must not drain)", got)
+	}
+	if c.pendingStall != 513 {
+		t.Fatalf("pendingStall = %d after STP-blocked Step; want 513 still queued", c.pendingStall)
+	}
+
+	// Reset clears the latch; next Step then drains the stall queue.
+	c.Reset()
+	if c.stoppedBySTP {
+		t.Fatalf("Reset did not clear stoppedBySTP")
+	}
+	// Reset also reinitializes pendingStall implicitly via the queue
+	// staying intact — Reset doesn't touch pendingStall, by design,
+	// so the stall is still owed. Drain it.
+	got = c.Step()
+	if got != 513 {
+		t.Fatalf("post-Reset stall drain = %d; want 513", got)
+	}
+}
+
+// WAI-halt (CMOS-only): Step() returns 0 once Halted is set with no
+// interrupt pending. A queued stall placed before the WAI must still
+// drain — pendingStall is checked *before* the Halted gate. After
+// drain, subsequent Steps return 0 until an interrupt wakes the CPU.
+func TestStall_DrainsBeforeWaiHaltGate(t *testing.T) {
+	ram := NewRAM()
+	ram.Load(0x8000, []byte{0xEA})
+	ram.Write(VecReset, 0x00)
+	ram.Write(VecReset+1, 0x80)
+	bus := &fakeTicker{ram: ram}
+	c := NewVariant(bus, VariantCMOS65C02)
+
+	// Simulate WAI: halted, NOT stoppedBySTP.
+	c.Halted = true
+
+	c.Stall(513)
+	got := c.Step()
+	if got != 513 {
+		t.Fatalf("WAI-halted Step stall drain = %d; want 513", got)
+	}
+	// Subsequent Steps return 0 until an interrupt wakes the CPU.
+	if got = c.Step(); got != 0 {
+		t.Fatalf("post-drain WAI-halted Step = %d; want 0", got)
+	}
+	// Tick fired exactly once with the 513 delta.
+	if bus.calls != 1 || bus.total != 513 {
+		t.Fatalf("ticker fired %d times totaling %d; want 1 call of 513", bus.calls, bus.total)
+	}
+}
+
 // Pending NMI preempts a queued stall — the next Step services the
 // interrupt, the stall waits one boundary, then drains.
 func TestStall_NMIPreempts(t *testing.T) {

--- a/internal/nes/dma/oamdma_test.go
+++ b/internal/nes/dma/oamdma_test.go
@@ -69,6 +69,31 @@ func TestOAMDMA_Range(t *testing.T) {
 	}
 }
 
+// OAMDMA reads exactly $XX00-$XXFF — never overruns into the
+// following page. Seeds page $02 with one value and page $03 with a
+// different value; after a DMA from $02, OAM must contain only the
+// $02 values. Catches off-by-one bus.Read addressing.
+func TestOAMDMA_ReadsExactly256BytesNoOverrun(t *testing.T) {
+	ram := cpu.NewRAM()
+	for i := range 256 {
+		ram.Write(0x0200+uint16(i), 0x11)
+		ram.Write(0x0300+uint16(i), 0x22)
+	}
+	pp := &fakePPU{}
+	d := New(ram, pp, &fakeStaller{})
+
+	d.Write(0x4014, 0x02)
+
+	if len(pp.oam) != 256 {
+		t.Fatalf("oam writes = %d; want exactly 256", len(pp.oam))
+	}
+	for i, b := range pp.oam {
+		if b != 0x11 {
+			t.Fatalf("oam[%d] = $%02X; want $11 (no over-read into page $03)", i, b)
+		}
+	}
+}
+
 // End-to-end through MMIO: register the peripheral, write through
 // the bus, observe both side effects (OAM populated + stall queued).
 // Catches register-order bugs in cmd/nessy/wiring.go.


### PR DESCRIPTION
## Summary
Tightens regression coverage around the #204 OAMDMA + `cpu.Stall` work. Six new tests, all passing locally and matching the existing test-style conventions in each package.

### `internal/nes/dma/`
- **`TestOAMDMA_ReadsExactly256BytesNoOverrun`** — seeds page $02 with $11 and page $03 with $22; DMA from $02 must populate OAM entirely with $11. Catches off-by-one in the source-address loop.

### `internal/cpu/`
- **`TestStall_BlockedByStpHalt`** — `stoppedBySTP` short-circuits `Step()` before pendingStall drains; stall stays queued. Reset clears the latch and the queue then drains.
- **`TestStall_DrainsBeforeWaiHaltGate`** — a stall queued before WAI-halt still drains exactly once; subsequent Steps return 0 until an interrupt wakes the CPU. Documents the `pendingStall`-before-`Halted` order in `exec.go`.

### `cmd/nessy/`
- **`TestBuildNES_OAMDMA_SourcesFromPRGROM`** — DMA from page $81 reads through `cart.CPURead` (NROM PRG bank), not RAM. Catches MMIO routing regressions during DMA. Adds a `buildiNESLayout` helper that takes the full 16 KiB PRG bank so sprite tables can be embedded.
- **`TestBuildNES_OAMDMA_RepeatedWrites`** — back-to-back `STA $4014` writes each queue their own 513-cycle stall and each drains independently. Real games DMA every frame; the test simulates two transients in close succession.
- **`TestBuildNES_OAMDMA_StallTicksPPU`** — a 513-cycle stall advances the PPU dot counter by 1539 (3 dots/cyc) via the CPU's bus-ticker fan-out. Catches regressions where `Step()`'s stall drain skips the ticker. A small `absoluteDot` helper collapses (frame, scanline, dot) into a monotonic index so the assertion survives frame wraparound.

## Test plan
- [x] `go test -race -count=1 ./...`
- [x] `golangci-lint run ./...` — 0 issues
- [x] All existing nestest / perfgate / Klaus / decimal suites still pass.