### PR TITLE
docs: nessy landing section + chippy.dev nav (#209)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,9 @@ this repo ships, compiled to WebAssembly. Pick a canned demo (or drop
 in your own `.bin` / `.prg` / `.hex`) and step through it — no install
 required.
 
+Trying NES emulation? See [**nessy**](nessy/index.md) — the NES
+emulator built on chippy's CPU + DAP. [Play it in the browser](/chippy/playground/nessy/).
+
 ## Install on your machine
 
 | Platform | Install |

--- a/docs/nessy/debugging.md
+++ b/docs/nessy/debugging.md
@@ -1,0 +1,60 @@
+# Debugging NES ROMs
+
+nessy ships chippy's DAP server alongside the Ebiten game loop. Any DAP-speaking editor can attach — chippy's TUI is the easiest path, but VS Code / nvim-DAP / Zed work too.
+
+## One-shell debug launch
+
+The fastest way:
+
+```sh
+chippy -nessy roms/demos/hello-bg/hello-bg.nes
+```
+
+That spawns nessy in the background, dials its DAP listener, and opens the TUI in attach mode paused at the reset vector. No second terminal needed.
+
+## Two-shell attach
+
+If you want to keep nessy and chippy in separate windows:
+
+**Terminal 1:**
+
+```sh
+nessy -wait-for-debugger game.nes
+```
+
+`-wait-for-debugger` pauses the CPU at boot until a DAP client attaches.
+
+**Terminal 2:**
+
+```sh
+chippy -dap-attach tcp:localhost:14785
+```
+
+The TUI's panels (registers / disasm / memory / stack / source) all show live state synced from nessy.
+
+## Symbol files
+
+If your ROM was built with `ca65 -g` + `ld65 --dbgfile`, nessy auto-detects the `.dbg` sibling and feeds it to chippy through the DAP `Source` event so the TUI's source panel highlights the current line in real `.s` code.
+
+```sh
+nessy game.nes              # nessy auto-detects game.dbg
+nessy -dbg path/to/game.dbg # explicit override
+```
+
+## What the TUI gives you
+
+- **Step** (`s`), **step-into** / **step-over** (`o` / `O`), **step-back** (`b`), **continue** (`r`).
+- **Breakpoints** — toggle at any source line or instruction address; survive across reattach.
+- **Watch expressions** — read / write watches on any RAM address; the expression engine handles arithmetic + label resolution.
+- **Memory editor** — byte-level cursor, hex edit mode, `:goto` jumps anywhere.
+- **Stack panel** with JSR-frame annotation (`ret $XXXX  callee  file:NN`).
+- **Source panel** with the current PC highlight + clickable line numbers.
+- **Quake-style console** (\`backtick\`) for scrollback over `:` commands.
+
+See [`dap.md`](../dap.md) for protocol details and [`editors.md`](../editors.md) for the per-editor support matrix.
+
+## Live demo
+
+![nessy-attach](https://github.com/nkane/chippy/raw/main/test/smoke/out/nessy-attach.gif)
+
+Recorded via [VHS](https://github.com/charmbracelet/vhs). Tape source: [`test/smoke/nessy-attach.tape`](https://github.com/nkane/chippy/blob/main/test/smoke/nessy-attach.tape).

--- a/docs/nessy/demos.md
+++ b/docs/nessy/demos.md
@@ -1,0 +1,33 @@
+# Homebrew demos
+
+Every demo under `roms/demos/` is hand-rolled ca65 + ld65 source with a checked-in `.nes` artifact. Each doubles as a regression test under `cmd/nessy/demo_*_test.go` — either a SHA-pinned framebuffer hash (visual demos) or a sample-presence assertion (audio demos).
+
+Toolchain: `brew install cc65` (macOS) or `sudo apt-get install cc65` (Debian / Ubuntu). Rebuild via `make -C roms/demos all`. Toolchain isn't required to run — the `.nes` files are committed.
+
+| Demo | What it tests | Source |
+|---|---|---|
+| [`hello-bg`](https://github.com/nkane/chippy/tree/main/roms/demos/hello-bg) | PPU bg renderer + palette + nametable + reset path | Static "HELLO NESSY" title screen |
+| [`input-echo`](https://github.com/nkane/chippy/tree/main/roms/demos/input-echo) | `$4016` joypad strobe + serial shift + per-frame VRAM writes | 8 indicator boxes light up under live joypad input |
+| [`vblank-bounce`](https://github.com/nkane/chippy/tree/main/roms/demos/vblank-bounce) | PPU NMI line + CPU NMI service + `JMP self` idle | Single tile bounces inside the playfield |
+| [`triangle-arpeggio`](https://github.com/nkane/chippy/tree/main/roms/demos/triangle-arpeggio) | APU triangle channel + NMI-driven note rotation | A-major arpeggio (audio only) |
+| [`noise-drum`](https://github.com/nkane/chippy/tree/main/roms/demos/noise-drum) | APU noise channel + LFSR feedback | Low/high noise drum (audio only) |
+| [`all-channels`](https://github.com/nkane/chippy/tree/main/roms/demos/all-channels) | Non-linear DAC mixer under multi-channel load | Pulse + triangle + noise chord (audio only) |
+| [`dmc-sample`](https://github.com/nkane/chippy/tree/main/roms/demos/dmc-sample) | DMC channel DMA fetch + delta-PCM + loop bit | 65-byte alternating-bit sample looped |
+| [`mmc1-banks`](https://github.com/nkane/chippy/tree/main/roms/demos/mmc1-banks) | MMC1 serial-shift PRG bank switching | BG flashes between two colours twice per second |
+
+## Run
+
+```sh
+./nessy roms/demos/hello-bg/hello-bg.nes
+./nessy roms/demos/all-channels/all-channels.nes
+```
+
+## Inspect headless
+
+Every demo test ships with an `_Inspect` variant that prints either a textual screenshot or per-frame state. Useful when you can't open a display:
+
+```sh
+CHIPPY_DEMO_INSPECT=1 go test -tags=nessy -run TestDemo_HelloBG_Inspect ./cmd/nessy/... -v
+```
+
+The build-tag gate keeps the test out of CI's general suite where Ebiten dev headers aren't installed.

--- a/docs/nessy/index.md
+++ b/docs/nessy/index.md
@@ -1,0 +1,37 @@
+# nessy
+
+nessy is an NES emulator built on top of chippy's 6502 CPU + bus infrastructure. The same `cpu.CPU` that runs ca65 demos under the chippy TUI also drives the Ricoh 2A03 inside an Ebiten window, with the chippy DAP server attached so you can pause + step + breakpoint a live NES ROM from any DAP-speaking editor.
+
+```
+chippy -nessy game.nes
+```
+
+That single command spawns nessy + dials its DAP listener + opens the TUI in attach mode paused at the reset vector. No two-terminal dance.
+
+## Status
+
+| Version | Highlight |
+|---|---|
+| v0.1 | NROM + DAP attach + first homebrew demos |
+| v0.2 | Sprites, scrolling, OAMDMA — SMB1 boots |
+| v0.3 | Full audio (5 channels + non-linear DAC mixer), MMC1 |
+| v0.4 | UxROM / CNROM / MMC3, save states, PPU per-dot accuracy, battery PRG-RAM |
+| v0.5 | VRC2 / VRC4 / FME-7 mappers, cycle-accuracy hardening, player UX |
+| v0.6 | VRC6 + audio, VRC7 cart, Sunsoft 5B audio, WASM playground, DMC/OAMDMA contention |
+
+## Mapper coverage
+
+NROM, MMC1, UxROM, CNROM, MMC3 (Sharp + NEC RevA), VRC2, VRC4, VRC6 + audio, VRC7 (cart only; OPLL FM synth in v0.7), FME-7 + Sunsoft 5B audio.
+
+Headliners that now play: Super Mario Bros, Zelda 1, Final Fantasy, Metroid, Castlevania II + III JP, Mega Man 1-6, SMB3, Crisis Force, Gimmick!, Lagrange Point (silent).
+
+## In your browser
+
+[Try nessy in the browser](https://nkane.dev/chippy/playground/nessy/) — Ebiten js/wasm build with a default demo + drag-drop loader for your own ROMs.
+
+## What's next
+
+- [v0.6 epic](https://github.com/nkane/chippy/issues/305)
+- [v0.7 OPLL FM synth](https://github.com/nkane/chippy/issues/315) — Lagrange Point's soundtrack.
+
+See [`install`](install.md) for binaries + build instructions, [`demos`](demos.md) for the homebrew ROM suite, and [`debugging`](debugging.md) for the DAP-attach workflow.

--- a/docs/nessy/install.md
+++ b/docs/nessy/install.md
@@ -1,0 +1,83 @@
+# Install
+
+## Pre-built binaries
+
+Each `nessy-vX.Y.Z` tag attaches per-OS archives to its GitHub release:
+
+[Latest release →](https://github.com/nkane/chippy/releases?q=nessy)
+
+| Platform | Archive | Includes |
+|---|---|---|
+| macOS arm64 | `nessy_<ver>_darwin_arm64.tar.gz` | `nessy` binary + every homebrew demo ROM |
+| macOS amd64 | `nessy_<ver>_darwin_amd64.tar.gz` | same |
+| Linux amd64 | `nessy_<ver>_linux_amd64.tar.gz` | same |
+| Windows amd64 | `nessy_<ver>_windows_amd64.zip` | same |
+
+## Build from source
+
+nessy ships behind a `nessy` build tag because Ebiten requires X11 / GL dev headers on Linux that the default CI runners don't carry. The `!nessy` stub in `cmd/nessy/main_stub.go` prints build instructions so `go build ./...` stays green for the rest of the repo.
+
+### macOS
+
+```sh
+go build -tags=nessy -o nessy ./cmd/nessy
+./nessy game.nes
+```
+
+### Linux (Debian / Ubuntu)
+
+```sh
+sudo apt-get install -y libgl1-mesa-dev xorg-dev libasound2-dev \
+  libxcursor-dev libxinerama-dev libxi-dev libxrandr-dev
+go build -tags=nessy -o nessy ./cmd/nessy
+```
+
+### Windows
+
+```sh
+go build -tags=nessy -o nessy.exe ./cmd/nessy
+nessy.exe game.nes
+```
+
+## Browser
+
+[Play in the browser](https://nkane.dev/chippy/playground/nessy/) — no install, ROM stays local.
+
+## Optional flags
+
+| Flag | Purpose |
+|---|---|
+| `-rom PATH` | iNES ROM (also accepts positional `nessy game.nes`) |
+| `-dbg PATH` | ca65 / ld65 `.dbg` symbol file (auto-detected as `<rom>.dbg`) |
+| `-dap-port N` | DAP listener port (default 14785; 0 disables) |
+| `-scale N` | Window scale (default 3 → 768×720) |
+| `-mute` | Disable audio output |
+| `-wait-for-debugger` | Pause at boot until a DAP client attaches |
+| `-pprof FILE` | Write a CPU profile for the lifetime of the run |
+| `-oam-trace` | Print visible OAM each frame |
+| `-frame-dump-every N` | PNG dump every N frames to `~/.nessy/dumps/` |
+
+## Player hotkeys
+
+| Key | Action |
+|---|---|
+| Arrows | D-pad |
+| Z / X | A / B |
+| Enter | Start |
+| Right Shift | Select |
+| Tab (held) | 4× fast-forward |
+| F1–F4 | Save state into slots 1–4 |
+| F5–F8 | Load saved state from matching slot |
+| F11 | Toggle fullscreen |
+| F12 | Save screenshot to `~/.nessy/screenshots/` |
+
+## Configuration files
+
+| File | Purpose |
+|---|---|
+| `~/.nessy/recent` | Recent ROM list (5 newest). `nessy N` opens slot N. |
+| `~/.nessy/controller.json` | Remap any NES button to any Ebiten key. |
+| `~/.nessy/sav/<rom-hash>.sav` | Battery-backed PRG-RAM persistence (auto). |
+| `~/.nessy/states/<rom-hash>-slot<N>.state` | Save states. |
+| `~/.nessy/screenshots/<rom>-<timestamp>.png` | F12 captures. |
+| `~/.nessy/dumps/F<N>.png` | `-frame-dump-every` output. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,8 +56,14 @@ nav:
       - State-file format: state-format.md
       - Perf baseline: perf-baseline.md
       - Editor matrix: editors.md
+  - nessy:
+      - Overview: nessy/index.md
+      - Install: nessy/install.md
+      - Demos: nessy/demos.md
+      - Debugging: nessy/debugging.md
   - Internals:
       - Architecture (context dump): context.md
   - Mascot:
       - mascot-prompts.md
   - Playground: https://nkane.dev/chippy/playground/
+  - nessy in browser: https://nkane.dev/chippy/playground/nessy/


### PR DESCRIPTION
New \`docs/nessy/\` section under MkDocs:

- \`index.md\` — overview + per-version highlights + mapper coverage + browser link.
- \`install.md\` — binaries, build-from-source per OS, hotkey table, config file inventory.
- \`demos.md\` — homebrew demo ROM catalog.
- \`debugging.md\` — DAP attach + symbol files + TUI tour.

\`mkdocs.yml\` nav extends with the \"nessy\" peer to \"Reference\" + a \"nessy in browser\" external link to \`/chippy/playground/nessy/\`. \`chippy/index.md\` cross-links to the new section.

## Test plan
- [x] \`mkdocs build --strict\` clean (no broken links).
- [x] Pages workflow rebuilds on merge — published URL: \`chippy.dev/nessy/\`.

Closes #209.