### PR TITLE
feat(nes): iNES 2.0 header support (#271)

### DIFF
--- a/internal/nes/ines.go
+++ b/internal/nes/ines.go
@@ -51,18 +51,49 @@ func (m Mirroring) String() string {
 	}
 }
 
-// ROM is a parsed iNES cartridge image. It owns the PRG-ROM + CHR-ROM
-// byte slices and the header flags a mapper constructor needs.
+// ROM is a parsed iNES (or NES 2.0) cartridge image. It owns the
+// PRG-ROM + CHR-ROM byte slices and the header flags a mapper
+// constructor needs.
 type ROM struct {
-	Mapper    uint8
+	Mapper    uint16 // 12-bit mapper number per NES 2.0 (low 8 bits = iNES 1.0)
+	SubMapper uint8  // NES 2.0 sub-mapper (0 when header is iNES 1.0 or sub-mapper unused)
 	Mirroring Mirroring
 	Battery   bool // PRG-RAM battery-backed
 	Trainer   []byte
 	PRG       []byte // n × 16 KiB
 	CHR       []byte // n × 8 KiB, or nil/empty for CHR-RAM carts
-	NES2      bool   // true when the header advertises NES 2.0 (extensions parsed best-effort)
-	// nes2Submapper / nes2PrgRam / etc — future fields. v0.1 ignores
-	// them and treats the file as iNES 1.0 for mapper construction.
+	NES2      bool   // true when the header advertises NES 2.0
+
+	// NES 2.0 extensions. Zero values for iNES 1.0 ROMs.
+	PRGRAMSize int      // $6000-$7FFF SRAM size in bytes
+	EEPROMSize int      // EEPROM (battery-backed PRG-RAM) size in bytes
+	CHRRAMSize int      // CHR-RAM size in bytes (0 = use CHR-ROM)
+	TVSystem   TVSystem // NTSC / PAL / Dual
+}
+
+// TVSystem names the cart's intended TV-system per NES 2.0 flag12.
+// chippy currently runs the NTSC timing diagram regardless; the hint
+// is recorded for future PAL / Dendy support.
+type TVSystem uint8
+
+const (
+	TVNTSC TVSystem = iota
+	TVPAL
+	TVDual // NTSC + PAL (both expected to work)
+	TVDendy
+)
+
+func (t TVSystem) String() string {
+	switch t {
+	case TVPAL:
+		return "PAL"
+	case TVDual:
+		return "dual"
+	case TVDendy:
+		return "Dendy"
+	default:
+		return "NTSC"
+	}
 }
 
 // Errors returned from Parse.
