### PR TITLE
feat(tui): Quake-style drop-down console — DRAFT (#232)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,6 +311,9 @@ jobs:
             ### chippy-bp-and-run (#225)
             ![chippy-bp-and-run](https://raw.githubusercontent.com/${{ github.repository }}/smoke-gifs/pr-${{ github.event.pull_request.number }}/chippy-bp-and-run.gif)
 
+            ### chippy-console (#232)
+            ![chippy-console](https://raw.githubusercontent.com/${{ github.repository }}/smoke-gifs/pr-${{ github.event.pull_request.number }}/chippy-console.gif)
+
   cmos-e2e:
     name: cmos e2e demo
     runs-on: ubuntu-latest

--- a/internal/tui/console.go
+++ b/internal/tui/console.go
@@ -53,6 +53,13 @@ func (m Model) updateConsole(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if len(m.ConsoleBuf) > 0 {
 			m.ConsoleBuf = m.ConsoleBuf[:len(m.ConsoleBuf)-1]
 		}
+	case "tab":
+		// Reuse the `:` prompt's verb / symbol completer so the
+		// console knows the same commands. Returns the extended
+		// buffer (or the same buffer if no completion possible).
+		if completed, ok := completePrompt(m.ConsoleBuf, m.Syms); ok {
+			m.ConsoleBuf = completed
+		}
 	case "pgup":
 		m.ConsoleScrollOffset += 8
 		if max := len(m.ConsoleScrollback); m.ConsoleScrollOffset > max {

--- a/internal/tui/console.go
+++ b/internal/tui/console.go
@@ -1,0 +1,146 @@
+package tui
+
+import (
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// Draft of issue #232 — the Quake-style drop-down console. Backtick
+// (`) opens; Esc / backtick close. While open the console owns
+// input — typing builds ConsoleBuf, Enter runs it via the existing
+// runCommand path (same verbs as the `:` prompt), output streams
+// into the scrollback. PgUp / PgDn walk the scrollback so output
+// past the visible height isn't lost.
+//
+// This is the bones-only first cut. Polish items deferred to
+// follow-ups: history walk inside the console, tab completion,
+// scrollback persistence, transparent overlay (real terminal
+// alpha doesn't exist; dim styling is the closest approximation).
+
+const (
+	consoleHeightRatio   = 2 // 1/2 of the screen
+	consoleScrollbackMax = 500
+)
+
+// updateConsole handles all input while the console is open.
+func (m Model) updateConsole(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "`":
+		m.ConsoleActive = false
+		m.ConsoleBuf = ""
+		m.Status = "ready"
+	case "ctrl+c":
+		return m, tea.Quit
+	case "enter":
+		line := strings.TrimSpace(m.ConsoleBuf)
+		m.ConsoleBuf = ""
+		if line == "" {
+			break
+		}
+		m.appendConsole("> " + line)
+		out := m.runCommand(line)
+		if out != "" {
+			for _, ln := range strings.Split(out, "\n") {
+				m.appendConsole(ln)
+			}
+		}
+		// Snap back to the bottom so the freshly-typed command's
+		// output is visible.
+		m.ConsoleScrollOffset = 0
+	case "backspace":
+		if len(m.ConsoleBuf) > 0 {
+			m.ConsoleBuf = m.ConsoleBuf[:len(m.ConsoleBuf)-1]
+		}
+	case "pgup":
+		m.ConsoleScrollOffset += 8
+		if max := len(m.ConsoleScrollback); m.ConsoleScrollOffset > max {
+			m.ConsoleScrollOffset = max
+		}
+	case "pgdown":
+		m.ConsoleScrollOffset -= 8
+		if m.ConsoleScrollOffset < 0 {
+			m.ConsoleScrollOffset = 0
+		}
+	default:
+		// Plain printable runes append to the buffer. Skip the
+		// backtick (already handled above as toggle) and any
+		// non-printable control chars.
+		if len(msg.Runes) == 1 {
+			r := msg.Runes[0]
+			if r >= 0x20 && r < 0x7F && r != '`' {
+				m.ConsoleBuf += string(r)
+			}
+		}
+	}
+	return m, m.scheduleTick()
+}
+
+// appendConsole pushes one line onto the scrollback with a soft
+// cap so long sessions don't grow unbounded.
+func (m *Model) appendConsole(line string) {
+	m.ConsoleScrollback = append(m.ConsoleScrollback, line)
+	if over := len(m.ConsoleScrollback) - consoleScrollbackMax; over > 0 {
+		m.ConsoleScrollback = m.ConsoleScrollback[over:]
+	}
+}
+
+// consoleView renders the drop-down overlay. Sized to ~half the
+// screen height; bordered + headed; bottom row is the live input
+// line with a `>` prompt.
+func (m Model) consoleView(width, totalHeight int) string {
+	height := totalHeight / consoleHeightRatio
+	if height < 6 {
+		height = 6
+	}
+	if height > totalHeight {
+		height = totalHeight
+	}
+
+	header := lipgloss.NewStyle().
+		Foreground(lipgloss.Color("207")).
+		Bold(true).
+		Render(" chippy console — esc/` close · PgUp/PgDn scroll ")
+	frame := lipgloss.NewStyle().
+		Border(lipgloss.NormalBorder()).
+		BorderForeground(lipgloss.Color("213")).
+		Padding(0, 1)
+	prompt := lipgloss.NewStyle().Foreground(lipgloss.Color("213"))
+
+	// Reserve: 1 header + 2 border + 1 input = 4 rows of chrome.
+	scrollRows := height - 4
+	if scrollRows < 1 {
+		scrollRows = 1
+	}
+
+	// Bottom-anchored scrollback with PgUp/PgDn offset.
+	total := len(m.ConsoleScrollback)
+	end := total - m.ConsoleScrollOffset
+	if end < 0 {
+		end = 0
+	}
+	if end > total {
+		end = total
+	}
+	start := end - scrollRows
+	if start < 0 {
+		start = 0
+	}
+	visible := m.ConsoleScrollback[start:end]
+
+	var body strings.Builder
+	body.WriteString(header)
+	body.WriteString("\n")
+	// Pad scrollback area to scrollRows so the input line stays
+	// pinned at the same y.
+	for i := 0; i < scrollRows-len(visible); i++ {
+		body.WriteString("\n")
+	}
+	for _, ln := range visible {
+		body.WriteString(ln + "\n")
+	}
+	body.WriteString(prompt.Render("> ") + m.ConsoleBuf + "_")
+
+	return frame.Width(width - 4).Render(body.String())
+}

--- a/internal/tui/console_test.go
+++ b/internal/tui/console_test.go
@@ -1,0 +1,165 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/nkane/chippy/internal/cpu"
+)
+
+func newConsoleModel(t *testing.T) Model {
+	t.Helper()
+	ram := cpu.NewRAM()
+	c := cpu.New(ram)
+	return New(c, ram)
+}
+
+// Backtick from the main key handler opens the console.
+func TestConsole_BacktickOpens(t *testing.T) {
+	m := newConsoleModel(t)
+	if m.ConsoleActive {
+		t.Fatalf("ConsoleActive should default false")
+	}
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'`'}})
+	m = updated.(Model)
+	if !m.ConsoleActive {
+		t.Errorf("backtick didn't toggle ConsoleActive on")
+	}
+	if m.ConsoleBuf != "" {
+		t.Errorf("ConsoleBuf should reset on open; got %q", m.ConsoleBuf)
+	}
+}
+
+// Esc from inside the console closes it.
+func TestConsole_EscCloses(t *testing.T) {
+	m := newConsoleModel(t)
+	m.ConsoleActive = true
+	m.ConsoleBuf = "stale"
+	updated, _ := m.updateConsole(tea.KeyMsg{Type: tea.KeyEsc})
+	m = updated.(Model)
+	if m.ConsoleActive {
+		t.Errorf("esc didn't close console")
+	}
+	if m.ConsoleBuf != "" {
+		t.Errorf("esc should clear buf; got %q", m.ConsoleBuf)
+	}
+}
+
+// Backtick from inside the console also closes it (toggle).
+func TestConsole_BacktickInsideCloses(t *testing.T) {
+	m := newConsoleModel(t)
+	m.ConsoleActive = true
+	updated, _ := m.updateConsole(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'`'}})
+	m = updated.(Model)
+	if m.ConsoleActive {
+		t.Errorf("backtick inside console didn't close it")
+	}
+}
+
+// Typing printable characters appends to the buffer. Backtick is
+// the toggle, NOT a filterable character — typing it closes the
+// console (verified separately in TestConsole_BacktickInsideCloses).
+func TestConsole_TypingAppendsBuf(t *testing.T) {
+	m := newConsoleModel(t)
+	m.ConsoleActive = true
+	for _, r := range []rune{'h', 'e', 'l', 'l', 'o'} {
+		updated, _ := m.updateConsole(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+		m = updated.(Model)
+	}
+	if m.ConsoleBuf != "hello" {
+		t.Errorf("buf = %q; want %q", m.ConsoleBuf, "hello")
+	}
+}
+
+// Enter runs the buffer through runCommand and appends `> cmd` plus
+// the result to the scrollback.
+func TestConsole_EnterRunsAndAppendsScrollback(t *testing.T) {
+	m := newConsoleModel(t)
+	m.ConsoleActive = true
+	m.ConsoleBuf = "pc"
+	updated, _ := m.updateConsole(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+	if len(m.ConsoleScrollback) == 0 {
+		t.Fatalf("scrollback empty after Enter")
+	}
+	if m.ConsoleScrollback[0] != "> pc" {
+		t.Errorf("scrollback[0] = %q; want %q", m.ConsoleScrollback[0], "> pc")
+	}
+	if m.ConsoleBuf != "" {
+		t.Errorf("buf not cleared after Enter; got %q", m.ConsoleBuf)
+	}
+}
+
+// Empty Enter is a no-op — no scrollback growth, no error.
+func TestConsole_EmptyEnterIsNoop(t *testing.T) {
+	m := newConsoleModel(t)
+	m.ConsoleActive = true
+	pre := len(m.ConsoleScrollback)
+	updated, _ := m.updateConsole(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(Model)
+	if len(m.ConsoleScrollback) != pre {
+		t.Errorf("empty Enter grew scrollback by %d", len(m.ConsoleScrollback)-pre)
+	}
+}
+
+// Backspace shortens the buffer; doesn't underflow.
+func TestConsole_Backspace(t *testing.T) {
+	m := newConsoleModel(t)
+	m.ConsoleActive = true
+	m.ConsoleBuf = "abc"
+	updated, _ := m.updateConsole(tea.KeyMsg{Type: tea.KeyBackspace})
+	m = updated.(Model)
+	if m.ConsoleBuf != "ab" {
+		t.Errorf("backspace → %q; want %q", m.ConsoleBuf, "ab")
+	}
+	// Empty-buf backspace shouldn't panic / underflow.
+	m.ConsoleBuf = ""
+	updated, _ = m.updateConsole(tea.KeyMsg{Type: tea.KeyBackspace})
+	m = updated.(Model)
+	if m.ConsoleBuf != "" {
+		t.Errorf("backspace on empty buf changed it to %q", m.ConsoleBuf)
+	}
+}
+
+// PgUp grows the scroll offset; PgDn shrinks; both clamp.
+func TestConsole_ScrollClamps(t *testing.T) {
+	m := newConsoleModel(t)
+	m.ConsoleActive = true
+	for i := 0; i < 5; i++ {
+		m.ConsoleScrollback = append(m.ConsoleScrollback, "line")
+	}
+	// PgUp from offset 0 → up to 5 (len cap).
+	for range 10 {
+		updated, _ := m.updateConsole(tea.KeyMsg{Type: tea.KeyPgUp})
+		m = updated.(Model)
+	}
+	if m.ConsoleScrollOffset != len(m.ConsoleScrollback) {
+		t.Errorf("PgUp clamp = %d; want %d", m.ConsoleScrollOffset, len(m.ConsoleScrollback))
+	}
+	// PgDn floors at 0.
+	for range 10 {
+		updated, _ := m.updateConsole(tea.KeyMsg{Type: tea.KeyPgDown})
+		m = updated.(Model)
+	}
+	if m.ConsoleScrollOffset != 0 {
+		t.Errorf("PgDn floor = %d; want 0", m.ConsoleScrollOffset)
+	}
+}
+
+// consoleView renders a header + the live input line at minimum,
+// even with empty scrollback. Smoke test against the rendered
+// string.
+func TestConsole_ViewRenders(t *testing.T) {
+	m := newConsoleModel(t)
+	m.ConsoleActive = true
+	m.ConsoleBuf = "hello"
+	out := m.consoleView(120, 40)
+	if !strings.Contains(out, "console") {
+		t.Errorf("header missing in view:\n%s", out)
+	}
+	if !strings.Contains(out, "hello") {
+		t.Errorf("buf %q missing from view:\n%s", m.ConsoleBuf, out)
+	}
+}

--- a/internal/tui/console_test.go
+++ b/internal/tui/console_test.go
@@ -148,6 +148,48 @@ func TestConsole_ScrollClamps(t *testing.T) {
 	}
 }
 
+// Tab completes the current buffer against the same verb / symbol
+// pool the `:` prompt uses. With no symbols loaded, completing a
+// prefix like "spe" should land on "speed ".
+func TestConsole_TabCompletesVerb(t *testing.T) {
+	m := newConsoleModel(t)
+	m.ConsoleActive = true
+	m.ConsoleBuf = "spe"
+	updated, _ := m.updateConsole(tea.KeyMsg{Type: tea.KeyTab})
+	m = updated.(Model)
+	if m.ConsoleBuf != "speed " {
+		t.Errorf("Tab on \"spe\" → %q; want %q", m.ConsoleBuf, "speed ")
+	}
+}
+
+// First open seeds the scrollback with an onboarding hint. Subsequent
+// opens don't spam: scrollback already non-empty so the seed-block
+// stays unique.
+func TestConsole_FirstOpenSeedsHint(t *testing.T) {
+	m := newConsoleModel(t)
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'`'}})
+	m = updated.(Model)
+	if len(m.ConsoleScrollback) == 0 {
+		t.Errorf("first open didn't seed scrollback")
+	}
+	first := m.ConsoleScrollback[0]
+	if !strings.Contains(first, "console") || !strings.Contains(first, "Tab") {
+		t.Errorf("seed hint missing key text; got %q", first)
+	}
+	// Close + reopen — no growth from the seed block.
+	closeAndReopen := func() Model {
+		u, _ := m.updateConsole(tea.KeyMsg{Type: tea.KeyEsc})
+		m := u.(Model)
+		u, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'`'}})
+		return u.(Model)
+	}
+	preLen := len(m.ConsoleScrollback)
+	m = closeAndReopen()
+	if len(m.ConsoleScrollback) != preLen {
+		t.Errorf("re-open seeded again: %d → %d", preLen, len(m.ConsoleScrollback))
+	}
+}
+
 // consoleView renders a header + the live input line at minimum,
 // even with empty scrollback. Smoke test against the rendered
 // string.

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -504,6 +504,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.ConsoleActive = true
 			m.ConsoleBuf = ""
 			m.Status = "console"
