### PR TITLE
fix(nes/apu): Mesen-aligned DMC Clock — apu_test 7/8 → 8/8 PASS

### DIFF
--- a/cmd/nessy/accuracy_test.go
+++ b/cmd/nessy/accuracy_test.go
@@ -87,19 +87,16 @@ var accuracyROMs = []accuracyROM{
 		maxFrames: 2400,
 	},
 	{
-		// Blargg apu_test — 8 sub-tests of APU behavior. After
-		// #376/#377 (NTSC 4-step frame intervals + DMC fetch via
-		// ProcessPendingDma) tests 1-4 pass; test 5 (len_timing)
-		// fails with "Second length of mode 0 is too soon" — a
-		// length-counter timing gap separate from the frame
-		// counter work. Tracked under #318; harness logs the
-		// status + skips so the existing PASS suite stays green.
+		// Blargg apu_test — 8 sub-tests of APU behavior (len_ctr,
+		// len_table, irq_flag, irq_timing, len_timing, irq_flag_
+		// timing, dmc_basics, dmc_rates). Full 8/8 PASS after the
+		// 6-substep frame counter (#380), DMC enable-fetch + $4015
+		// read (#381), and Mesen-aligned DMC Clock pattern.
 		name:      "apu_test.nes",
 		url:       "https://github.com/christopherpow/nes-test-roms/raw/master/apu_test/apu_test.nes",
 		sha:       "00d4722bae1c82a14528dd3220462d3fb9ce4b14b8cec996619dea23e07fef0a",
 		pathEnv:   "CHIPPY_ACCURACY_APU_TEST_BIN",
 		maxFrames: 3000,
-		knownFail: "tests 1-7 PASS (incl. 7-dmc_basics after the DMC enable-fetch + $4015 read fixes); 8-dmc_rates fails at sub-test 3 ('Rate 0's period is too long') — DMC fetch decrement timing across multiple bytes needs alignment to Mesen",
 	},
 }
 

