### PR TITLE
fix(nes/apu): DMC buffer-fill + enable-fetch + $4015 read — apu_test 6/8 → 7/8

### DIFF
--- a/cmd/nessy/accuracy_test.go
+++ b/cmd/nessy/accuracy_test.go
@@ -99,7 +99,7 @@ var accuracyROMs = []accuracyROM{
 		sha:       "00d4722bae1c82a14528dd3220462d3fb9ce4b14b8cec996619dea23e07fef0a",
 		pathEnv:   "CHIPPY_ACCURACY_APU_TEST_BIN",
 		maxFrames: 3000,
-		knownFail: "tests 1-6 PASS (incl. 5-len_timing after the 6-internal-sub-step frame counter); 7-dmc_basics + 8-dmc_rates fail — DMC accuracy gaps tracked separately",
+		knownFail: "tests 1-7 PASS (incl. 7-dmc_basics after the DMC enable-fetch + $4015 read fixes); 8-dmc_rates fails at sub-test 3 ('Rate 0's period is too long') — DMC fetch decrement timing across multiple bytes needs alignment to Mesen",
 	},
 }
 

--- a/internal/nes/apu/apu.go
+++ b/internal/nes/apu/apu.go
@@ -198,6 +198,7 @@ func New() *APU {
 	a := &APU{
 		pulse2:    pulse2,
 		noise:     noiseChannel{lfsr: 1},
+		dmc:       dmcChannel{bufferEmpty: true, silenced: true},
 		mode4Step: true,
 		// alternateTick starts true so that after the 8-cycle reset
 		// loop's stallTicks the APU's per-cycle parity check at $4017
@@ -410,14 +411,15 @@ func (a *APU) Read(addr uint16) byte {
 	if a.dmc.irqPending {
 		v |= 0x80
 	}
-	// Reading $4015 clears the frame-IRQ flag. DMC IRQ has its own
-	// ack path via dmc.clearIRQ — also fired here per nesdev (one
-	// $4015 read acks both).
+	// Reading $4015 clears the frame-counter IRQ flag only. The DMC
+	// IRQ flag is NOT cleared by a $4015 read — only by a $4015
+	// write (any value) or $4010 write with bit 7 = 0. Mesen2
+	// NesApu.cpp:101 + Blargg apu_test 7-dmc_basics test 10
+	// (#318).
 	a.frameIRQFlag = false
 	if a.irqSink != nil {
 		a.irqSink.ClearIRQSource(frameIRQSource)
 	}
-	a.dmc.clearIRQ(a.irqSink)
 	return v
 }
 
@@ -473,7 +475,7 @@ func (a *APU) Write(addr uint16, v byte) {
 		a.pulse2.setEnabled(v&0x02 != 0)
 		a.triangle.setEnabled(v&0x04 != 0)
 		a.noise.setEnabled(v&0x08 != 0)
-		a.dmc.setEnabled(v&0x10 != 0)
+		a.dmc.setEnabled(v&0x10 != 0, a.dmcStaller)
 		// Writing $4015 also clears the DMC IRQ flag (per nesdev).
 		a.dmc.clearIRQ(a.irqSink)
 	}

--- a/internal/nes/apu/dmc.go
+++ b/internal/nes/apu/dmc.go
@@ -109,12 +109,25 @@ func (d *dmcChannel) writeReg3(v byte) {
 // length IF bytes-remaining is currently zero (per nesdev — avoids
 // restarting a sample mid-play). Disabling clears bytes-remaining
 // + the IRQ flag; output level + sample buffer survive.
-func (d *dmcChannel) setEnabled(on bool) {
+//
+// When enabling with the sample buffer empty + bytesRemaining > 0
+// after reload, immediately flag a DMA fetch via the CPU sink.
+// Mesen2 DeltaModulationChannel::SetEnabled delays this by 2-3 CPU
+// cycles depending on cycle parity; chippy fires inline since the
+// CPU's ProcessPendingDma drains on the next bus read regardless
+// and Blargg apu_test 7-dmc_basics test 19 cares only that the
+// fetch happens before the user-visible $4015 poll a few dozen
+// cycles later (#318).
+func (d *dmcChannel) setEnabled(on bool, staller DMCStaller) {
 	d.enabled = on
 	if on {
 		if d.bytesRemaining == 0 {
 			d.currentAddr = d.sampleAddrBase
 			d.bytesRemaining = d.sampleLenBase
+		}
+		if d.bytesRemaining > 0 && d.bufferEmpty && staller != nil && !d.fetchPending {
+			d.fetchPending = true
+			staller.SetNeedDmcDma()
 		}
 	} else {
 		d.bytesRemaining = 0
@@ -157,25 +170,37 @@ func (d *dmcChannel) clockShift() {
 	d.bitsRemaining--
 }
 
-// maybeRefill restocks the shift register from the sample buffer
-// when the 8-bit unit is exhausted. If the buffer is empty and the
-// sample pointer still has bytes to fetch, signal the CPU's DMA
-// state machine (#376 Phase 2C); ProcessPendingDma drains the
-// 4-cycle (or 6 under contention) bus-steal on the next opcode
-// fetch and pushes the byte back through APU.SetDmcReadBuffer.
+// maybeRefill is two real-silicon ops fused: (1) the output unit
+// reloads the shift register from the sample buffer when the 8-bit
+// unit is exhausted, and (2) the memory reader queues a DMA refill
+// when the sample buffer is empty + the byte counter still has
+// bytes. Either or both can fire on a single call; an empty buffer
+// only silences the channel when the byte counter is also zero
+// (otherwise the fetch we just queued will refill it).
+//
+// (#376 Phase 2C) The fetch path doesn't read directly — it sets
+// fetchPending + calls cpu.SetNeedDmcDma; ProcessPendingDma drains
+// the 4-cycle (or 6 under contention) bus-steal on the next CPU
+// read and pushes the byte back through APU.SetDmcReadBuffer.
 func (d *dmcChannel) maybeRefill(_ DMCBus, staller DMCStaller, _ IRQSink) {
 	if d.bitsRemaining != 0 {
 		return
 	}
-	if d.bufferEmpty {
+	// Output unit: reload shifter from buffer if anything's there.
+	if !d.bufferEmpty {
+		d.silenced = false
+		d.shiftRegister = d.sampleBuffer
+		d.bufferEmpty = true
+		d.bitsRemaining = 8
+	} else if d.bytesRemaining == 0 {
+		// Buffer empty + no more bytes — silence.
 		d.silenced = true
-		return
 	}
-	d.silenced = false
-	d.shiftRegister = d.sampleBuffer
-	d.bufferEmpty = true
-	d.bitsRemaining = 8
-
+	// Memory reader: queue a DMA refill if the buffer is empty +
+	// the byte counter is still alive. The bufferEmpty check above
+	// always leaves it true at this point (either the reload set
+	// it, or it was already true). Skip if a fetch is already in
+	// flight (the channel pending one byte at a time).
 	if d.bytesRemaining > 0 && staller != nil && !d.fetchPending {
 		d.fetchPending = true
 		staller.SetNeedDmcDma()

--- a/internal/nes/apu/dmc_test.go
+++ b/internal/nes/apu/dmc_test.go
@@ -186,14 +186,15 @@ func TestDMC_LoopReloadsOnExhaustion(t *testing.T) {
 	}
 }
 
-// $4015 read clears the pending DMC IRQ flag + drops the sink
-// assertion.
-func TestDMC_Read4015ClearsDMCIRQ(t *testing.T) {
+// $4015 read surfaces the DMC IRQ flag in bit 7 but does NOT clear
+// it — per nesdev + Mesen2 NesApu.cpp:101. Only $4015 write (any
+// value) or $4010 write with bit 7 clear acks DMC IRQ. Blargg
+// apu_test 7-dmc_basics test 10 pins this.
+func TestDMC_Read4015DoesNotClearDMCIRQ(t *testing.T) {
 	a := New()
 	s := NewStatus(a)
 	sink := newFakeSink()
 	a.SetIRQSink(sink)
-	// Force IRQ-pending state directly (skip the full DMA dance).
 	a.dmc.irqPending = true
 	sink.AssertIRQSource(dmcIRQSource)
 
@@ -201,11 +202,11 @@ func TestDMC_Read4015ClearsDMCIRQ(t *testing.T) {
 	if v&0x80 == 0 {
 		t.Errorf("$4015 read = $%02X; want bit 7 set", v)
 	}
-	if a.dmc.irqPending {
-		t.Errorf("$4015 read didn't clear DMC IRQ flag")
+	if !a.dmc.irqPending {
+		t.Errorf("$4015 read cleared DMC IRQ flag; want it to stay")
 	}
-	if sink.cleared[dmcIRQSource] == 0 {
-		t.Errorf("$4015 read didn't ClearIRQSource(dmc)")
+	if sink.cleared[dmcIRQSource] != 0 {
+		t.Errorf("$4015 read called ClearIRQSource(dmc); want no clear")
 	}
 }
 


### PR DESCRIPTION
## Why

Blargg `apu_test` 7-dmc_basics exposed three real-silicon DMC behaviors chippy was getting wrong. All three matter for any ROM that uses DMC (post-#377 the DMA path is correct, but the channel-side handling was off).

## Three fixes

### 1. `maybeRefill` shouldn't silence when bytesRemaining > 0

Real silicon (Mesen `DeltaModulationChannel`): when the sample buffer empties + the byte counter still has bytes, schedule a DMA fetch. **Only** go silent when BOTH buffer and byte counter are exhausted.

chippy's old behavior: any time `bufferEmpty=true` at the 8-bit boundary → silenced. That left the channel mute after a brief disable+re-enable sequence even with a valid sample queued.

Fix: split the function so the output-unit reload and the memory-reader schedule are independent. Silence only fires on `bufferEmpty=true && bytesRemaining==0`.

### 2. Enabling DMC didn't schedule the initial fetch

Mesen's `SetEnabled` schedules a fetch with a 2-3 CPU cycle `transferStartDelay`. chippy waited for the next timer tick (up to 428 cycles for rate 0) before firing the fetch.

Fix: `setEnabled(on, staller)` now calls `SetNeedDmcDma` inline if the buffer is empty after the `InitSample` reload. CPU's `ProcessPendingDma` drains on the next bus access regardless of the small delay difference. Matters for Blargg test 19's 30-cycle poll window.

### 3. `$4015` read was clearing the DMC IRQ flag

Per nesdev + Mesen `NesApu.cpp:101`, `$4015` read clears **only** the frame counter IRQ. DMC IRQ is cleared by `$4015` write (any value) or `$4010` write with bit 7 = 0.

chippy was calling `dmc.clearIRQ` on read. Blargg test 10 ('Reading IRQ flag shouldn't clear it') was failing.

### Bonus: DMC init state

`dmcChannel` now initialises with `bufferEmpty=true` + `silenced=true` so the first enable triggers the proper fetch-on-empty path instead of consuming 8 cycles of garbage from the zero-valued buffer.

## Result

`apu_test.nes`:

| Sub-test | Before | After |
|---|---|---|
| 1-6 | PASS | PASS |
| **7-dmc_basics** (18 sub-tests) | **FAIL #2** | **PASS** |
| 8-dmc_rates | (gated) | FAIL #3 ('Rate 0's period is too long' — DMC fetch decrement timing across multiple bytes) |

**Score: 6/8 → 7/8.**

## No regression

- ppu_vbl_nmi 10/10 ✓
- instr_timing PASS ✓
- cpu_interrupts_v2 5/5 ✓
- All APU unit tests green ✓

`TestDMC_Read4015ClearsDMCIRQ` → `TestDMC_Read4015DoesNotClearDMCIRQ` (inverted assertion matching real silicon).

## Test plan

- `go test -tags=accuracy ./cmd/nessy/...` — 3 ROMs PASS + apu_test SKIP with 7/8 logged.
- `go test -race -count=1 ./...` clean.
- `golangci-lint run ./...` 0 issues.

Refs #318