### PR TITLE
feat(cart): CNROM mapper (mapper 3) (#264)

### DIFF
--- a/internal/nes/cart/cart.go
+++ b/internal/nes/cart/cart.go
@@ -47,7 +47,9 @@ func Open(rom *nes.ROM) (Cartridge, error) {
 		return NewMMC1(rom)
 	case 2:
 		return NewUxROM(rom)
+	case 3:
+		return NewCNROM(rom)
 	default:
-		return nil, fmt.Errorf("cart: unsupported mapper %d (NROM/0, MMC1/1, UxROM/2)", rom.Mapper)
+		return nil, fmt.Errorf("cart: unsupported mapper %d (NROM/0, MMC1/1, UxROM/2, CNROM/3)", rom.Mapper)
 	}
 }

--- a/internal/nes/cart/cnrom.go
+++ b/internal/nes/cart/cnrom.go
@@ -1,0 +1,97 @@
+package cart
+
+import (
+	"fmt"
+
+	"github.com/nkane/chippy/internal/nes"
+)
+
+// CNROM is mapper 3 — Nintendo's simplest CHR-switch family. Used by
+// Arkanoid, Bump'n'Jump, Cybernoid, and many early sport titles.
+//
+//	PRG: fixed 16 KiB or 32 KiB at $8000-$FFFF (same as NROM).
+//	CHR: 8 KiB switchable bank at PPU $0000-$1FFF; up to 2 MiB
+//	     across 256 banks (rare). Most CNROM ROMs ship 4 banks.
+//	Mirroring: pinned at construction from the iNES header.
+//	Writes to $8000-$FFFF set the CHR bank (low 2 bits typically;
+//	we accept the full byte and modulo by bank count).
+//
+// Real silicon has a CNROM-512 variant with bus-conflict behavior;
+// v0.4 ships the simple correct version.
+type CNROM struct {
+	prg       []byte
+	chr       []byte
+	chrIsRAM  bool
+	mirroring nes.Mirroring
+	chrBank   byte
+}
+
+// NewCNROM constructs a CNROM cart. PRG must be 16 or 32 KiB; CHR
+// must be a positive multiple of 8 KiB (CHR-RAM-only CNROM is rare
+// but allowed — same fallback as NROM).
+func NewCNROM(rom *nes.ROM) (*CNROM, error) {
+	switch len(rom.PRG) {
+	case 16 * 1024, 32 * 1024:
+	default:
+		return nil, fmt.Errorf("cnrom: PRG must be 16 or 32 KiB; got %d bytes", len(rom.PRG))
+	}
+	c := &CNROM{
+		prg:       rom.PRG,
+		mirroring: rom.Mirroring,
+	}
+	switch {
+	case len(rom.CHR) == 0:
+		c.chr = make([]byte, 8*1024)
+		c.chrIsRAM = true
+	case len(rom.CHR)%(8*1024) == 0:
+		c.chr = rom.CHR
+	default:
+		return nil, fmt.Errorf("cnrom: CHR must be 0 or a multiple of 8 KiB; got %d bytes", len(rom.CHR))
+	}
+	return c, nil
+}
+
+// CPURead serves $8000-$FFFF from PRG (NROM-style 16-KiB mirror or
+// flat 32-KiB). $4020-$7FFF returns open-bus 0.
+func (c *CNROM) CPURead(addr uint16) byte {
+	if addr < 0x8000 {
+		return 0
+	}
+	idx := int(addr-0x8000) % len(c.prg)
+	return c.prg[idx]
+}
+
+// CPUWrite to $8000-$FFFF sets the CHR bank. Real silicon honors
+// only the low 2 bits on most carts; the modulo in CPURead handles
+// the variable bank count.
+func (c *CNROM) CPUWrite(addr uint16, v byte) {
+	if addr < 0x8000 {
+		return
+	}
+	c.chrBank = v
+}
+
+// PPURead serves the active 8 KiB CHR bank at PPU $0000-$1FFF.
+func (c *CNROM) PPURead(addr uint16) byte {
+	if addr >= 0x2000 {
+		return 0
+	}
+	totalBanks := len(c.chr) / (8 * 1024)
+	if totalBanks == 0 {
+		totalBanks = 1
+	}
+	bank := int(c.chrBank) % totalBanks
+	return c.chr[bank*8*1024+int(addr)]
+}
+
+// PPUWrite is effective only when the cart shipped no CHR-ROM
+// (CHR-RAM fallback).
+func (c *CNROM) PPUWrite(addr uint16, v byte) {
+	if addr >= 0x2000 || !c.chrIsRAM {
+		return
+	}
+	c.chr[addr] = v
+}
+
+// Mirroring is pinned at construction.
+func (c *CNROM) Mirroring() nes.Mirroring { return c.mirroring }

