### PR TITLE
feat(tui, dap): forward bp conditions over DAP + BP-modal `c` keybind

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -893,14 +893,19 @@ func (m *Model) syncSourceBreakpoints() {
 	if m.Source == nil {
 		return
 	}
-	pcs := make([]uint16, 0, len(m.Breakpoints))
+	bps := make([]SourceBP, 0, len(m.Breakpoints))
 	for pc, bp := range m.Breakpoints {
-		if bp == nil || !bp.Enabled {
+		if bp == nil || !bp.Enabled || bp.Rejected {
 			continue
 		}
-		pcs = append(pcs, pc)
+		bps = append(bps, SourceBP{
+			PC:       pc,
+			Cond:     bp.Cond,
+			HitLimit: bp.HitLimit,
+			Log:      bp.Log,
+		})
 	}
-	_ = m.Source.SetBreakpoints(pcs)
+	_ = m.Source.SetBreakpoints(bps)
 }
 
 // statusAfterStep updates Status reflecting halt or normal stepping outcome.
@@ -1097,6 +1102,20 @@ func (m Model) updateBPManager(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			if bp := m.Breakpoints[bps[m.BPCursor]]; bp != nil {
 				bp.Enabled = !bp.Enabled
 				m.saveState()
+			}
+		}
+	case "c":
+		// Edit / clear the conditional expression on the selected bp.
+		// Opens the prompt pre-populated with `:bp $XXXX if <existing>`;
+		// user finishes the line + enter. To clear, leave nothing after
+		// `if`.
+		if m.BPCursor < len(bps) {
+			addr := bps[m.BPCursor]
+			if bp := m.Breakpoints[addr]; bp != nil {
+				m.ShowBPs = false
+				m.PromptActive = true
+				m.PromptBuf = fmt.Sprintf("bp $%04X if %s", addr, bp.Cond)
+				m.Status = "edit cond — enter to commit"
 			}
 		}
 	case "enter":
@@ -1523,7 +1542,7 @@ func (m Model) bpModal() string {
 		}
 		b.WriteString("\n")
 	}
-	b.WriteString(help.Render("  j/k move  d delete  e enable/disable  enter set PC  esc close"))
+	b.WriteString(help.Render("  j/k move  d delete  e enable/disable  c edit cond  enter set PC  esc close"))
 	return lipgloss.NewStyle().
 		Border(lipgloss.DoubleBorder()).
 		BorderForeground(lipgloss.Color("196")).

