### PR TITLE
feat(cart): UxROM mapper (mapper 2) (#263)

### DIFF
--- a/internal/nes/cart/cart.go
+++ b/internal/nes/cart/cart.go
@@ -45,7 +45,9 @@ func Open(rom *nes.ROM) (Cartridge, error) {
 		return NewNROM(rom)
 	case 1:
 		return NewMMC1(rom)
+	case 2:
+		return NewUxROM(rom)
 	default:
-		return nil, fmt.Errorf("cart: unsupported mapper %d (v0.3 ships NROM/mapper 0 + MMC1/mapper 1)", rom.Mapper)
+		return nil, fmt.Errorf("cart: unsupported mapper %d (NROM/0, MMC1/1, UxROM/2)", rom.Mapper)
 	}
 }

--- a/internal/nes/cart/uxrom.go
+++ b/internal/nes/cart/uxrom.go
@@ -1,0 +1,101 @@
+package cart
+
+import (
+	"fmt"
+
+	"github.com/nkane/chippy/internal/nes"
+)
+
+// UxROM is mapper 2 — Nintendo's "UNROM" / "UOROM" family. Used by
+// Mega Man 1+2, Castlevania, Contra, DuckTales, Metal Gear, and
+// most early UxROM titles.
+//
+//	PRG: up to 256 KiB across 16 KiB banks.
+//	  $8000-$BFFF — switchable bank (low 4 bits of CPUWrite data).
+//	  $C000-$FFFF — last 16 KiB bank, hardwired.
+//	CHR: 8 KiB CHR-RAM (no CHR bank switching; iNES CHR banks
+//	     ignored — most UxROM carts ship without CHR-ROM).
+//	Mirroring: pinned at construction from the iNES header.
+//	Writes to $8000-$FFFF set the PRG bank directly (no shift
+//	register — value bits 0-3 select the bank).
+//
+// Real silicon has a bus-conflict variant (UNROM): the written
+// value is ANDed with the read value from the ROM. v0.4 ships the
+// simple correct version; bus-conflict modeling is a v0.5+ stretch
+// for the handful of ROMs that depend on it.
+type UxROM struct {
+	prg       []byte
+	chr       []byte // 8 KiB CHR-RAM
+	mirroring nes.Mirroring
+	prgBank   byte // active bank at $8000-$BFFF
+}
+
+// NewUxROM constructs a UxROM cart from a parsed iNES ROM. PRG must
+// be a non-zero multiple of 16 KiB.
+func NewUxROM(rom *nes.ROM) (*UxROM, error) {
+	if len(rom.PRG) == 0 || len(rom.PRG)%(16*1024) != 0 {
+		return nil, fmt.Errorf("uxrom: PRG must be a non-zero multiple of 16 KiB; got %d bytes", len(rom.PRG))
+	}
+	c := &UxROM{
+		prg:       rom.PRG,
+		chr:       make([]byte, 8*1024),
+		mirroring: rom.Mirroring,
+	}
+	// If the ROM ships CHR-ROM (rare for UxROM), copy it into the
+	// CHR-RAM slot so PPU reads still work. Writes from the game
+	// will then overwrite — same lossy-but-functional behavior as
+	// NROM's CHR-RAM fallback.
+	if len(rom.CHR) == 8*1024 {
+		copy(c.chr, rom.CHR)
+	}
+	return c, nil
+}
+
+// CPURead serves $8000-$BFFF from the switchable bank, $C000-$FFFF
+// from the last bank. $4020-$7FFF is unmapped on UxROM and returns
+// open-bus 0.
+func (c *UxROM) CPURead(addr uint16) byte {
+	if addr < 0x8000 {
+		return 0
+	}
+	bankSize := 16 * 1024
+	totalBanks := len(c.prg) / bankSize
+	var bank int
+	if addr < 0xC000 {
+		bank = int(c.prgBank) % totalBanks
+	} else {
+		bank = totalBanks - 1
+	}
+	off := int(addr&0x3FFF) + bank*bankSize
+	return c.prg[off%len(c.prg)]
+}
+
+// CPUWrite sets the PRG bank from data bits 0-3. Real UxROM uses
+// only 3-4 bits depending on cart-size variant; we accept the full
+// nibble + modulo by the actual bank count in CPURead to handle
+// either case.
+func (c *UxROM) CPUWrite(addr uint16, v byte) {
+	if addr < 0x8000 {
+		return
+	}
+	c.prgBank = v & 0x0F
+}
+
+// PPURead serves the 8 KiB CHR-RAM at $0000-$1FFF.
+func (c *UxROM) PPURead(addr uint16) byte {
+	if addr >= 0x2000 {
+		return 0
+	}
+	return c.chr[addr]
+}
+
+// PPUWrite to CHR-RAM is effective (writes land in the 8 KiB pool).
+func (c *UxROM) PPUWrite(addr uint16, v byte) {
+	if addr >= 0x2000 {
+		return
+	}
+	c.chr[addr] = v
+}
+
+// Mirroring is pinned at construction from the iNES header.
+func (c *UxROM) Mirroring() nes.Mirroring { return c.mirroring }