+			// First-open onboarding hint — printed only when the
+			// scrollback is empty so it doesn't spam on repeat
+			// opens.
+			if len(m.ConsoleScrollback) == 0 {
+				m.appendConsole("chippy console — same verbs as `:` prompt. Tab completes.")
+				m.appendConsole("Try: help, syms, bp <addr>, goto <addr|sym>, watch <addr>, speed N, theme NAME.")
+				m.appendConsole("Esc or ` closes.")
+			}
 		case "i":
 			if m.Keyboard != nil {
 				m.InputMode = true

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -142,6 +142,18 @@ type Model struct {
 	PromptActive bool
 	PromptBuf    string
 
+	// Quake-style drop-down console (issue #232 draft). Backtick
+	// toggles. While active a scrollback panel covers the top ~50%
+	// of the screen with an embedded prompt — each Enter runs the
+	// current buffer through runCommand and appends `> cmd` + the
+	// result to the scrollback. Esc / backtick closes; PgUp / PgDn
+	// scroll. The existing `:` prompt stays as the bottom-line
+	// quick-fire variant.
+	ConsoleActive       bool
+	ConsoleBuf          string
+	ConsoleScrollback   []string
+	ConsoleScrollOffset int
+
 	// Prompt command history. Persisted to HistPath when set, capped at
 	// histCap entries. HistIdx walks back from the newest entry; -1 means
 	// "not navigating, PromptBuf is live". HistTemp saves the in-progress
@@ -441,6 +453,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.PromptActive {
 			return m.updatePrompt(msg)
 		}
+		// Quake console owns all input while open. Backtick toggles
+		// from anywhere except the other modal states above (those
+		// gates fire first so the console can't fight them).
+		if m.ConsoleActive {
+			return m.updateConsole(msg)
+		}
 		// Help modal: paging keys advance, any other key dismisses.
 		if m.ShowHelp {
 			switch msg.String() {
@@ -482,6 +500,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "q", "ctrl+c":
 			m.saveState()
 			return m, tea.Quit
+		case "`":
+			m.ConsoleActive = true
+			m.ConsoleBuf = ""
+			m.Status = "console"
 		case "i":
 			if m.Keyboard != nil {
 				m.InputMode = true
@@ -1208,6 +1230,14 @@ func (m Model) View() string {
 		bodyBlock = lipgloss.Place(m.W, bodyHeight, lipgloss.Center, lipgloss.Center, m.symsModal())
 	case m.ImmediateActive:
 		bodyBlock = lipgloss.Place(m.W, bodyHeight, lipgloss.Center, lipgloss.Center, m.immediateModal())
+	case m.ConsoleActive:
+		// Quake drop-down: console anchored at the top, the rest of
+		// the body still visible behind it (only top half consumed).
+		console := m.consoleView(m.W, bodyHeight)
+		bodyBlock = lipgloss.JoinVertical(lipgloss.Left,
+			console,
+			lipgloss.PlaceHorizontal(m.W, lipgloss.Center, body),
+		)
 	default:
 		bodyBlock = lipgloss.PlaceHorizontal(m.W, lipgloss.Center, body)
 	}

--- a/test/smoke/Makefile
+++ b/test/smoke/Makefile
@@ -23,7 +23,8 @@ NESSY     := $(REPO_ROOT)/nessy
 CHIPPY_TAPES := \
 	$(REPO_ROOT)/test/smoke/chippy-source-scroll.tape \
 	$(REPO_ROOT)/test/smoke/chippy-syms.tape \
-	$(REPO_ROOT)/test/smoke/chippy-bp-and-run.tape
+	$(REPO_ROOT)/test/smoke/chippy-bp-and-run.tape \
+	$(REPO_ROOT)/test/smoke/chippy-console.tape
 
 NESSY_TAPES := \
 	$(REPO_ROOT)/test/smoke/nessy-attach.tape

--- a/test/smoke/chippy-console.tape
+++ b/test/smoke/chippy-console.tape
@@ -22,9 +22,19 @@ Enter
 Sleep 1500ms
 Show
 
-# Open the console.
+# Open the console — first-open onboarding hint seeds the
+# scrollback so users see what commands exist.
 Type "`"
-Sleep 800ms
+Sleep 1200ms
+
+# Type a partial verb + Tab to demonstrate completion.
+Type "spe"
+Sleep 300ms
+Tab
+Sleep 600ms
+Type "60"
+Enter
+Sleep 500ms
 
 # Run pc — outputs the current PC.
 Type "pc"

--- a/test/smoke/chippy-console.tape
+++ b/test/smoke/chippy-console.tape
@@ -1,0 +1,65 @@
+# chippy-console.tape
+#
+# Smoke test for #232 / PR #275 — Quake-style drop-down console.
+# Opens the console with backtick, runs a few commands through it,
+# exercises PgUp / PgDn scroll, closes with backtick. PR review
+# reads the GIF; CI only checks that VHS rendered without crashing.
+
+Output test/smoke/out/chippy-console.gif
+
+Require ./chippy
+
+Set Shell "bash"
+Set FontSize 14
+Set Width 1400
+Set Height 800
+Set Padding 12
+Set TypingSpeed 30ms
+
+Hide
+Type "./chippy -rom example/count_to_ten.bin"
+Enter
+Sleep 1500ms
+Show
+
+# Open the console.
+Type "`"
+Sleep 800ms
+
+# Run pc — outputs the current PC.
+Type "pc"
+Enter
+Sleep 500ms
+
+# Run goto start — jumps somewhere recognizable.
+Type "goto start"
+Enter
+Sleep 500ms
+
+# Run pc again so the scrollback has multiple lines.
+Type "pc"
+Enter
+Sleep 500ms
+
+# Walk the scrollback up + down.
+PageUp
+Sleep 400ms
+PageDown
+Sleep 400ms
+
+# Type something then backspace partially to show editing.
+Type "rmw"
+Sleep 300ms
+Backspace
+Backspace
+Backspace
+Sleep 300ms
+
+# Close the console.
+Type "`"
+Sleep 500ms
+
+# Quit cleanly.
+Type ":q"
+Enter
+Sleep 500ms


### PR DESCRIPTION
## Status
**Draft.** Bones-only first cut of the issue spec. Functional + tested, but several polish items deferred (see below).

## What works
- Backtick (\`) toggles a top-anchored drop-down console panel.
- While open the console owns input — typing builds `ConsoleBuf`, Enter runs it through the existing `runCommand` path (same verbs as the `:` prompt), output streams into a scrollback.
- Esc or backtick closes.
- PgUp / PgDn walk the scrollback (clamped at bounds).
- Backspace, soft cap of 500 scrollback entries.

## Files
- `internal/tui/console.go` — `updateConsole` + `consoleView` + `appendConsole`.
- `internal/tui/console_test.go` — 8 tests covering toggle, typing, Enter+run, backspace, scroll clamps, view render.
- `internal/tui/model.go` — new fields (`ConsoleActive` / `ConsoleBuf` / `ConsoleScrollback` / `ConsoleScrollOffset`), backtick key in the main `Update`, View dispatch.

## Test plan
- [x] `go test -race -count=1 ./...` — green.
- [x] `golangci-lint run ./...` — 0 issues.
- [ ] **Manual TUI smoke** (run before merge): `./chippy -rom example/count_to_ten.bin` → press `` ` ``, type `pc`, Enter; verify `> pc` + the result land in scrollback. Press `` ` `` again to close. Toggle a few more times; PgUp / PgDn while scrollback fills.

## Out of scope (deferred follow-ups; issue #232 stays open)
- History walk inside the console (Up / Down arrows).
- Tab completion against the same syms / verbs pool as `:`.
- Routing `:help` / `:syms` modal output into the scrollback instead of their own modals.
- Scrollback persistence across sessions.
- Transparent overlay — real terminal alpha doesn't exist; the dim-styled frame is the closest approximation.

Refs #232.