--- a/internal/nes/apu/apu.go
+++ b/internal/nes/apu/apu.go
@@ -198,7 +198,7 @@ func New() *APU {
 	a := &APU{
 		pulse2:    pulse2,
 		noise:     noiseChannel{lfsr: 1},
-		dmc:       dmcChannel{bufferEmpty: true, silenced: true},
+		dmc:       dmcChannel{bufferEmpty: true, silenced: true, bitsRemaining: 8},
 		mode4Step: true,
 		// alternateTick starts true so that after the 8-cycle reset
 		// loop's stallTicks the APU's per-cycle parity check at $4017

--- a/internal/nes/apu/dmc.go
+++ b/internal/nes/apu/dmc.go
@@ -125,6 +125,11 @@ func (d *dmcChannel) setEnabled(on bool, staller DMCStaller) {
 			d.currentAddr = d.sampleAddrBase
 			d.bytesRemaining = d.sampleLenBase
 		}
+		// Schedule a fetch immediately if the buffer is empty +
+		// bytes are pending (Mesen StartDmcTransfer condition). The
+		// existing leftover byte in the buffer plays out first if
+		// bufferEmpty is false; no fetch scheduled until that byte
+		// has been clocked through.
 		if d.bytesRemaining > 0 && d.bufferEmpty && staller != nil && !d.fetchPending {
 			d.fetchPending = true
 			staller.SetNeedDmcDma()
@@ -134,74 +139,62 @@ func (d *dmcChannel) setEnabled(on bool, staller DMCStaller) {
 	}
 }
 
-// tickTimer drops the period timer by one CPU cycle. When it
-// underflows it clocks one shift bit and (if the sample buffer is
-// empty + bytes-remaining > 0) requests a DMA refill via the
-// caller-supplied stall + bus.
-func (d *dmcChannel) tickTimer(bus DMCBus, staller DMCStaller, irqSink IRQSink) {
-	period := dmcRateLUT[d.rateIdx]
+// tickTimer drops the period timer by one CPU cycle. When the
+// timer underflows the clock fires (Mesen2 DeltaModulationChannel
+// ::Run/Clock). bitsRemaining=8 invariant (init in APU.New) +
+// always-shift semantics in clock() mean 8 clocks per byte exactly,
+// no extra "reload-only" cycle — matches Mesen's 17-byte sample at
+// rate 0 = 17*8*428 cycles total.
+func (d *dmcChannel) tickTimer(_ DMCBus, staller DMCStaller, _ IRQSink) {
 	if d.timer == 0 {
-		d.timer = period
-		d.clockShift()
-		d.maybeRefill(bus, staller, irqSink)
+		// Reload to period-1 so fire-to-fire = period CPU cycles
+		// exactly, matching Mesen2 ApuTimer::Run (which advances by
+		// `_timer + 1` per fire with period stored as rate-1).
+		d.timer = dmcRateLUT[d.rateIdx] - 1
+		d.clock(staller)
 		return
 	}
 	d.timer--
 }
 
-// clockShift moves one bit out of the shift register and adjusts
-// the output level. Real silicon's bit-counter loads from
-// sampleBuffer when bitsRemaining hits zero; v0.3 keeps the model
-// simple by loading at the top of the unit (every 8 bits).
-func (d *dmcChannel) clockShift() {
-	if d.silenced || d.bitsRemaining == 0 {
-		return
-	}
-	if d.shiftRegister&1 == 1 {
-		if d.output <= 125 {
-			d.output += 2
-		}
-	} else {
-		if d.output >= 2 {
-			d.output -= 2
-		}
-	}
-	d.shiftRegister >>= 1
-	d.bitsRemaining--
-}
-
-// maybeRefill is two real-silicon ops fused: (1) the output unit
-// reloads the shift register from the sample buffer when the 8-bit
-// unit is exhausted, and (2) the memory reader queues a DMA refill
-// when the sample buffer is empty + the byte counter still has
-// bytes. Either or both can fire on a single call; an empty buffer
-// only silences the channel when the byte counter is also zero
-// (otherwise the fetch we just queued will refill it).
+// clock is one DMC output unit tick. Mirrors Mesen2 Delta
+// ModulationChannel::Run inner body:
 //
-// (#376 Phase 2C) The fetch path doesn't read directly — it sets
-// fetchPending + calls cpu.SetNeedDmcDma; ProcessPendingDma drains
-// the 4-cycle (or 6 under contention) bus-steal on the next CPU
-// read and pushes the byte back through APU.SetDmcReadBuffer.
-func (d *dmcChannel) maybeRefill(_ DMCBus, staller DMCStaller, _ IRQSink) {
-	if d.bitsRemaining != 0 {
-		return
+//  1. If not silenced: emit a bit (adjust output level ±2, shift
+//     shift-register one place).
+//  2. Always decrement bitsRemaining.
+//  3. If bitsRemaining == 0: reset to 8 + reload shifter from
+//     sample buffer (or silence if buffer is empty).
+//  4. Schedule a DMA fetch if the buffer is empty + bytes remain.
+//
+// The fetch-schedule check runs every clock, not just at unit
+// boundaries, so the memory reader is responsive to mid-byte
+// disable/re-enable sequences without burning extra timer cycles.
+func (d *dmcChannel) clock(staller DMCStaller) {
+	if !d.silenced {
+		if d.shiftRegister&1 == 1 {
+			if d.output <= 125 {
+				d.output += 2
+			}
+		} else {
+			if d.output >= 2 {
+				d.output -= 2
+			}
+		}
+		d.shiftRegister >>= 1
 	}
-	// Output unit: reload shifter from buffer if anything's there.
-	if !d.bufferEmpty {
-		d.silenced = false
-		d.shiftRegister = d.sampleBuffer
-		d.bufferEmpty = true
+	d.bitsRemaining--
+	if d.bitsRemaining == 0 {
 		d.bitsRemaining = 8
-	} else if d.bytesRemaining == 0 {
-		// Buffer empty + no more bytes — silence.
-		d.silenced = true
+		if d.bufferEmpty {
+			d.silenced = true
+		} else {
+			d.silenced = false
+			d.shiftRegister = d.sampleBuffer
+			d.bufferEmpty = true
+		}
 	}
-	// Memory reader: queue a DMA refill if the buffer is empty +
-	// the byte counter is still alive. The bufferEmpty check above
-	// always leaves it true at this point (either the reload set
-	// it, or it was already true). Skip if a fetch is already in
-	// flight (the channel pending one byte at a time).
-	if d.bytesRemaining > 0 && staller != nil && !d.fetchPending {
+	if d.bufferEmpty && d.bytesRemaining > 0 && staller != nil && !d.fetchPending {
 		d.fetchPending = true
 		staller.SetNeedDmcDma()
 	}


### PR DESCRIPTION
## Why

User asked to address the DMC accuracy gap. Re-checked Mesen2 `DeltaModulationChannel::Run` against chippy's clocking loop and found three structural mismatches that compounded to make chippy's 17-byte sample at rate 0 take ~65k cycles instead of the spec'd 58208 (= 17×8×428).

## Three structural fixes

### 1. Drop the wasted 'reload-only' fire per byte

Old `tickTimer` called `clockShift` (early-returned on `bitsRemaining=0`) then `maybeRefill` (loaded shifter + set `bitsRemaining=8`). Each byte burned **9 timer fires**: 1 load + 8 shifts.

Mesen does 8 fires per byte: each `Clock` shifts unconditionally + decrements + maybe-reloads at the bit-counter boundary.

Replaced `clockShift` + `maybeRefill` with a unified `clock()` that mirrors Mesen `Run`'s inner body. Initialise `bitsRemaining=8` (matching Mesen `Reset` line 36) so the first fire shifts immediately rather than wasting on a load.

### 2. Off-by-1 timer period

Old reload set `d.timer = dmcRateLUT[rateIdx]` (= 428 for rate 0). With my decrement-then-check loop that meant fire-to-fire = **429 cycles**.

Mesen sets `_period = rateTable[0] - 1` (= 427) and `Run` advances by `_timer + 1` per fire, ending at exactly **428**.

Reload to `period - 1` matches.

### 3. Fetch-schedule runs every clock, not just at boundaries

The buffer-empty + bytes-remaining check now fires after every `clock`. CPU's `ProcessPendingDma` drains on the next bus read. Responsive to mid-byte disable/re-enable sequences without burning extra timer cycles.

## Result

| ROM | Before | After |
|---|---|---|
| 1-len_ctr | PASS | PASS |
| 2-len_table | PASS | PASS |
| 3-irq_flag | PASS | PASS |
| 4-irq_timing | PASS | PASS |
| 5-len_timing | PASS | PASS |
| 6-irq_flag_timing | PASS | PASS |
| 7-dmc_basics | PASS | PASS |
| **8-dmc_rates** | **FAIL #3 ('Rate 0 too long')** | **PASS** (all 16 rates × 2 boundary checks) |

**apu_test.nes: 7/8 → 8/8.** `knownFail` cleared.

## No regression

- ppu_vbl_nmi 10/10 ✓
- instr_timing PASS ✓
- cpu_interrupts_v2 5/5 ✓
- All APU unit tests green ✓

## Test plan

- `go test -tags=accuracy ./cmd/nessy/...` — **all 4 ROMs PASS**.
- `go test -race -count=1 ./...` clean.
- `golangci-lint run ./...` 0 issues.

Refs #318