### PR TITLE
test(nes/accuracy): add instr_misc.nes (4/4 PASS) — #318

### DIFF
--- a/cmd/nessy/accuracy_test.go
+++ b/cmd/nessy/accuracy_test.go
@@ -98,6 +98,19 @@ var accuracyROMs = []accuracyROM{
 		pathEnv:   "CHIPPY_ACCURACY_APU_TEST_BIN",
 		maxFrames: 3000,
 	},
+	{
+		// Blargg instr_misc — 4 sub-tests: abs_x_wrap (LDA absX
+		// wrapping past $FFFF), branch_wrap (branches wrapping
+		// past $FFFF), dummy_reads (addressing-mode dummy reads
+		// land on the right bus address), dummy_reads_apu (ditto
+		// for APU register addresses, exercises bus-side reads
+		// against side-effecting registers).
+		name:      "instr_misc.nes",
+		url:       "https://github.com/christopherpow/nes-test-roms/raw/master/instr_misc/instr_misc.nes",
+		sha:       "b6762e20a285216304dfd2b5e1f192459354b23a5e48b2f5f9fb7cb0dac51243",
+		pathEnv:   "CHIPPY_ACCURACY_INSTR_MISC_BIN",
+		maxFrames: 3000,
+	},
 }
 
 func TestAccuracy(t *testing.T) {


### PR DESCRIPTION
Wire Blargg `instr_misc.nes` into the accuracy harness. Full 4/4 PASS straight away on the cycle-accurate core:

| Sub-test | Result |
|---|---|
| 1-abs_x_wrap | PASS |
| 2-branch_wrap | PASS |
| 3-dummy_reads | PASS |
| 4-dummy_reads_apu | PASS |

These all clear because the per-cycle interleave (#342, #372, #377) routes every addressing mode's dummy cycles through the `addrDummies` template — nothing chippy-specific to fix.

Harness now tracks 5 ROMs, all green: ppu_vbl_nmi 10/10, instr_timing, cpu_interrupts_v2 5/5, apu_test 8/8, instr_misc 4/4.

## Test plan

- `go test -tags=accuracy ./cmd/nessy/...` — all 5 ROMs PASS.
- `go test -race -count=1 ./...` clean.
- `golangci-lint run ./...` 0 issues.

Refs #318