### PR TITLE
test(nes/accuracy): add apu_test.nes (4/8 sub-tests PASS) — #318

### DIFF
--- a/cmd/nessy/accuracy_test.go
+++ b/cmd/nessy/accuracy_test.go
@@ -86,6 +86,21 @@ var accuracyROMs = []accuracyROM{
 		pathEnv:   "CHIPPY_ACCURACY_INTERRUPTS_BIN",
 		maxFrames: 2400,
 	},
+	{
+		// Blargg apu_test — 8 sub-tests of APU behavior. After
+		// #376/#377 (NTSC 4-step frame intervals + DMC fetch via
+		// ProcessPendingDma) tests 1-4 pass; test 5 (len_timing)
+		// fails with "Second length of mode 0 is too soon" — a
+		// length-counter timing gap separate from the frame
+		// counter work. Tracked under #318; harness logs the
+		// status + skips so the existing PASS suite stays green.
+		name:      "apu_test.nes",
+		url:       "https://github.com/christopherpow/nes-test-roms/raw/master/apu_test/apu_test.nes",
+		sha:       "00d4722bae1c82a14528dd3220462d3fb9ce4b14b8cec996619dea23e07fef0a",
+		pathEnv:   "CHIPPY_ACCURACY_APU_TEST_BIN",
+		maxFrames: 3000,
+		knownFail: "tests 1-4 (irq_flag, len_ctr, len_table, irq_timing) PASS; test 5 (len_timing) fails — length-counter clock alignment relative to half-frame ticks needs a sub-cycle fix",
+	},
 }
 
 func TestAccuracy(t *testing.T) {


### PR DESCRIPTION
## Why

Roll the next nesdev accuracy ROM into the harness now that the per-cycle APU work landed (#376/#377 — NTSC 4-step frame counter non-uniform intervals + DMC fetch via ProcessPendingDma). Apu_test is the obvious next probe since the recent work targets exactly the timing this ROM measures.

## What

Wire Blargg `apu_test.nes` into `cmd/nessy/accuracy_test.go`. SHA-pinned, env-overridable, downloads on first run like the existing ROMs.

## Result

4 of 8 sub-tests PASS straight away:

- 1-len_ctr ✓
- 2-len_table ✓
- 3-irq_flag ✓
- 4-irq_timing ✓
- **5-len_timing FAIL** — 'Second length of mode 0 is too soon'

Wired as `knownFail` so the harness logs the gap and skips on the failing case; the existing 3 ROMs (ppu_vbl_nmi 10/10, instr_timing, cpu_interrupts_v2 5/5) stay PASS.

## What 5-len_timing wants

Length-counter clock alignment relative to the half-frame ticks. The frame-counter step boundaries land at the right Mesen cycles after #377; the gap is in how the length counter clocks off those boundaries — likely a sub-cycle ordering issue around when the half-frame decrement fires relative to the step boundary itself. Separate fix from the frame interval table.

## Test plan

- `go test -tags=accuracy -run TestAccuracy ./cmd/nessy/...` — 3 ROMs PASS + apu_test SKIP (known gap logged).
- `go test -race -count=1 ./...` clean.
- `golangci-lint run ./...` 0 issues.

Refs #318