### PR TITLE
feat(nessy): -frame-dump-every N writes framebuffer PNGs

### DIFF
--- a/cmd/nessy/framedump.go
+++ b/cmd/nessy/framedump.go
@@ -1,0 +1,53 @@
+//go:build nessy
+
+package main
+
+import (
+	"fmt"
+	"image"
+	"image/png"
+	"os"
+	"path/filepath"
+)
+
+// frameDumpDir returns the directory frame PNGs land in. Empty when
+// $HOME isn't resolvable — dump silently disabled.
+func frameDumpDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".nessy", "dumps")
+}
+
+// dumpFrame writes the current PPU framebuffer (256 × 240 RGBA) to
+// $HOME/.nessy/dumps/F<frame>.png. Used by the -frame-dump-every
+// flag for "scrub the recording after a play session" diagnostics.
+// Each frame is its own file; user prunes after analysis.
+// Best-effort — errors logged but not fatal.
+func (g *game) dumpFrame() {
+	dir := frameDumpDir()
+	if dir == "" {
+		return
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		fmt.Fprintln(os.Stderr, "nessy: mkdir frame-dump:", err)
+		return
+	}
+	rgba := &image.RGBA{
+		Pix:    g.bus.ppu.FrameBuffer(),
+		Stride: 256 * 4,
+		Rect:   image.Rect(0, 0, 256, 240),
+	}
+	path := filepath.Join(dir, fmt.Sprintf("F%07d.png", g.frameNum))
+	f, err := os.Create(path)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "nessy: frame-dump create:", err)
+		return
+	}
+	defer f.Close()
+	if err := png.Encode(f, rgba); err != nil {
+		fmt.Fprintln(os.Stderr, "nessy: frame-dump encode:", err)
+		return
+	}
+}

--- a/cmd/nessy/game.go
+++ b/cmd/nessy/game.go
@@ -44,11 +44,12 @@ var keyMap = []struct {
 // a concurrent DAP request can't observe a mid-instruction register
 // snapshot.
 type game struct {
-	bus       *nesBus
-	cpuMu     *sync.Mutex
-	audio     *audioSink // optional; nil when -mute set or audio init failed
-	titleBase string     // window title prefix; FPS appended every ~0.5 s
-	frameNum  uint64
+	bus            *nesBus
+	cpuMu          *sync.Mutex
+	audio          *audioSink // optional; nil when -mute set or audio init failed
+	titleBase      string     // window title prefix; FPS appended every ~0.5 s
+	frameNum       uint64
+	frameDumpEvery int // 0 = off; N = write framebuffer PNG every N frames
 }
 
 func newGame(bus *nesBus, cpuMu *sync.Mutex, titleBase string) *game {
@@ -101,6 +102,9 @@ func (g *game) Update() error {
 	if g.titleBase != "" && g.frameNum%30 == 0 {
 		ebiten.SetWindowTitle(fmt.Sprintf("%s — TPS %.1f FPS %.1f",
 			g.titleBase, ebiten.ActualTPS(), ebiten.ActualFPS()))
+	}
+	if g.frameDumpEvery > 0 && g.frameNum%uint64(g.frameDumpEvery) == 0 {
+		g.dumpFrame()
 	}
 	return nil
 }

--- a/cmd/nessy/main.go
+++ b/cmd/nessy/main.go
@@ -25,6 +25,7 @@ func main() {
 		mute      = flag.Bool("mute", false, "disable audio output (APU still runs; samples are dropped)")
 		waitDbg   = flag.Bool("wait-for-debugger", false, "pause the CPU at boot until a DAP client attaches (set by `chippy -nessy`)")
 		pprofPath = flag.String("pprof", "", "write a CPU profile to FILE for the lifetime of the run; analyze with `go tool pprof FILE`")
+		frameDump = flag.Int("frame-dump-every", 0, "dump the framebuffer as PNG to ~/.nessy/dumps/F<N>.png every N frames (0 = off); expensive — diagnostic only")
 	)
 	flag.Usage = func() {
 		fmt.Fprintf(os.Stderr, "usage: nessy [-rom PATH | PATH] [-dbg PATH] [-dap-port N] [-scale N] [-mute] [-wait-for-debugger] [-pprof FILE]\n\n")
@@ -144,6 +145,7 @@ func main() {
 
 	titleBase := fmt.Sprintf("nessy — %s", filepath.Base(*romPath))
 	g := newGame(bus, cpuMu, titleBase)
+	g.frameDumpEvery = *frameDump
 	sink, err := newAudioSink(*mute)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "nessy: audio init failed (continuing muted):", err)


### PR DESCRIPTION
Diagnostic flag for visual-bug repro. Each Nth frame's framebuffer saved as PNG to \`~/.nessy/dumps/F<frame>.png\`. Scrub the sequence after a play session to find the exact frame a bug appeared on without screenshot-during-play.

\`\`\`
./nessy -frame-dump-every 30 ~/Desktop/smb.nes
# play, quit
open ~/.nessy/dumps/
\`\`\`

Opt-in (0 default). N >= 30 keeps cost <1ms/real-frame at 60 FPS.

## Test plan
- [x] Build green, tests green, lint clean.
- [ ] Manual: \`-frame-dump-every 60\`, play, verify PNGs.