--- a/internal/nes/cart/cnrom_test.go
+++ b/internal/nes/cart/cnrom_test.go
@@ -1,0 +1,96 @@
+package cart
+
+import (
+	"testing"
+
+	"github.com/nkane/chippy/internal/nes"
+)
+
+func fillCnromRom(t *testing.T, prgKB, chrBanks int) *nes.ROM {
+	t.Helper()
+	prg := make([]byte, prgKB*1024)
+	for i := range prg {
+		prg[i] = 0xEA // NOP filler
+	}
+	chr := make([]byte, chrBanks*8*1024)
+	for i := range chrBanks {
+		chr[i*8*1024] = byte(i)
+	}
+	return &nes.ROM{Mapper: 3, PRG: prg, CHR: chr}
+}
+
+// Power-on: CHR bank 0 active.
+func TestCNROM_PowerOnBank0(t *testing.T) {
+	c, err := NewCNROM(fillCnromRom(t, 16, 4))
+	if err != nil {
+		t.Fatalf("NewCNROM: %v", err)
+	}
+	if got := c.PPURead(0x0000); got != 0 {
+		t.Errorf("PPU $0000 = $%02X; want bank 0", got)
+	}
+}
+
+// CPUWrite to $8000-$FFFF switches the CHR bank.
+func TestCNROM_BankSwitch(t *testing.T) {
+	c, err := NewCNROM(fillCnromRom(t, 16, 4))
+	if err != nil {
+		t.Fatalf("NewCNROM: %v", err)
+	}
+	c.CPUWrite(0x8000, 0x02)
+	if got := c.PPURead(0x0000); got != 2 {
+		t.Errorf("post-switch PPU $0000 = $%02X; want bank 2", got)
+	}
+	c.CPUWrite(0xFFFF, 0x03)
+	if got := c.PPURead(0x0000); got != 3 {
+		t.Errorf("post-switch PPU $0000 = $%02X; want bank 3", got)
+	}
+}
+
+// PRG read independent of CHR bank.
+func TestCNROM_PRGUnaffectedByCHRSwitch(t *testing.T) {
+	c, err := NewCNROM(fillCnromRom(t, 32, 4))
+	if err != nil {
+		t.Fatalf("NewCNROM: %v", err)
+	}
+	c.CPUWrite(0x8000, 0x02) // change CHR
+	if got := c.CPURead(0x8000); got != 0xEA {
+		t.Errorf("PRG read after CHR switch = $%02X; want $EA", got)
+	}
+}
+
+// 16-KiB PRG mirrors at $C000.
+func TestCNROM_PRG16KMirror(t *testing.T) {
+	c, err := NewCNROM(fillCnromRom(t, 16, 1))
+	if err != nil {
+		t.Fatalf("NewCNROM: %v", err)
+	}
+	if c.CPURead(0x8000) != c.CPURead(0xC000) {
+		t.Errorf("16-KiB PRG should mirror $8000 ↔ $C000")
+	}
+}
+
+// CHR-RAM fallback when ROM ships no CHR.
+func TestCNROM_CHRRAMFallback(t *testing.T) {
+	rom := fillCnromRom(t, 16, 0)
+	rom.CHR = nil
+	c, err := NewCNROM(rom)
+	if err != nil {
+		t.Fatalf("NewCNROM: %v", err)
+	}
+	c.PPUWrite(0x0100, 0xAA)
+	if got := c.PPURead(0x0100); got != 0xAA {
+		t.Errorf("CHR-RAM round-trip failed: $%02X", got)
+	}
+}
+
+// cart.Open dispatches mapper=3 to CNROM.
+func TestCartOpen_DispatchesCNROM(t *testing.T) {
+	rom := fillCnromRom(t, 16, 1)
+	c, err := Open(rom)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	if _, ok := c.(*CNROM); !ok {
+		t.Errorf("Open returned %T; want *CNROM", c)
+	}
+}


### PR DESCRIPTION
Unlocks Arkanoid, Bump'n'Jump, Cybernoid, and many early sport titles.

## Implementation
- **PRG**: fixed 16 or 32 KiB at \`\$8000-\$FFFF\` (NROM-style mirror for 16-KiB carts).
- **CHR**: 8 KiB switchable bank at PPU \`\$0000-\$1FFF\` (up to 256 banks). CHR-RAM fallback when ROM ships no CHR.
- **Mirroring**: pinned from iNES header.
- \`CPUWrite\` to \`\$8000-\$FFFF\` sets the CHR bank.
- \`cart.Open\` dispatches \`mapper=3\` → \`NewCNROM\`.

## Tests
Power-on bank 0, bank switching, PRG independence, 16-KiB mirror, CHR-RAM fallback, factory dispatch.

## Regression sweep
- [x] \`go test -race -count=1 ./...\` green.
- [x] \`golangci-lint run ./...\` 0 issues.

## Out of scope
CNROM-512 bus-conflict modeling.

Closes #264.