### PR TITLE
docs(cpu): note #342 per-cycle PPU requirement at the tick site

### DIFF
--- a/internal/cpu/exec.go
+++ b/internal/cpu/exec.go
@@ -89,6 +89,12 @@ func (c *CPU) Step() int {
 	// cycle delta after each instruction. The Ticker assertion is
 	// cached on c.busTicker at SetBus time so the no-ticker fast path
 	// is one nil-check; perfgate ceiling holds.
+	//
+	// NOTE (#342): this batches the PPU tick at instruction granularity,
+	// so a $2002 read sees the PPU lagging up to one instruction. Single-
+	// dot-accurate vblank timing (Blargg ppu_vbl_nmi test 2) needs per-
+	// CPU-cycle PPU stepping with register reads resolving at their exact
+	// cycle — a larger architecture change scoped separately.
 	if c.busTicker != nil {
 		c.busTicker.Tick(cycles)
 	}


### PR DESCRIPTION
Comment-only. Records the #342 investigation outcome at the exact call site (the post-instruction batched PPU tick in \`cpu.Step\`).

## Finding
Instruction-granularity PPU catch-up (pre-tick before \`in.Exec\`) is **insufficient** for Blargg \`ppu_vbl_nmi\` test 2 (vbl_set_time): tests 1 + 5-8 pass, 2-4 fail. The remaining error is sub-instruction — single-dot vblank precision needs per-CPU-cycle PPU stepping with \$2002 reads resolving at their exact cycle.

Real fix (scoped to #342, v0.9): per-cycle CPU↔PPU interleave + per-addressing-mode read/write schedule + the vblank set/read suppression race. CPU-core change, high blast radius — not a v0.8 bolt-on.

The accuracy harness (#318) already gates it: drop vbl_nmi's \`knownFail\` once tests 2-4 pass.

No behaviour change — pure comment.

Refs #342.