--- a/internal/tui/source.go
+++ b/internal/tui/source.go
@@ -51,12 +51,15 @@ type Source interface {
 	// DAP `pause`.
 	Pause() error
 
-	// SetBreakpoints (re)installs the active set of PC breakpoints
-	// on the source. LocalSource records them so its Step can break;
-	// RemoteSource forwards via DAP `setInstructionBreakpoints`.
+	// SetBreakpoints (re)installs the active breakpoint set on the
+	// source. LocalSource only needs the PCs (conditions evaluate
+	// inside the TUI's run loop against the live CPU). RemoteSource
+	// forwards via DAP `setInstructionBreakpoints` with the optional
+	// `condition` field so the server can short-circuit non-matching
+	// hits without a TUI round-trip.
 	// Called whenever the TUI's `m.Breakpoints` map mutates so the
 	// remote stays in sync.
-	SetBreakpoints(pcs []uint16) error
+	SetBreakpoints(bps []SourceBP) error
 
 	// Attached reports whether this is a remote (DAP-backed) source.
 	// Used by the status bar and to gate features that don't work
@@ -145,7 +148,19 @@ func (s *LocalSource) Pause() error { return nil }
 // run loop via `shouldBreakAt`. The interface still requires the
 // method so RemoteSource can forward the same list to the remote
 // server.
-func (s *LocalSource) SetBreakpoints(pcs []uint16) error { return nil }
+func (s *LocalSource) SetBreakpoints(bps []SourceBP) error { return nil }
+
+// SourceBP is the wire shape Source.SetBreakpoints uses. PC is the
+// instruction address; Cond is the raw expression string ("" =
+// unconditional); HitLimit mirrors Breakpoint.HitLimit (0 unlimited,
+// >0 break on/after Nth hit, -1 one-shot); Log is the log-point
+// message ("" = pause-style bp).
+type SourceBP struct {
+	PC       uint16
+	Cond     string
+	HitLimit int
+	Log      string
+}
 
 // Attached returns false for LocalSource.
 func (s *LocalSource) Attached() bool { return false }

--- a/internal/tui/source_remote.go
+++ b/internal/tui/source_remote.go
@@ -154,18 +154,36 @@ func (s *RemoteSource) Pause() error {
 	return err
 }
 
-// SetBreakpoints (re)installs the active PC breakpoint set on the
+// SetBreakpoints (re)installs the active breakpoint set on the
 // server via `setInstructionBreakpoints`. Sends the full list each
-// time — the server treats every call as authoritative.
-func (s *RemoteSource) SetBreakpoints(pcs []uint16) error {
+// time — the server treats every call as authoritative. Forwards
+// the optional DAP `condition`, `hitCondition`, and `logMessage`
+// fields so a conditional / log / one-shot bp set in the local TUI
+// also short-circuits on the remote server.
+func (s *RemoteSource) SetBreakpoints(bps []SourceBP) error {
 	type instBP struct {
 		InstructionReference string `json:"instructionReference"`
+		Condition            string `json:"condition,omitempty"`
+		HitCondition         string `json:"hitCondition,omitempty"`
+		LogMessage           string `json:"logMessage,omitempty"`
 	}
-	bps := make([]instBP, 0, len(pcs))
-	for _, pc := range pcs {
-		bps = append(bps, instBP{InstructionReference: fmt.Sprintf("$%04X", pc)})
+	wire := make([]instBP, 0, len(bps))
+	for _, b := range bps {
+		var hit string
+		switch {
+		case b.HitLimit > 0:
+			hit = fmt.Sprintf("%d", b.HitLimit)
+		case b.HitLimit == -1:
+			hit = "1" // one-shot: break on first hit
+		}
+		wire = append(wire, instBP{
+			InstructionReference: fmt.Sprintf("$%04X", b.PC),
+			Condition:            b.Cond,
+			HitCondition:         hit,
+			LogMessage:           b.Log,
+		})
 	}
-	args := map[string]any{"breakpoints": bps}
+	args := map[string]any{"breakpoints": wire}
 	_, err := s.client.Request("setInstructionBreakpoints", args)
 	return err
 }

--- a/internal/tui/source_remote_test.go
+++ b/internal/tui/source_remote_test.go
@@ -117,7 +117,12 @@ func TestRemoteSource_SetBreakpoints_NoError(t *testing.T) {
 	src := NewRemoteSource(client, mirrorCPU, mirrorRAM, "tcp:test")
 	defer func() { _ = src.Close() }()
 
-	if err := src.SetBreakpoints([]uint16{0xC005, 0xC100}); err != nil {
+	if err := src.SetBreakpoints([]SourceBP{
+		{PC: 0xC005},
+		{PC: 0xC100, Cond: "A == $42"},
+		{PC: 0xC200, HitLimit: -1}, // one-shot
+		{PC: 0xC300, Log: "hit pc"},
+	}); err != nil {
 		t.Errorf("SetBreakpoints: %v", err)
 	}
 }


### PR DESCRIPTION
Closes #388. Investigation into the issue scope found chippy already had:

- `:bp X if EXPR` syntax (`internal/tui/bp.go`).
- `Breakpoint.Cond` field + compiled `condFn`.
- Hit-count gating that respects cond (cond-fail doesn't bump the hit counter).
- BP manager modal `🔶` sigil for conditional.
- JSON persistence + reload-time recompile (`internal/tui/state.go`).
- DAP server `setInstructionBreakpoints` honouring `condition` field (`dap/bpmeta_test.go`).
- Help modal documents the syntax.

What was actually missing:

## 1. RemoteSource didn't forward conditions

When the chippy TUI was a DAP client (`chippy -dap-attach` to a remote nessy / chippy / arbitrary DAP target), `Source.SetBreakpoints` shipped only `[]uint16`. The remote treated every bp as unconditional.

Changed the interface to `SetBreakpoints([]SourceBP) error` where `SourceBP` carries `PC + Cond + HitLimit + Log`. `RemoteSource` maps these to DAP `setInstructionBreakpoints`'s `condition` + `hitCondition` + `logMessage` fields. `LocalSource` still no-ops (TUI's `m.Breakpoints` map is the source of truth for the in-process run loop).

`HitLimit` mapping:
- `> 0` → `hitCondition = "N"` (break on Nth hit).
- `-1` (one-shot) → `hitCondition = "1"` (break on first hit).
- `0` (unlimited) → omitted.

## 2. BP-manager modal had no edit-cond keybind

Added `c`: pre-populates the prompt with `bp $XXXX if <existing>` so the user finishes the line and `enter` commits. To clear the cond, leave nothing after `if`. Help modal footer updated.

## Test plan

- `go build ./...` clean.
- `go test -race -count=1 ./...` all green (incl. updated `TestRemoteSource_SetBreakpoints_NoError` exercising cond + hit + log fields).
- `golangci-lint run ./...` 0 issues.

## No regression

- LocalSource path unchanged (still no-ops).
- All existing bp tests pass.

Refs #396 (v1.3.0 epic).