@@ -103,7 +134,7 @@ func ParseBytes(data []byte) (*ROM, error) {
 	}
 
 	rom := &ROM{
-		Mapper:  (flag7 & 0xF0) | (flag6 >> 4),
+		Mapper:  uint16((flag7 & 0xF0) | (flag6 >> 4)),
 		Battery: flag6&0x02 != 0,
 	}
 	switch {
@@ -116,6 +147,9 @@ func ParseBytes(data []byte) (*ROM, error) {
 	}
 	// NES 2.0 detection: bits 2-3 of flag7 == 0b10 ("NES 2 ID").
 	rom.NES2 = (flag7 & 0x0C) == 0x08
+	if rom.NES2 {
+		parseNES2Extensions(data, rom, &prgBanks, &chrBanks)
+	}
 
 	off := headerLen
 	if flag6&0x04 != 0 { // trainer present
@@ -147,4 +181,84 @@ func ParseBytes(data []byte) (*ROM, error) {
 		return nil, ErrInvalidSize
 	}
 	return rom, nil
+}
+
+// parseNES2Extensions reads the NES 2.0-specific bytes (flag8 +
+// flag9 + flag10 + flag12) and writes the derived fields into rom.
+// Also extends PRG / CHR bank counts when the v2.0 high nibbles
+// are non-zero. Per the spec:
+//
+//	flag8 bits 0-3 → high nibble of 12-bit mapper number.
+//	flag8 bits 4-7 → 4-bit sub-mapper.
+//	flag9 bits 0-3 → high nibble of PRG bank count (combined with
+//	                 flag4 to form a 12-bit value; if the high
+//	                 nibble is $F the value is computed as an
+//	                 exponent + multiplier per the spec).
+//	flag9 bits 4-7 → same for CHR.
+//	flag10 bits 0-3 → PRG-RAM size (2 << v) bytes when v != 0.
+//	flag10 bits 4-7 → EEPROM size (2 << v) bytes when v != 0.
+//	flag11 — same shape for CHR-RAM + CHR-NVRAM.
+//	flag12 bits 0-1 → TV system (0 = NTSC, 1 = PAL, 2 = dual,
+//	                  3 = Dendy).
+//
+// chippy currently consumes the mapper / sub-mapper / TV-system
+// hints; PRG/CHR-RAM/EEPROM sizes are recorded but not yet acted
+// on (cart constructors still use fixed 8 KiB PRG-RAM).
+func parseNES2Extensions(data []byte, rom *ROM, prgBanks, chrBanks *int) {
+	flag8 := data[8]
+	flag9 := data[9]
+	flag10 := data[10]
+	flag11 := data[11]
+	flag12 := data[12]
+
+	// Mapper high nibble + sub-mapper.
+	rom.Mapper |= uint16(flag8&0x0F) << 8
+	rom.SubMapper = (flag8 & 0xF0) >> 4
+
+	// Extended PRG / CHR bank counts. NES 2.0 uses flag9's nibbles
+	// as the high 4 bits of a 12-bit bank count; if the nibble is
+	// $F, the corresponding flag4/flag5 byte is interpreted as
+	// (M × 2^E) with M = bits 0-1 + 1 and E = bits 2-7 (exponential
+	// encoding). chippy implements the linear path + the exponent
+	// fallback.
+	*prgBanks = extendedBankCount(flag9&0x0F, data[4])
+	*chrBanks = extendedBankCount((flag9&0xF0)>>4, data[5])
+
+	// PRG-RAM + EEPROM. Both nibbles store (2 << v) bytes when
+	// non-zero. v = 0 means absent (size 0).
+	if v := flag10 & 0x0F; v != 0 {
+		rom.PRGRAMSize = 64 << v
+	}
+	if v := (flag10 & 0xF0) >> 4; v != 0 {
+		rom.EEPROMSize = 64 << v
+	}
+	// CHR-RAM + CHR-NVRAM (flag11). We only track CHR-RAM size.
+	if v := flag11 & 0x0F; v != 0 {
+		rom.CHRRAMSize = 64 << v
+	}
+
+	switch flag12 & 0x03 {
+	case 1:
+		rom.TVSystem = TVPAL
+	case 2:
+		rom.TVSystem = TVDual
+	case 3:
+		rom.TVSystem = TVDendy
+	default:
+		rom.TVSystem = TVNTSC
+	}
+}
+
+// extendedBankCount returns the bank count given the v2.0 high
+// nibble + the v1.0 low byte. Implements both linear (high < $F)
+// and exponential (high == $F) encodings per the NES 2.0 spec.
+func extendedBankCount(high4, lo byte) int {
+	if high4 == 0x0F {
+		// Exponent / multiplier: M = bits 0-1 + 1, E = bits 2-7.
+		// Size = M × 2^E. lo encodes both.
+		exp := int((lo >> 2) & 0x3F)
+		mul := int((lo&0x03)<<1) | 1 // M ∈ {1, 3, 5, 7}
+		return mul << exp
+	}
+	return int(high4)<<8 | int(lo)
 }

--- a/internal/nes/ines_test.go
+++ b/internal/nes/ines_test.go
@@ -75,7 +75,7 @@ func TestParse_MapperByteAssembly(t *testing.T) {
 	cases := []struct {
 		name         string
 		flag6, flag7 byte
-		want         uint8
+		want         uint16
 	}{
 		{"mapper 0 (NROM)", 0x00, 0x00, 0},
 		{"mapper 1 (MMC1)", 0x10, 0x00, 1},

--- a/internal/nes/ines_v2_test.go
+++ b/internal/nes/ines_v2_test.go
@@ -1,0 +1,159 @@
+package nes
+
+import (
+	"bytes"
+	"testing"
+)
+
+// buildNES2 constructs a synthetic NES 2.0 file. flag7 always has
+// the NES2 ID bits set (0b10 in bits 2-3); the rest of flag8-12 is
+// caller-controlled.
+func buildNES2(prgBanks, chrBanks int, flag6, flag8, flag9, flag10, flag11, flag12 byte) []byte {
+	var b bytes.Buffer
+	b.Write([]byte{'N', 'E', 'S', 0x1A})
+	b.WriteByte(byte(prgBanks))
+	b.WriteByte(byte(chrBanks))
+	b.WriteByte(flag6)
+	b.WriteByte(0x08) // flag7 = NES 2.0 ID (bits 2-3 = 0b10)
+	b.WriteByte(flag8)
+	b.WriteByte(flag9)
+	b.WriteByte(flag10)
+	b.WriteByte(flag11)
+	b.WriteByte(flag12)
+	b.WriteByte(0) // flag13
+	b.WriteByte(0) // flag14
+	b.WriteByte(0) // flag15
+	// PRG / CHR payload — only matters for the parse not erroring.
+	for range prgBanks * prgBankSize {
+		b.WriteByte(0xBB)
+	}
+	for range chrBanks * chrBankSize {
+		b.WriteByte(0xCC)
+	}
+	return b.Bytes()
+}
+
+// NES 2.0 header parses + sets the NES2 flag.
+func TestNES2_DetectsIDBits(t *testing.T) {
+	data := buildNES2(1, 1, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00)
+	rom, err := ParseBytes(data)
+	if err != nil {
+		t.Fatalf("ParseBytes: %v", err)
+	}
+	if !rom.NES2 {
+		t.Errorf("NES2 flag not set on v2.0 header")
+	}
+}
+
+// 12-bit mapper number: low byte from flag6/7 + high nibble from
+// flag8 bits 0-3.
+func TestNES2_12BitMapper(t *testing.T) {
+	// flag6 high nibble = 4 (low half of mapper), flag7 high nibble
+	// = 5 (middle), flag8 low nibble = 7 (high nibble of 12-bit).
+	// Combined mapper = (7 << 8) | (5 << 4) | 4 = $754.
+	data := buildNES2(1, 1, 0x40, 0x07, 0x00, 0x00, 0x00, 0x00)
+	// flag7 high nibble was overwritten by buildNES2's NES2 ID
+	// byte ($08) — that means bits 4-7 of flag7 are 0. So the
+	// middle nibble is 0 in this synthetic. Expected mapper:
+	// (7 << 8) | (0 << 4) | 4 = $704.
+	rom, err := ParseBytes(data)
+	if err != nil {
+		t.Fatalf("ParseBytes: %v", err)
+	}
+	want := uint16(0x704)
+	if rom.Mapper != want {
+		t.Errorf("Mapper = $%03X; want $%03X", rom.Mapper, want)
+	}
+}
+
+// Sub-mapper from flag8 high nibble.
+func TestNES2_SubMapper(t *testing.T) {
+	data := buildNES2(1, 1, 0x00, 0x30, 0x00, 0x00, 0x00, 0x00) // sub-mapper 3
+	rom, err := ParseBytes(data)
+	if err != nil {
+		t.Fatalf("ParseBytes: %v", err)
+	}
+	if rom.SubMapper != 3 {
+		t.Errorf("SubMapper = %d; want 3", rom.SubMapper)
+	}
+}
+
+// PRG-RAM size from flag10 low nibble (size = 64 << v).
+func TestNES2_PRGRAMSize(t *testing.T) {
+	data := buildNES2(1, 1, 0x00, 0x00, 0x00, 0x07, 0x00, 0x00) // v=7 → 8 KiB
+	rom, err := ParseBytes(data)
+	if err != nil {
+		t.Fatalf("ParseBytes: %v", err)
+	}
+	if rom.PRGRAMSize != 8*1024 {
+		t.Errorf("PRGRAMSize = %d; want 8192", rom.PRGRAMSize)
+	}
+}
+
+// EEPROM size from flag10 high nibble.
+func TestNES2_EEPROMSize(t *testing.T) {
+	data := buildNES2(1, 1, 0x00, 0x00, 0x00, 0x70, 0x00, 0x00) // v=7 → 8 KiB
+	rom, err := ParseBytes(data)
+	if err != nil {
+		t.Fatalf("ParseBytes: %v", err)
+	}
+	if rom.EEPROMSize != 8*1024 {
+		t.Errorf("EEPROMSize = %d; want 8192", rom.EEPROMSize)
+	}
+}
+
+// TV system from flag12 bits 0-1.
+func TestNES2_TVSystem(t *testing.T) {
+	cases := []struct {
+		flag12 byte
+		want   TVSystem
+	}{
+		{0x00, TVNTSC},
+		{0x01, TVPAL},
+		{0x02, TVDual},
+		{0x03, TVDendy},
+	}
+	for _, c := range cases {
+		data := buildNES2(1, 1, 0x00, 0x00, 0x00, 0x00, 0x00, c.flag12)
+		rom, err := ParseBytes(data)
+		if err != nil {
+			t.Fatalf("flag12=$%02X: %v", c.flag12, err)
+		}
+		if rom.TVSystem != c.want {
+			t.Errorf("flag12=$%02X → TVSystem=%s; want %s",
+				c.flag12, rom.TVSystem, c.want)
+		}
+	}
+}
+
+// CHR-RAM size from flag11 low nibble.
+func TestNES2_CHRRAMSize(t *testing.T) {
+	data := buildNES2(1, 0, 0x00, 0x00, 0x00, 0x00, 0x07, 0x00) // v=7 → 8 KiB
+	rom, err := ParseBytes(data)
+	if err != nil {
+		t.Fatalf("ParseBytes: %v", err)
+	}
+	if rom.CHRRAMSize != 8*1024 {
+		t.Errorf("CHRRAMSize = %d; want 8192", rom.CHRRAMSize)
+	}
+}
+
+// iNES 1.0 file (flag7 NES2 ID bits not set) still parses cleanly
+// with NES2=false + zero extension fields. Catches the regression
+// where NES 2.0 detection might overshoot.
+func TestNES2_LegacyHeaderStaysV1(t *testing.T) {
+	data := buildiNES(1, 1, 0x00, 0x00, false)
+	rom, err := ParseBytes(data)
+	if err != nil {
+		t.Fatalf("ParseBytes: %v", err)
+	}
+	if rom.NES2 {
+		t.Errorf("legacy header detected as NES 2.0")
+	}
+	if rom.SubMapper != 0 {
+		t.Errorf("legacy SubMapper = %d; want 0", rom.SubMapper)
+	}
+	if rom.TVSystem != TVNTSC {
+		t.Errorf("legacy TVSystem = %s; want NTSC default", rom.TVSystem)
+	}
+}


### PR DESCRIPTION
NES 2.0 extends the iNES header with 12-bit mapper / sub-mapper / extended PRG-CHR sizes / TV system. Modern repacks ship v2.0; v1.0 parser was misreading those bytes.

## Changes
- \`ROM.Mapper\` widened to \`uint16\` (12-bit).
- New fields: \`SubMapper\`, \`PRGRAMSize\`, \`EEPROMSize\`, \`CHRRAMSize\`, \`TVSystem\`.
- \`TVSystem\` enum (NTSC / PAL / Dual / Dendy) with String for diagnostics.
- \`parseNES2Extensions\` reads flag8-12 + writes derived fields when the v2.0 ID bits are set.
- \`extendedBankCount\` handles both linear + exponential PRG/CHR sizing.

\`cart.Open\` still dispatches on Mapper's low byte (high-mapper ROMs error out via existing "unsupported" path). Filled by VRC / FME-7 work in v0.5 (#269 / #270).

## Tests
ID bit detection, 12-bit mapper assembly, sub-mapper extraction, PRG-RAM/EEPROM/CHR-RAM size decoding, TVSystem decoding, legacy v1.0 stays v1.0.

## Regression
- [x] Full sweep + lint green.

Closes #271.