### PR TITLE
feat(cart+nessy): battery-backed PRG-RAM persistence (#267)

### DIFF
--- a/cmd/nessy/battery.go
+++ b/cmd/nessy/battery.go
@@ -1,0 +1,92 @@
+//go:build nessy
+
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/nkane/chippy/internal/nes/cart"
+)
+
+// batteryDir is the resolved directory used for .sav files. Empty
+// when the host has no usable HOME — battery persistence
+// silently disabled.
+func batteryDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".nessy", "sav")
+}
+
+// savPath returns the .sav file path for a ROM, keyed by the
+// SHA-256 of the ROM bytes so renaming the ROM doesn't orphan the
+// save.
+func savPath(romBytes []byte) string {
+	dir := batteryDir()
+	if dir == "" {
+		return ""
+	}
+	sum := sha256.Sum256(romBytes)
+	return filepath.Join(dir, hex.EncodeToString(sum[:])+".sav")
+}
+
+// loadBattery reads a sibling .sav for the cart's PRG-RAM if the
+// cart is battery-backed + the file exists + sizes match. Silent
+// no-op otherwise. Errors logged to stderr but never fatal —
+// users who can't load a save can still play.
+func loadBattery(c cart.Cartridge, romBytes []byte) {
+	if !c.BatteryBacked() {
+		return
+	}
+	ram := c.PRGRAM()
+	if ram == nil {
+		return
+	}
+	path := savPath(romBytes)
+	if path == "" {
+		return
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			fmt.Fprintln(os.Stderr, "nessy: load battery .sav:", err)
+		}
+		return
+	}
+	if len(data) != len(ram) {
+		fmt.Fprintf(os.Stderr, "nessy: .sav size mismatch (%d vs %d) — ignoring\n", len(data), len(ram))
+		return
+	}
+	copy(ram, data)
+	fmt.Fprintln(os.Stderr, "nessy: battery .sav loaded from", path)
+}
+
+// saveBattery writes the cart's PRG-RAM to the sibling .sav file.
+// Best-effort — errors logged, never fatal.
+func saveBattery(c cart.Cartridge, romBytes []byte) {
+	if !c.BatteryBacked() {
+		return
+	}
+	ram := c.PRGRAM()
+	if ram == nil {
+		return
+	}
+	path := savPath(romBytes)
+	if path == "" {
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		fmt.Fprintln(os.Stderr, "nessy: mkdir .sav:", err)
+		return
+	}
+	if err := os.WriteFile(path, ram, 0o644); err != nil {
+		fmt.Fprintln(os.Stderr, "nessy: write battery .sav:", err)
+		return
+	}
+	fmt.Fprintln(os.Stderr, "nessy: battery .sav written to", path)
+}

--- a/cmd/nessy/main.go
+++ b/cmd/nessy/main.go
@@ -70,13 +70,12 @@ func main() {
 		os.Exit(2)
 	}
 
-	f, err := os.Open(*romPath)
+	romBytes, err := os.ReadFile(*romPath)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "nessy:", err)
 		os.Exit(1)
 	}
-	rom, err := nes.Parse(f)
-	_ = f.Close()
+	rom, err := nes.ParseBytes(romBytes)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "nessy: parse ROM:", err)
 		os.Exit(1)
@@ -87,6 +86,13 @@ func main() {
 		fmt.Fprintln(os.Stderr, "nessy: build NES:", err)
 		os.Exit(1)
 	}
+
+	// Battery-backed PRG-RAM (#267). Load any existing .sav into
+	// the cart's PRG-RAM before the CPU runs; write it back when
+	// the game loop exits. SHA-keyed so renaming the ROM doesn't
+	// orphan the save.
+	loadBattery(bus.cart, romBytes)
+	defer saveBattery(bus.cart, romBytes)
 
 	// Optional ca65 / ld65 .dbg symbol + source map. Auto-detect as
 	// `<rom>.dbg` sibling if the user didn't pass -dbg. Missing /

--- a/internal/nes/cart/cart.go
+++ b/internal/nes/cart/cart.go
@@ -33,6 +33,19 @@ type Cartridge interface {
 	// Most carts pin this at construction; MMC1+ later mappers can
 	// flip it dynamically (defer to v0.2+).
 	Mirroring() nes.Mirroring
+
+	// BatteryBacked reports whether the cart's PRG-RAM ($6000-$7FFF)
+	// is supposed to persist across power-off (iNES flag6 bit 1).
+	// nessy uses this to decide whether to read/write a sibling
+	// .sav file. NROM / UxROM / CNROM all return false (no PRG-RAM
+	// slot or non-battery). MMC1 / MMC3 honor the header bit.
+	BatteryBacked() bool
+
+	// PRGRAM exposes the 8 KiB PRG-RAM region for save / restore.
+	// Returns nil when the cart has no PRG-RAM (NROM / UxROM /
+	// CNROM). The returned slice aliases internal storage —
+	// callers must copy if they need to detach.
+	PRGRAM() []byte
 }
 
 // Open dispatches on the parsed ROM's Mapper byte and returns the

