### PR TITLE
chore: stage nessy repo carve-out (#351)

### DIFF
--- a/docs/repo-split.md
+++ b/docs/repo-split.md
@@ -1,0 +1,89 @@
+# chippy / nessy repo split
+
+The plan + procedure for carving the nessy NES emulator out of the
+chippy monorepo into `github.com/nkane/nessy` (#351). The shared
+6502 core stays in chippy and is consumed as a library — that's why
+it was promoted out of `internal/` (#349) and documented as a public
+API (#350, [`api.md`](api.md)).
+
+## Why split
+
+chippy's CPU/bus/DAP core is mature + library-shaped; nessy is a
+graphics app (Ebiten/GL deps) on top of it. Separate repos let:
+- chippy ship as a clean 6502 library without dragging Ebiten in.
+- nessy version + release on its own cadence.
+- the chippy CI drop the X11/GL/build-tag complexity nessy needs.
+
+## What moves where
+
+| Stays in chippy | Moves to nessy |
+|---|---|
+| `cpu`, `dap`, `peripheral`, `expr`, `loader`, `symbols`, `trace` (public) | `cmd/nessy{,-wasm,-record}` |
+| `cmd/chippy`, `internal/tui` | `internal/nes/*` (apu, cart, dma, joypad, ppu, ines, timing) |
+| chippy demos (`example/`), docs | `roms/demos/`, `web/nessy/`, `docs/nessy/` |
+| chippy release + pages workflows | nessy release workflow + smoke recorder + accuracy suite |
+
+After the split nessy's `go.mod` requires `github.com/nkane/chippy`
+at a pinned version; its core imports
+(`github.com/nkane/chippy/cpu` …) already use the public paths so
+they need no rewrite. Only the nessy-internal imports
+(`…/internal/nes/*`) get re-pointed to `github.com/nkane/nessy`.
+
+## Procedure
+
+### 1. Cut a chippy library release
+nessy must pin a real chippy version. Tag chippy first:
+```sh
+git checkout main && git pull
+git tag v1.1.0        # follow semver; this is the library version nessy pins
+git push origin v1.1.0
+```
+
+### 2. Create the empty nessy repo
+On GitHub: new repo `nkane/nessy`, no README/license (the carve
+brings them).
+
+### 3. Run the carve script
+```sh
+scripts/carve-nessy.sh v1.1.0 /tmp/nessy-carve
+```
+It clones chippy, `git filter-repo`s down to the nessy paths (history
+preserved), rewrites `nessy-vX.Y.Z` tags → bare `vX.Y.Z`, re-points
+the `internal/nes` imports, and writes the nessy `go.mod`.
+
+### 4. Verify + push
+```sh
+cd /tmp/nessy-carve/nessy
+go mod tidy
+go build -tags=nessy ./... && go test -race ./...
+git remote add origin git@github.com:nkane/nessy.git
+git push -u origin main --tags
+```
+
+### 5. Clean chippy
+In a follow-up chippy PR, remove the carved paths + the nessy CI
+jobs (the `nessy tagged build`, the smoke job's `nessy-record` step,
+the `accuracy` job, the nessy release-workflow branch). chippy keeps
+the core + TUI only.
+
+### 6. Wire CI in the nessy repo
+Port the nessy-specific jobs: tagged build (darwin/linux/windows),
+the headless recorder smoke (#339), the accuracy ROM suite (#318),
+the per-OS release pipeline (`nessy-vX.Y.Z` → now bare `vX.Y.Z`).
+
+## Open question: `chippy -nessy ROM`
+
+The one-shell debug launch spawns the nessy binary. Post-split,
+chippy can't build nessy. Options:
+1. Drop the auto-spawn; document "install nessy separately, then
+   `nessy -wait-for-debugger ROM` + `chippy -dap-attach`".
+2. Keep `-nessy` as a convenience that shells out to a `nessy` found
+   on `$PATH` (no build dependency).
+
+Lean #2 — the attach UX is nice + it's a thin exec wrapper.
+
+## Status
+
+Staged, not executed — gated on the new GitHub repo existing + a
+chippy library tag. `scripts/carve-nessy.sh` + this doc are the
+runnable plan.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,7 @@ nav:
       - Debugging: nessy/debugging.md
   - Internals:
       - Architecture (context dump): context.md
+      - Repo split plan: repo-split.md
   - Mascot:
       - mascot-prompts.md
   - Playground: https://nkane.dev/chippy/playground/

--- a/scripts/carve-nessy.sh
+++ b/scripts/carve-nessy.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# carve-nessy.sh — extract the nessy emulator into its own repo (#351).
+#
+# Run this AFTER:
+#   1. github.com/nkane/nessy exists (empty).
+#   2. chippy has a published library tag to pin (e.g. v1.1.0) — the
+#      core packages cpu/dap/peripheral/expr/loader/symbols/trace are
+#      already public (#349).
+#
+# It does NOT mutate the chippy repo. It produces a fresh nessy repo
+# from a filtered clone of chippy history, keeping only nessy paths +
+# rewriting the nessy-internal import paths to the new module.
+#
+# Requires: git-filter-repo (https://github.com/newren/git-filter-repo).
+#
+# Usage:
+#   scripts/carve-nessy.sh <chippy-version-tag> <workdir>
+#   e.g.  scripts/carve-nessy.sh v1.1.0 /tmp/nessy-carve
+#
+# After it finishes, review /tmp/nessy-carve/nessy then push it to
+# github.com/nkane/nessy (the script prints the exact commands).
+
+set -euo pipefail
+
+CHIPPY_VERSION="${1:?usage: carve-nessy.sh <chippy-version-tag> <workdir>}"
+WORKDIR="${2:?usage: carve-nessy.sh <chippy-version-tag> <workdir>}"
+CHIPPY_REMOTE="git@github.com:nkane/chippy.git"
+NESSY_MODULE="github.com/nkane/nessy"
+CHIPPY_MODULE="github.com/nkane/chippy"
+
+if ! command -v git-filter-repo >/dev/null 2>&1; then
+  echo "error: git-filter-repo not found — install it first:" >&2
+  echo "  brew install git-filter-repo   # or pip install git-filter-repo" >&2
+  exit 1
+fi
+
+mkdir -p "$WORKDIR"
+cd "$WORKDIR"
+rm -rf nessy
+git clone "$CHIPPY_REMOTE" nessy
+cd nessy
+
+# Paths that move to the nessy repo (everything nessy-specific). The
+# shared 6502 core stays in chippy + is pulled in as a module dep.
+git filter-repo \
+  --path cmd/nessy/ \
+  --path cmd/nessy-wasm/ \
+  --path cmd/nessy-record/ \
+  --path internal/nes/ \
+  --path roms/demos/ \
+  --path web/nessy/ \
+  --path docs/nessy/ \
+  --path test/smoke/nessy-input-echo.json \
+  --path-glob 'roms/demos/*' \
+  --tag-rename 'nessy-v:v'
+
+# Rewrite the nessy-internal import paths to the new module. The core
+# imports (github.com/nkane/chippy/cpu, /dap, …) are left untouched —
+# they resolve through the go.mod require added below.
+grep -rl "${CHIPPY_MODULE}/internal/nes" --include='*.go' . \
+  | xargs -r sed -i.bak "s|${CHIPPY_MODULE}/internal/nes|${NESSY_MODULE}/internal/nes|g"
+find . -name '*.bak' -delete
+
+# Fresh go.mod for the nessy module, pinning the chippy core library.
+cat > go.mod <<EOF
+module ${NESSY_MODULE}
+
+go 1.23
+
+require (
+	${CHIPPY_MODULE} ${CHIPPY_VERSION}
+	github.com/hajimehoshi/ebiten/v2 v2.9.9
+)
+EOF
+
+echo
+echo "==> nessy repo staged in $WORKDIR/nessy"
+echo "Next:"
+echo "  cd $WORKDIR/nessy"
+echo "  go mod tidy            # resolve ebiten + transitive deps"
+echo "  go build -tags=nessy ./... && go test -race ./..."
+echo "  git remote add origin git@github.com:nkane/nessy.git"
+echo "  git push -u origin main --tags"


### PR DESCRIPTION
Runnable plan for splitting nessy into \`github.com/nkane/nessy\`, gated on the new repo existing + a chippy library tag to pin. **Staged, not executed** — chippy is unchanged.

## scripts/carve-nessy.sh
Clones chippy → \`git filter-repo\` down to the nessy paths (history preserved) → rewrites \`nessy-vX.Y.Z\` tags to bare \`vX.Y.Z\` → re-points \`internal/nes\` imports to the nessy module → writes the nessy \`go.mod\` pinning the chippy core. Produces a fresh nessy tree to review + push; does NOT mutate chippy.

\`\`\`sh
scripts/carve-nessy.sh v1.1.0 /tmp/nessy-carve
\`\`\`

## docs/repo-split.md
Full procedure: cut chippy library tag → create repo → run script → verify → clean chippy → wire nessy CI. Plus the what-moves-where table + the \`chippy -nessy\` launcher open question.

## Key point
Core imports (\`github.com/nkane/chippy/cpu\` …) need **no** rewrite — already public from #349. Only the \`internal/nes\` paths re-point to \`github.com/nkane/nessy\`.

## Test plan
- [x] \`bash -n\` script syntax clean.
- [x] go.mod ebiten version matches current (v2.9.9).
- [x] mkdocs nav + strict build (repo-split.md under Internals).

Refs #351. The actual carve runs when the nessy repo exists.