### PR TITLE
feat(nessy): -oam-trace flag dumps visible OAM each frame

### DIFF
--- a/cmd/nessy/game.go
+++ b/cmd/nessy/game.go
@@ -5,6 +5,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -59,6 +60,7 @@ type game struct {
 	titleBase      string     // window title prefix; FPS appended every ~0.5 s
 	frameNum       uint64
 	frameDumpEvery int           // 0 = off; N = write framebuffer PNG every N frames
+	oamTrace       bool          // -oam-trace: dump visible-sprite OAM every frame
 	states         *saveStateMgr // F1-F4 = save slots 1-4; F5-F8 = load slots 1-4
 }
 
@@ -125,7 +127,30 @@ func (g *game) Update() error {
 	if g.frameDumpEvery > 0 && g.frameNum%uint64(g.frameDumpEvery) == 0 {
 		g.dumpFrame()
 	}
+	if g.oamTrace {
+		g.dumpOAM()
+	}
 	return nil
+}
+
+// dumpOAM prints visible-sprite OAM rows to stderr, one frame per
+// line. Format: "F<frame> i=<idx>:t=$<tile>@(<x>,<y>) ...".
+// Sprites with y >= 240 (off-screen per silicon) are skipped so
+// the line stays scannable. Diagnostic only; flag is opt-in.
+func (g *game) dumpOAM() {
+	var b strings.Builder
+	fmt.Fprintf(&b, "F%d", g.frameNum)
+	for i := 0; i < 64; i++ {
+		base := byte(i * 4)
+		y := g.bus.ppu.OAM(base + 0)
+		if y >= 240 {
+			continue
+		}
+		tile := g.bus.ppu.OAM(base + 1)
+		x := g.bus.ppu.OAM(base + 3)
+		fmt.Fprintf(&b, " %d:t=$%02X@(%d,%d)", i, tile, x, y)
+	}
+	fmt.Fprintln(os.Stderr, b.String())
 }
 
 func (g *game) Draw(screen *ebiten.Image) {

--- a/cmd/nessy/main.go
+++ b/cmd/nessy/main.go
@@ -28,6 +28,7 @@ func main() {
 		waitDbg   = flag.Bool("wait-for-debugger", false, "pause the CPU at boot until a DAP client attaches (set by `chippy -nessy`)")
 		pprofPath = flag.String("pprof", "", "write a CPU profile to FILE for the lifetime of the run; analyze with `go tool pprof FILE`")
 		frameDump = flag.Int("frame-dump-every", 0, "dump the framebuffer as PNG to ~/.nessy/dumps/F<N>.png every N frames (0 = off); expensive — diagnostic only")
+		oamTrace  = flag.Bool("oam-trace", false, "print visible sprite OAM (idx:tile@x,y) to stderr every frame; expensive — diagnostic only")
 	)
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "usage: nessy [-rom PATH | PATH] [-dbg PATH] [-dap-port N] [-scale N] [-mute] [-wait-for-debugger] [-pprof FILE]\n\n")
@@ -148,6 +149,7 @@ func main() {
 	titleBase := fmt.Sprintf("nessy — %s", filepath.Base(*romPath))
 	g := newGame(bus, cpuMu, titleBase)
 	g.frameDumpEvery = *frameDump
+	g.oamTrace = *oamTrace
 	// Save-state hotkey manager. ROM hash tags each .state file so a
 	// slot saved against one game can't accidentally restore into a
 	// different ROM with a half-matching state shape.


### PR DESCRIPTION
Diagnostic for the SMB1 "Mario disappears mid-jump" report. Each frame prints one line to stderr listing every visible (y < 240) sprite:

\`\`\`
F<frame> i=<idx>:t=$<tile>@(<x>,<y>) ...
\`\`\`

Mario in SMB1 is typically sprites 1-8 with paired x/y values; grep the trace by idx + scrub the Y column to spot the frame where his rows go off-screen.

Expensive; opt-in via \`-oam-trace\` bool.