--- a/internal/nes/cart/cnrom.go
+++ b/internal/nes/cart/cnrom.go
@@ -95,3 +95,7 @@ func (c *CNROM) PPUWrite(addr uint16, v byte) {
 
 // Mirroring is pinned at construction.
 func (c *CNROM) Mirroring() nes.Mirroring { return c.mirroring }
+
+// CNROM ships no PRG-RAM slot — never battery-backed.
+func (c *CNROM) BatteryBacked() bool { return false }
+func (c *CNROM) PRGRAM() []byte      { return nil }

--- a/internal/nes/cart/mmc1.go
+++ b/internal/nes/cart/mmc1.go
@@ -29,6 +29,7 @@ type MMC1 struct {
 	chr      []byte
 	chrIsRAM bool
 	prgRAM   [0x2000]byte
+	battery  bool // iNES flag6 bit 1; routes save to a sibling .sav
 
 	// Shift register state.
 	shift    byte // 5-bit accumulator
@@ -58,6 +59,7 @@ func NewMMC1(rom *nes.ROM) (*MMC1, error) {
 		// $C000, switch at $8000) per nesdev. control bits 2-3 = 11.
 		control:   0x0C,
 		mirroring: rom.Mirroring,
+		battery:   rom.Battery,
 	}
 	switch {
 	case len(rom.CHR) == 0:
@@ -207,3 +209,12 @@ func (c *MMC1) chrOffset(addr uint16) int {
 // Mirroring returns the cached mode (updated on every control
 // register write).
 func (c *MMC1) Mirroring() nes.Mirroring { return c.mirroring }
+
+// BatteryBacked reports the iNES header's battery bit. ROMs with
+// the bit set (Zelda, Final Fantasy, Metroid via password) expect
+// their $6000-$7FFF PRG-RAM to survive power-off.
+func (c *MMC1) BatteryBacked() bool { return c.battery }
+
+// PRGRAM exposes the 8 KiB PRG-RAM region for save / restore.
+// Aliased; callers must copy if detachment is needed.
+func (c *MMC1) PRGRAM() []byte { return c.prgRAM[:] }

--- a/internal/nes/cart/nrom.go
+++ b/internal/nes/cart/nrom.go
@@ -82,3 +82,7 @@ func (c *NROM) PPUWrite(addr uint16, v byte) {
 }
 
 func (c *NROM) Mirroring() nes.Mirroring { return c.mirroring }
+
+// NROM has no PRG-RAM slot — never battery-backed.
+func (c *NROM) BatteryBacked() bool { return false }
+func (c *NROM) PRGRAM() []byte      { return nil }

--- a/internal/nes/cart/uxrom.go
+++ b/internal/nes/cart/uxrom.go
@@ -99,3 +99,7 @@ func (c *UxROM) PPUWrite(addr uint16, v byte) {
 
 // Mirroring is pinned at construction from the iNES header.
 func (c *UxROM) Mirroring() nes.Mirroring { return c.mirroring }
+
+// UxROM ships no PRG-RAM slot — never battery-backed.
+func (c *UxROM) BatteryBacked() bool { return false }
+func (c *UxROM) PRGRAM() []byte      { return nil }


### PR DESCRIPTION
Zelda 1, Final Fantasy, Metroid (via password), and other MMC1 titles set the iNES battery bit so their \`\$6000-\$7FFF\` PRG-RAM survives power-off. nessy now reads/writes a sibling \`.sav\` file keyed by ROM SHA so the save persists across launches.

## internal/nes/cart
\`Cartridge\` interface gains:
- \`BatteryBacked() bool\` — header bit propagated from \`rom.Battery\`.
- \`PRGRAM() []byte\` — aliased slice exposing the internal 8 KiB PRG-RAM region.

NROM / UxROM / CNROM return false / nil. MMC1 implements both.

## cmd/nessy/battery.go (nessy build tag)
- \`savPath\` keys files by \`sha256(rom bytes)\` under \`~/.nessy/sav/<sha>.sav\`.
- \`loadBattery\` reads the .sav into cart PRG-RAM on startup (silent no-op when missing; warning + ignore on size mismatch).
- \`saveBattery\` writes back on exit via \`defer\` after \`buildNES\`.

\`main.go\` reads ROM bytes via \`ReadFile\` so SHA + parse share the same data.

## Out of scope
- Auto-save on a timer (only on quit).
- Compressed \`.sav\` format.
- Cross-platform XDG dirs (uses \`os.UserHomeDir\`).

## Test plan
- [x] \`go test -race -count=1 ./...\` green.
- [x] \`golangci-lint run ./...\` 0 issues.
- [ ] **Manual MMC1**: Zelda 1 save persists across nessy quit + relaunch.

Closes #267.