### PR TITLE
feat(ppu): #268 stage 2 — per-scanline BG render via stepDot

### DIFF
--- a/internal/nes/ppu/ppu.go
+++ b/internal/nes/ppu/ppu.go
@@ -621,6 +621,13 @@ func (p *PPU) stepDot() {
 	if p.dot == 1 && p.scanline >= 0 && p.scanline < ScreenHeight {
 		p.checkSprite0HitForScanline(p.scanline)
 	}
+	// Per-scanline BG render (issue #268). Each visible scanline
+	// rasterizes at dot 256 (end of the visible portion of that
+	// scanline) so subsequent $2005 / $2006 writes from the game's
+	// poll loop reach the NEXT scanline's scroll snapshot.
+	if p.dot == 256 && p.scanline >= 0 && p.scanline < ScreenHeight {
+		p.renderScanlineEnabled(p.scanline)
+	}
 	switch {
 	case p.scanline == vblankScanline && p.dot == 1:
 		// Render the visible frame using state captured at vblank

--- a/internal/nes/ppu/render.go
+++ b/internal/nes/ppu/render.go
@@ -26,43 +26,45 @@ package ppu
 // sufficient for SMB1-class games — see the issue's "out of scope"
 // notes.
 func (p *PPU) renderFrame() {
-	// Reset bgOpaque before drawing. renderSprites reads it and every
-	// frame starts from a clean slate.
-	for i := range p.bgOpaque {
-		p.bgOpaque[i] = false
+	// BG layer is primarily drawn per-scanline by stepDot at dot
+	// 256 of each visible scanline (issue #268). renderFrame still
+	// walks the whole frame here as a fallback for tests that call
+	// it directly + as a safety net in case stepDot hasn't fired
+	// for some scanlines (the per-scanline call is idempotent so
+	// the redundant render at vblank doesn't change pixels). Also
+	// flushes the per-frame scrollEvents log.
+	for y := range ScreenHeight {
+		p.renderScanlineEnabled(y)
+	}
+	p.scrollEvents = p.scrollEvents[:0]
+}
+
+// renderScanlineEnabled is the per-scanline entry point called from
+// stepDot at dot 256 of each visible scanline. Handles the BG-show
+// gate (PPUMASK bit 3) — when off, fills a single row with the
+// universal background color; when on, defers to renderScanline.
+// Also resets bgOpaque at scanline 0 so the sprite compositor (still
+// per-frame at vblank entry, for now) sees a clean mask.
+func (p *PPU) renderScanlineEnabled(y int) {
+	if y == 0 {
+		for i := range p.bgOpaque {
+			p.bgOpaque[i] = false
+		}
 	}
 	if p.mask&0x08 == 0 {
-		// PPUMASK bit 3 = "show background". When off the screen is
-		// the universal background color and bgOpaque stays
-		// all-false so sprites win every composite.
 		r, g, b := paletteRGB(p.palette[0])
-		for i := 0; i < len(p.frame); i += 4 {
-			p.frame[i+0] = r
-			p.frame[i+1] = g
-			p.frame[i+2] = b
-			p.frame[i+3] = 0xFF
+		rowBase := y * ScreenWidth * 4
+		for x := 0; x < ScreenWidth; x++ {
+			off := rowBase + x*4
+			p.frame[off+0] = r
+			p.frame[off+1] = g
+			p.frame[off+2] = b
+			p.frame[off+3] = 0xFF
 		}
-		p.scrollEvents = p.scrollEvents[:0]
 		return
 	}
-
-	// Walk scanlines, advancing the events cursor as we cross each
-	// snapshot's scanline. Activity below the snapshot's scanline
-	// renders with the *previous* snapshot — events are inclusive at
-	// the snapshot's scanline (e.g. a write at scanline 32 applies
-	// from row 32 down).
-	active := p.frameStartScroll
-	eventIdx := 0
-	for y := range ScreenHeight {
-		for eventIdx < len(p.scrollEvents) && p.scrollEvents[eventIdx].scanline <= y {
-			active = p.scrollEvents[eventIdx]
-			eventIdx++
-		}
-		p.renderScanline(y, active)
-	}
-	// Done consuming this frame's events. Next frame starts with a
-	// clean log + a fresh frameStartScroll captured by stepDot.
-	p.scrollEvents = p.scrollEvents[:0]
+	snap := p.activeScrollFor(y)
+	p.renderScanline(y, snap)
 }
 
 // renderScanline rasterizes one row using the supplied snapshot's


### PR DESCRIPTION
## Summary
Stage 2 of #268. Moves BG rasterization out of the vblank-entry per-frame loop into the stepDot path. At dot 256 of each visible scanline, `renderScanlineEnabled(y)` fires — gates on PPUMASK bit 3, defers to `renderScanline`.

Combined with stage 1's per-scanline sprite-0 hit detector, SMB1's `$2005` / `$2006` writes that the game emits in response to the sprite-0 hit now reach the NEXT scanline's scroll snapshot. Scrolls apply at the actual scanline the game intended — not the post-frame snapshot v0.2 captured.

`renderFrame` stays as a fallback that walks every scanline (tests call it directly + safety net for any scanlines stepDot misses). `renderScanlineEnabled` is idempotent within a frame.

## Test plan
- [x] `go test -race -count=1 ./...`
- [x] `golangci-lint run ./...`
- [x] `go test -tags=nestest -run TestNestest ./cmd/nessy/...`
- [x] `go test -tags=perfgate -run TestPerfGate ./internal/cpu/...`

Refs #268.