### PR TITLE
fix(nessy): decouple audio thread from cpuMu — kills SMB1 stutter

### DIFF
--- a/cmd/nessy/audio.go
+++ b/cmd/nessy/audio.go
@@ -27,16 +27,15 @@ type apuStream struct {
 	pending []byte
 }
 
-// maxQueueBytes caps the pending queue at ~100ms of stereo PCM
-// (44100 samples/sec × 4 bytes × 0.1 s ≈ 17.6 KB). Without the
-// cap, any frame where game.Update runs slightly faster than
-// wallclock — Ebiten's catch-up scheduling occasionally fires two
-// Updates back-to-back when the previous frame ran long —
-// accumulates samples the audio thread can't drain fast enough
-// and the playback latency keeps growing. Audio drifts behind the
-// visible game state. Capping bounds latency at ~100ms; the
-// dropped-oldest policy prefers fresh audio over a smooth tail.
-const maxQueueBytes = 4 * 44100 / 10
+// maxQueueBytes caps the pending queue at ~500ms of stereo PCM
+// (44100 samples/sec × 4 bytes × 0.5 s ≈ 88 KB). Bounds worst-case
+// audio latency at half a second so drift doesn't grow unbounded
+// across a long session, but big enough that the Ebiten / oto
+// drain cadence's natural jitter never hits the cap during normal
+// play — drops translate to audible clicks, so the cap exists for
+// the pathological case (e.g. nessy paused with a debugger
+// attached while audio kept queueing).
+const maxQueueBytes = 4 * 44100 / 2
 
 // Push appends new stereo PCM bytes. Called from the game-loop
 // goroutine after it drains APU.Samples() under cpuMu — we copy /
@@ -101,11 +100,17 @@ func newAudioSink(mute bool) (*audioSink, error) {
 }
 
 // start kicks off playback. Called once after newGame so the
-// player is ready before the game loop's first tick.
+// player is ready before the game loop's first tick. Pre-seeds
+// the queue with a short slice of silence so the audio thread's
+// initial Read finds something to consume before the first frame
+// of game audio arrives — without that prime, oto starts in an
+// "underrun" state and emits a click on first real data.
 func (s *audioSink) start() {
 	if s == nil {
 		return
 	}
+	const primeBytes = 4 * 44100 / 10 // ~100ms of silence
+	s.stream.Push(make([]byte, primeBytes))
 	s.player.Play()
 }
 

--- a/cmd/nessy/audio.go
+++ b/cmd/nessy/audio.go
@@ -27,6 +27,17 @@ type apuStream struct {
 	pending []byte
 }
 
+// maxQueueBytes caps the pending queue at ~100ms of stereo PCM
+// (44100 samples/sec × 4 bytes × 0.1 s ≈ 17.6 KB). Without the
+// cap, any frame where game.Update runs slightly faster than
+// wallclock — Ebiten's catch-up scheduling occasionally fires two
+// Updates back-to-back when the previous frame ran long —
+// accumulates samples the audio thread can't drain fast enough
+// and the playback latency keeps growing. Audio drifts behind the
+// visible game state. Capping bounds latency at ~100ms; the
+// dropped-oldest policy prefers fresh audio over a smooth tail.
+const maxQueueBytes = 4 * 44100 / 10
+
 // Push appends new stereo PCM bytes. Called from the game-loop
 // goroutine after it drains APU.Samples() under cpuMu — we copy /
 // reshape outside the cpuMu critical section so the audio thread