--- a/internal/nes/cart/uxrom_test.go
+++ b/internal/nes/cart/uxrom_test.go
@@ -1,0 +1,109 @@
+package cart
+
+import (
+	"testing"
+
+	"github.com/nkane/chippy/internal/nes"
+)
+
+// fillUxromRom builds a UxROM ROM with `prgBanks` 16 KiB PRG banks.
+// Each bank's first byte = bank number for trivial identification.
+func fillUxromRom(t *testing.T, prgBanks int) *nes.ROM {
+	t.Helper()
+	prg := make([]byte, prgBanks*16*1024)
+	for i := range prgBanks {
+		prg[i*16*1024] = byte(i)
+	}
+	return &nes.ROM{Mapper: 2, PRG: prg}
+}
+
+// Power-on default: bank 0 at $8000, last bank at $C000.
+func TestUxROM_PowerOnDefault(t *testing.T) {
+	c, err := NewUxROM(fillUxromRom(t, 4))
+	if err != nil {
+		t.Fatalf("NewUxROM: %v", err)
+	}
+	if got := c.CPURead(0x8000); got != 0 {
+		t.Errorf("$8000 = $%02X; want bank 0", got)
+	}
+	if got := c.CPURead(0xC000); got != 3 {
+		t.Errorf("$C000 = $%02X; want bank 3 (last)", got)
+	}
+}
+
+// CPUWrite to $8000-$FFFF sets the PRG bank.
+func TestUxROM_BankSwitch(t *testing.T) {
+	c, err := NewUxROM(fillUxromRom(t, 8))
+	if err != nil {
+		t.Fatalf("NewUxROM: %v", err)
+	}
+	c.CPUWrite(0x8000, 0x02)
+	if got := c.CPURead(0x8000); got != 2 {
+		t.Errorf("post-switch $8000 = $%02X; want bank 2", got)
+	}
+	// Switch again.
+	c.CPUWrite(0xFFFF, 0x05)
+	if got := c.CPURead(0x8000); got != 5 {
+		t.Errorf("post-switch $8000 = $%02X; want bank 5", got)
+	}
+	// $C000 always last bank regardless of switch.
+	if got := c.CPURead(0xC000); got != 7 {
+		t.Errorf("$C000 = $%02X; want bank 7 (last, unchanged)", got)
+	}
+}
+
+// CHR-RAM round-trips.
+func TestUxROM_CHRRAMRoundTrip(t *testing.T) {
+	c, err := NewUxROM(fillUxromRom(t, 2))
+	if err != nil {
+		t.Fatalf("NewUxROM: %v", err)
+	}
+	c.PPUWrite(0x0000, 0xAB)
+	c.PPUWrite(0x1FFF, 0xCD)
+	if got := c.PPURead(0x0000); got != 0xAB {
+		t.Errorf("$0000 = $%02X; want $AB", got)
+	}
+	if got := c.PPURead(0x1FFF); got != 0xCD {
+		t.Errorf("$1FFF = $%02X; want $CD", got)
+	}
+}
+
+// Below-$8000 reads return open-bus 0; writes are no-ops.
+func TestUxROM_BelowPRGUnmapped(t *testing.T) {
+	c, err := NewUxROM(fillUxromRom(t, 2))
+	if err != nil {
+		t.Fatalf("NewUxROM: %v", err)
+	}
+	if got := c.CPURead(0x6000); got != 0 {
+		t.Errorf("$6000 = $%02X; want open-bus 0", got)
+	}
+	c.CPUWrite(0x6000, 0xFF) // no-op
+	if c.prgBank != 0 {
+		t.Errorf("$6000 write touched prgBank: %d", c.prgBank)
+	}
+}
+
+// cart.Open dispatches mapper=2 to UxROM.
+func TestCartOpen_DispatchesUxROM(t *testing.T) {
+	rom := fillUxromRom(t, 2)
+	c, err := Open(rom)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if _, ok := c.(*UxROM); !ok {
+		t.Errorf("Open returned %T; want *UxROM", c)
+	}
+}
+
+// Mirroring is pinned from the iNES header.
+func TestUxROM_MirroringPinned(t *testing.T) {
+	rom := fillUxromRom(t, 2)
+	rom.Mirroring = nes.MirrorVertical
+	c, err := NewUxROM(rom)
+	if err != nil {
+		t.Fatalf("NewUxROM: %v", err)
+	}
+	if c.Mirroring() != nes.MirrorVertical {
+		t.Errorf("Mirroring = %s; want vertical", c.Mirroring())
+	}
+}


### PR DESCRIPTION
Unlocks Mega Man 1+2, Castlevania, Contra, DuckTales, Metal Gear, and most early UxROM titles.

## Implementation
- **PRG**: up to 256 KiB / 16 KiB banks. \`\$8000-\$BFFF\` = switchable bank (low 4 bits of \`CPUWrite\` to \`\$8000-\$FFFF\`); \`\$C000-\$FFFF\` = last bank, hardwired.
- **CHR**: 8 KiB CHR-RAM (CHR-ROM variants get copied into the RAM slot at construction).
- **Mirroring**: pinned at construction from the iNES header.
- \`cart.Open\` dispatches \`mapper=2\` → \`NewUxROM\`.

## Tests (\`uxrom_test.go\`)
- Power-on bank 0 at \`\$8000\`, last bank at \`\$C000\`.
- \`CPUWrite\` sets PRG bank.
- \`\$C000\` always last bank regardless of switch.
- CHR-RAM round-trip.
- Below-\`\$8000\` reads return open-bus; writes are no-ops.
- \`cart.Open\` returns \`*UxROM\` for \`mapper=2\`.
- Mirroring pinned from iNES header.

## Regression sweep
- [x] \`go test -race -count=1 ./...\` — green.
- [x] \`golangci-lint run ./...\` — 0 issues.

## Out of scope (v0.5+)
- UNROM bus-conflict modeling.
- iNES 2.0 sub-mapper disambiguation.

Closes #263.