@@ -34,6 +45,14 @@ type apuStream struct {
 func (s *apuStream) Push(stereo []byte) {
 	s.mu.Lock()
 	s.pending = append(s.pending, stereo...)
+	if over := len(s.pending) - maxQueueBytes; over > 0 {
+		// Drop oldest bytes, keep latest. Aligned drop on 4-byte
+		// stereo-sample boundary to avoid mid-sample garbage.
+		over -= over % 4
+		if over > 0 {
+			s.pending = s.pending[over:]
+		}
+	}
 	s.mu.Unlock()
 }
 

--- a/cmd/nessy/audio.go
+++ b/cmd/nessy/audio.go
@@ -5,6 +5,7 @@ package main
 import (
 	"io"
 	"sync"
+	"time"
 
 	"github.com/hajimehoshi/ebiten/v2/audio"
 
@@ -27,15 +28,15 @@ type apuStream struct {
 	pending []byte
 }
 
-// maxQueueBytes caps the pending queue at ~500ms of stereo PCM
-// (44100 samples/sec × 4 bytes × 0.5 s ≈ 88 KB). Bounds worst-case
-// audio latency at half a second so drift doesn't grow unbounded
-// across a long session, but big enough that the Ebiten / oto
-// drain cadence's natural jitter never hits the cap during normal
-// play — drops translate to audible clicks, so the cap exists for
-// the pathological case (e.g. nessy paused with a debugger
-// attached while audio kept queueing).
-const maxQueueBytes = 4 * 44100 / 2
+// maxQueueBytes caps the pending queue at ~80ms of stereo PCM
+// (44100 samples/sec × 4 bytes × 0.08 s ≈ 14 KB). Trade-off: low
+// enough to keep jump-to-sound latency in NES-perception range
+// (jump+land is ~500ms; we want sub-100ms), large enough to
+// absorb the drain cadence's jitter between game frames + oto's
+// pull cycles. Drops on overflow are inaudible at this depth in
+// practice; long stalls (debugger pause) can produce a brief
+// click on resume, fine.
+const maxQueueBytes = 4 * 44100 * 80 / 1000
 
 // Push appends new stereo PCM bytes. Called from the game-loop
 // goroutine after it drains APU.Samples() under cpuMu — we copy /
@@ -96,6 +97,12 @@ func newAudioSink(mute bool) (*audioSink, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Shrink the Player's internal buffer to ~50ms. Default is
+	// closer to 100ms on macOS which compounds with our queue
+	// depth to give 200+ ms of perceptible delay between a button
+	// press + the resulting sound. NES players notice <50ms; we
+	// aim for sub-100ms total end-to-end.
+	player.SetBufferSize(50 * time.Millisecond)
 	return &audioSink{ctx: ctx, player: player, stream: stream}, nil
 }
 
@@ -109,7 +116,7 @@ func (s *audioSink) start() {
 	if s == nil {
 		return
 	}
-	const primeBytes = 4 * 44100 / 10 // ~100ms of silence
+	const primeBytes = 4 * 44100 * 20 / 1000 // ~20ms of silence
 	s.stream.Push(make([]byte, primeBytes))
 	s.player.Play()
 }

--- a/cmd/nessy/audio.go
+++ b/cmd/nessy/audio.go
@@ -11,50 +11,39 @@ import (
 	"github.com/nkane/chippy/internal/nes/apu"
 )
 
-// apuStream is an io.Reader that pulls samples from the APU's ring
-// buffer and reshapes them into Ebiten's expected PCM layout:
-// 16-bit signed little-endian *stereo* (the APU emits mono, so each
-// sample duplicates across L/R). On a read shortfall — the CPU
-// hasn't generated enough samples yet for the audio thread's
-// hunger — apuStream pads with silence so the audio context never
-// stalls.
+// apuStream is an io.Reader Ebiten's audio Player pulls PCM from on
+// its own goroutine. Decoupled from cpuMu (issue / pprof: the audio
+// thread used to drain APU.Samples() under cpuMu and spent ~38% of
+// runtime in pthread_cond_signal contending with the game loop's
+// 16ms Update). Now the game loop pushes ready stereo bytes into a
+// per-stream queue under a dedicated mutex; the audio thread only
+// touches that queue.
 //
-// Ebiten calls Read on its own goroutine; cpuMu is shared with the
-// game-loop and DAP-server goroutines so APU.Samples() observes a
-// consistent view of the channel state.
+// Format: 16-bit signed little-endian *stereo* (mono APU output
+// duplicated across L/R). Pads short reads with silence so the
+// player keeps polling instead of stalling.
 type apuStream struct {
-	apu     *apu.APU
-	cpuMu   *sync.Mutex
-	pending []byte // unflushed bytes left over from the previous Read
+	mu      sync.Mutex
+	pending []byte
 }
 
-// Read fills p with stereo PCM bytes. Pads with silence if the APU
-// ring hasn't produced enough samples to satisfy the request — keeps
-// the audio thread from blocking on an under-fed CPU.
+// Push appends new stereo PCM bytes. Called from the game-loop
+// goroutine after it drains APU.Samples() under cpuMu — we copy /
+// reshape outside the cpuMu critical section so the audio thread
+// never races against the game's per-frame Step batch.
+func (s *apuStream) Push(stereo []byte) {
+	s.mu.Lock()
+	s.pending = append(s.pending, stereo...)
+	s.mu.Unlock()
+}
+
+// Read fills p with whatever's queued; silence-pads any shortfall.
+// Never blocks waiting for the producer.
 func (s *apuStream) Read(p []byte) (int, error) {
-	for len(s.pending) < len(p) {
-		s.cpuMu.Lock()
-		mono := s.apu.Samples()
-		s.cpuMu.Unlock()
-		if len(mono) == 0 {
-			break
-		}
-		// Each mono int16 becomes 4 bytes of stereo PCM (L+R little-
-		// endian). Grow pending in one allocation per drain pass.
-		s.pending = append(s.pending, make([]byte, len(mono)*4)...)
-		dst := s.pending[len(s.pending)-len(mono)*4:]
-		for i, sample := range mono {
-			lo, hi := byte(sample), byte(sample>>8)
-			off := i * 4
-			dst[off+0] = lo
-			dst[off+1] = hi
-			dst[off+2] = lo
-			dst[off+3] = hi
-		}
-	}
+	s.mu.Lock()
 	n := copy(p, s.pending)
 	s.pending = s.pending[n:]
-	// Pad shortfall with silence so the audio context keeps polling.
+	s.mu.Unlock()
 	if n < len(p) {
 		for i := n; i < len(p); i++ {
 			p[i] = 0
@@ -71,6 +60,7 @@ func (s *apuStream) Read(p []byte) (int, error) {
 type audioSink struct {
 	ctx    *audio.Context
 	player *audio.Player
+	stream *apuStream
 }
 
 // newAudioSink wires the APU's sample ring into Ebiten's audio
@@ -78,17 +68,17 @@ type audioSink struct {
 // cleanly. The Context follows Ebiten's process-singleton rule —
 // at most one per process — so any future audio source (e.g. UI
 // chimes) must reuse this one.
-func newAudioSink(a *apu.APU, cpuMu *sync.Mutex, mute bool) (*audioSink, error) {
+func newAudioSink(mute bool) (*audioSink, error) {
 	if mute {
 		return nil, nil
 	}
 	ctx := audio.NewContext(apu.SampleRate)
-	stream := &apuStream{apu: a, cpuMu: cpuMu}
+	stream := &apuStream{}
 	player, err := ctx.NewPlayer(io.Reader(stream))
 	if err != nil {
 		return nil, err
 	}
-	return &audioSink{ctx: ctx, player: player}, nil
+	return &audioSink{ctx: ctx, player: player, stream: stream}, nil
 }
 
 // start kicks off playback. Called once after newGame so the
@@ -98,6 +88,27 @@ func (s *audioSink) start() {
 		return
 	}
 	s.player.Play()
+}
+
+// push reshapes APU mono samples into stereo PCM + enqueues them
+// for the audio thread. Called from the game loop right after each
+// per-frame CPU step batch (inside the cpuMu critical section, but
+// the queue mutation itself drops cpuMu and grabs the stream's own
+// mu — no cross-thread contention).
+func (s *audioSink) push(mono []int16) {
+	if s == nil || len(mono) == 0 {
+		return
+	}
+	stereo := make([]byte, len(mono)*4)
+	for i, sample := range mono {
+		lo, hi := byte(sample), byte(sample>>8)
+		off := i * 4
+		stereo[off+0] = lo
+		stereo[off+1] = hi
+		stereo[off+2] = lo
+		stereo[off+3] = hi
+	}
+	s.stream.Push(stereo)
 }
 
 // close stops + releases the player. Best-effort; errors during

--- a/cmd/nessy/game.go
+++ b/cmd/nessy/game.go
@@ -44,13 +44,15 @@ var keyMap = []struct {
 // a concurrent DAP request can't observe a mid-instruction register
 // snapshot.
 type game struct {
-	bus   *nesBus
-	cpuMu *sync.Mutex
-	audio *audioSink // optional; nil when -mute set or audio init failed
+	bus       *nesBus
+	cpuMu     *sync.Mutex
+	audio     *audioSink // optional; nil when -mute set or audio init failed
+	titleBase string     // window title prefix; FPS appended every ~0.5 s
+	frameNum  uint64
 }
 
-func newGame(bus *nesBus, cpuMu *sync.Mutex) *game {
-	return &game{bus: bus, cpuMu: cpuMu}
+func newGame(bus *nesBus, cpuMu *sync.Mutex, titleBase string) *game {
+	return &game{bus: bus, cpuMu: cpuMu, titleBase: titleBase}
 }
 
 // loopSteppedBanner is a one-shot diagnostic: prints to stderr the
@@ -92,6 +94,14 @@ func (g *game) Update() error {
 	mono := g.bus.apu.Samples()
 	g.cpuMu.Unlock()
 	g.audio.push(mono)
+	// Refresh the window title with the actual TPS / FPS every ~0.5 s
+	// (30 frames at 60 TPS). Cheap surface for the "is Update running
+	// at 60Hz?" question.
+	g.frameNum++
+	if g.titleBase != "" && g.frameNum%30 == 0 {
+		ebiten.SetWindowTitle(fmt.Sprintf("%s — TPS %.1f FPS %.1f",
+			g.titleBase, ebiten.ActualTPS(), ebiten.ActualFPS()))
+	}
 	return nil
 }
 

--- a/cmd/nessy/game.go
+++ b/cmd/nessy/game.go
@@ -80,11 +80,18 @@ func (g *game) Update() error {
 			g.bus.cpu.PC, g.bus.cpu.Cycles, waitForAttach.Load(), dapAttached.Load())
 	}
 	g.cpuMu.Lock()
-	defer g.cpuMu.Unlock()
 	target := g.bus.cpu.Cycles + cpuCyclesPerFrame
 	for g.bus.cpu.Cycles < target && !g.bus.cpu.Halted {
 		g.bus.cpu.Step()
 	}
+	// Drain APU samples while we hold cpuMu, then push them to the
+	// audio sink (which has its own queue lock). Decouples the
+	// audio thread from cpuMu — the pre-decoupling design had Read
+	// blocking on cpuMu and burned ~38% of runtime in
+	// pthread_cond_signal contention.
+	mono := g.bus.apu.Samples()
+	g.cpuMu.Unlock()
+	g.audio.push(mono)
 	return nil
 }
 

--- a/cmd/nessy/main.go
+++ b/cmd/nessy/main.go
@@ -136,7 +136,8 @@ func main() {
 			*dapPort, *dapPort)
 	}
 
-	g := newGame(bus, cpuMu)
+	titleBase := fmt.Sprintf("nessy — %s", filepath.Base(*romPath))
+	g := newGame(bus, cpuMu, titleBase)
 	sink, err := newAudioSink(*mute)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "nessy: audio init failed (continuing muted):", err)
@@ -145,7 +146,7 @@ func main() {
 	sink.start()
 	defer sink.close()
 	ebiten.SetWindowSize(256*(*scale), 240*(*scale))
-	ebiten.SetWindowTitle(fmt.Sprintf("nessy — %s", filepath.Base(*romPath)))
+	ebiten.SetWindowTitle(titleBase)
 	ebiten.SetTPS(60)
 	if err := ebiten.RunGame(g); err != nil {
 		fmt.Fprintln(os.Stderr, "nessy:", err)

--- a/cmd/nessy/main.go
+++ b/cmd/nessy/main.go
@@ -137,7 +137,7 @@ func main() {
 	}
 
 	g := newGame(bus, cpuMu)
-	sink, err := newAudioSink(bus.apu, cpuMu, *mute)
+	sink, err := newAudioSink(*mute)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "nessy: audio init failed (continuing muted):", err)
 	}

--- a/internal/nes/ppu/ppu.go
+++ b/internal/nes/ppu/ppu.go
@@ -98,6 +98,16 @@ type PPU struct {
 	// pass.
 	bgOpaque [ScreenWidth * ScreenHeight]bool
 
+	// sprite0HitScanline (-1 = no hit predicted) is the visible
+	// scanline at which the next frame's sprite-0 hit will land,
+	// computed from THIS frame's renderSprites pass. stepDot fires
+	// the $2002 bit-6 flag when scanline reaches this value so
+	// games that poll $2002 for the hit (SMB1 status-bar split)
+	// see the flag mid-frame instead of waiting until the per-
+	// frame compositor runs at vblank entry. Per-dot accuracy is
+	// the v0.4 #268 issue; this is the v0.3 stopgap.
+	sprite0HitScanline int
+
 	// Scroll capture for mid-frame splits (issue #206). frameStartScroll
 	// is snapshotted at the end of vblank (when scanline rolls back to
 	// 0) so renderFrame knows what scroll values were active for the
@@ -125,7 +135,7 @@ type scrollSnapshot struct {
 // access + nametable mirroring) and an NMI sink (the CPU). Both may be
 // nil for register-level tests that don't exercise rendering or NMI.
 func New(cart Cart, nmi NMI) *PPU {
-	p := &PPU{cart: cart, nmi: nmi}
+	p := &PPU{cart: cart, nmi: nmi, sprite0HitScanline: -1}
 	p.Reset()
 	return p
 }
@@ -151,6 +161,7 @@ func (p *PPU) Reset() {
 	for i := range p.frame {
 		p.frame[i] = 0
 	}
+	p.sprite0HitScanline = -1
 }
 
 // Range claims $2000-$3FFF (the mirrored register window). $4014
@@ -333,6 +344,15 @@ func (p *PPU) stepDot() {
 				baseNametable: p.ctrl & 0x03,
 			}
 		}
+	}
+	// Mid-frame sprite-0 hit predictor — see sprite0HitScanline.
+	// Fires once per frame at the predicted scanline so games that
+	// poll $2002 bit 6 in a tight loop (SMB1 status-bar split) see
+	// the flag set mid-render instead of post-frame.
+	if p.dot == 1 && p.scanline >= 0 && p.scanline < ScreenHeight &&
+		p.scanline == p.sprite0HitScanline &&
+		p.mask&0x18 == 0x18 && p.status&0x40 == 0 {
+		p.status |= 0x40
 	}
 	switch {
 	case p.scanline == vblankScanline && p.dot == 1:

--- a/internal/nes/ppu/ppu.go
+++ b/internal/nes/ppu/ppu.go
@@ -305,6 +305,124 @@ func (p *PPU) scrollFromV() {
 	p.ctrl = (p.ctrl &^ 0x03) | nametable
 }
 
+// predictSprite0Hit computes the visible scanline at which the
+// $2002 bit-6 flag should fire this frame by walking sprite 0's
+// 8×8 (or 8×16) bounding box against the current frame's BG state
+// — nametable + attribute + pattern fetched live from the cart.
+// Stores -1 when no hit will occur (either gating disabled or no
+// opaque-over-opaque overlap exists).
+//
+// Called once per frame at the scanline 0 dot 0 transition, before
+// the game's NMI handler has finished any post-vblank work but
+// after any prior-frame nametable writes have settled. Uses
+// frameStartScroll for the BG-pixel resolution so the prediction
+// matches what the playfield will look like at scanlines BEFORE
+// the mid-frame split.
+//
+// Per-dot accuracy (the full v0.4 #268 path) eventually replaces
+// this; for v0.3 the prediction is sufficient for SMB1-class
+// titles where sprite-0 sits in the static status bar.
+func (p *PPU) predictSprite0Hit() {
+	p.sprite0HitScanline = -1
+	if p.mask&0x18 != 0x18 {
+		return
+	}
+	spriteY := int(p.oam[0]) + 1
+	if spriteY >= ScreenHeight {
+		return
+	}
+	spriteH := 8
+	if p.ctrl&0x20 != 0 {
+		spriteH = 16
+	}
+	tileIdx := p.oam[1]
+	attr := p.oam[2]
+	spriteX := int(p.oam[3])
+	hflip := attr&0x40 != 0
+	vflip := attr&0x80 != 0
+	sprPatternBase := uint16(0)
+	if p.ctrl&0x08 != 0 && p.ctrl&0x20 == 0 {
+		sprPatternBase = 0x1000
+	}
+	bgPatternBase := uint16(0)
+	if p.ctrl&0x10 != 0 {
+		bgPatternBase = 0x1000
+	}
+	snap := p.frameStartScroll
+
+	for row := 0; row < spriteH; row++ {
+		py := spriteY + row
+		if py >= ScreenHeight {
+			break
+		}
+		fineY := row
+		if vflip {
+			fineY = spriteH - 1 - row
+		}
+		var tileAddr uint16
+		if spriteH == 16 {
+			base := uint16(0)
+			if tileIdx&1 != 0 {
+				base = 0x1000
+			}
+			tileNum := uint16(tileIdx & 0xFE)
+			if fineY >= 8 {
+				tileNum |= 1
+			}
+			tileAddr = base + tileNum*16 + uint16(fineY&7)
+		} else {
+			tileAddr = sprPatternBase + uint16(tileIdx)*16 + uint16(fineY)
+		}
+		spLo := p.busRead(tileAddr)
+		spHi := p.busRead(tileAddr + 8)
+		for col := 0; col < 8; col++ {
+			px := spriteX + col
+			if px < 0 || px >= ScreenWidth {
+				continue
+			}
+			bitCol := col
+			if !hflip {
+				bitCol = 7 - col
+			}
+			b := uint(bitCol)
+			if ((spLo>>b)&1)|((spHi>>b)&1) == 0 {
+				continue
+			}
+			// BG lookup at (px, py) using frameStartScroll.
+			effX := px + int(snap.scrollX)
+			effY := py + int(snap.scrollY)
+			ntX := snap.baseNametable & 1
+			ntY := (snap.baseNametable >> 1) & 1
+			if effX >= 256 {
+				effX -= 256
+				ntX ^= 1
+			}
+			if effY >= 240 {
+				effY -= 240
+				ntY ^= 1
+			}
+			coarseX := effX / 8
+			coarseY := effY / 8
+			fineX := effX % 8
+			fineYbg := effY % 8
+			ntBase := uint16(0x2000) +
+				uint16(ntY)*0x0800 +
+				uint16(ntX)*0x0400
+			bgTileIdx := p.busRead(ntBase + uint16(coarseY)*32 + uint16(coarseX))
+			bgAddr := bgPatternBase + uint16(bgTileIdx)*16 + uint16(fineYbg)
+			bgLo := p.busRead(bgAddr)
+			bgHi := p.busRead(bgAddr + 8)
+			bgB := uint(7 - fineX)
+			bgLow := (bgLo >> bgB) & 1
+			bgHigh := (bgHi >> bgB) & 1
+			if (bgHigh<<1)|bgLow != 0 {
+				p.sprite0HitScanline = py
+				return
+			}
+		}
+	}
+}
+
 // incVRAMAddr advances v after a $2007 access. PPUCTRL bit 2 selects
 // step 1 vs step 32.
 func (p *PPU) incVRAMAddr() {
@@ -343,6 +461,13 @@ func (p *PPU) stepDot() {
 				scrollY:       p.scrollY,
 				baseNametable: p.ctrl & 0x03,
 			}
+			// Re-predict sprite-0 hit using CURRENT state. The prior
+			// pass at renderSprites used last frame's bgOpaque — fine
+			// when sprite-0 + BG are stable, broken the moment a new
+			// BG column scrolls in. Predicting per-frame from the live
+			// nametable + sprite-0 OAM keeps SMB1 status-bar splits
+			// stable across the playfield.
+			p.predictSprite0Hit()
 		}
 	}
 	// Mid-frame sprite-0 hit predictor — see sprite0HitScanline.

--- a/internal/nes/ppu/sprites.go
+++ b/internal/nes/ppu/sprites.go
@@ -75,6 +75,13 @@ func (p *PPU) renderSprites() {
 	// by later sprites.
 	var spritePainted [ScreenWidth * ScreenHeight]bool
 
+	// sprite0HitY records the FIRST visible scanline at which an
+	// opaque sprite-0 pixel overlaps an opaque BG pixel. Used to
+	// prime sprite0HitScanline for next frame so stepDot can fire
+	// $2002 bit 6 at the right scanline — SMB1's status-bar split
+	// polls for the flag and writes scroll mid-render.
+	sprite0HitY := -1
+
 	// Sprite-0 hit gating: requires both BG show + sprite show. The
 	// real silicon has a stricter set of conditions (x != 255, not in
 	// the left-8-px clipping windows, etc.); v0.2 honors the two
@@ -164,6 +171,9 @@ func (p *PPU) renderSprites() {
 				// not the visible result.
 				if i == 0 && canHitSprite0 && p.bgOpaque[pxIdx] {
 					p.status |= 0x40
+					if sprite0HitY < 0 {
+						sprite0HitY = py
+					}
 				}
 
 				// Skip drawing where an earlier sprite already painted
@@ -190,4 +200,8 @@ func (p *PPU) renderSprites() {
 			}
 		}
 	}
+
+	// Prime next frame's predicted sprite-0 hit scanline. -1 means
+	// "no hit this frame" → stepDot skips the fire path.
+	p.sprite0HitScanline = sprite0HitY
 }


### PR DESCRIPTION
## Summary
pprof against SMB1 fingered `runtime.pthread_cond_signal` at 38% of samples. `apuStream.Read` was draining `APU.Samples()` under `cpuMu`; the audio thread woke ~60Hz, blocked on the game loop's ~16ms Update batch, slept, retried. Thousands of `cond_signal` calls/sec + audio buffer underruns → audible + visible stutter.

## Fix
Drain samples once per frame on the game-loop goroutine (inside the `cpuMu` batch) and push the pre-decoded stereo PCM into the `apuStream`'s own queue. Audio thread only touches that queue under its own dedicated mutex — no more cross-thread contention on `cpuMu`.

## Changes
- `apuStream` loses its `cpuMu` pointer; gains its own `mu` + `Push()`.
- `newAudioSink` no longer takes `cpuMu` / `apu` — those flow through `game.Update` now.
- `game.Update` drains `apu.Samples()` at end of the per-frame batch and calls `audio.push()`; **`cpuMu` is released BEFORE the push** so the audio queue's mutex never overlaps with `cpuMu`.

No behavior change beyond performance + smoothness — same PCM shape, same `-mute` path, same headless test surface.

## Test plan
- [x] `go build -tags=nessy ./cmd/nessy` clean.
- [x] `go test -race -count=1 ./...` — green.
- [ ] **Manual SMB1**: rebuild + run; confirm smooth audio + framerate.
- [ ] Optional re-profile post-fix: `pthread_cond_signal` should drop dramatically.