### PR TITLE
feat(tui): :mem command + memory writes go through the bus

### DIFF
--- a/internal/tui/complete.go
+++ b/internal/tui/complete.go
@@ -21,6 +21,7 @@ var defaultVerbs = func() []string {
 		"bp", "bpr", "bpw", "bprw",
 		"rmbpr", "rmbpw", "rmbprw",
 		"syms", "symbols",
+		"mem",
 		"trace",
 		"textsave",
 		"theme",

--- a/internal/tui/mem_cmd_test.go
+++ b/internal/tui/mem_cmd_test.go
@@ -1,0 +1,74 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nkane/chippy/cpu"
+)
+
+func newMemCmdModel() Model {
+	ram := cpu.NewRAM()
+	c := cpu.New(ram)
+	return New(c, ram)
+}
+
+func TestCmdMem_SingleByte(t *testing.T) {
+	m := newMemCmdModel()
+	got := m.cmdMem([]string{"$0200", "$42"})
+	if !strings.Contains(got, "$0200") || !strings.Contains(got, "$42") {
+		t.Fatalf("status: %q", got)
+	}
+	if v := m.RAM.Read(0x0200); v != 0x42 {
+		t.Errorf("RAM[$0200] = $%02X; want $42", v)
+	}
+}
+
+func TestCmdMem_MultiBytes(t *testing.T) {
+	m := newMemCmdModel()
+	if got := m.cmdMem([]string{"$0300", "41", "42", "43"}); !strings.Contains(got, "3 bytes") {
+		t.Fatalf("status: %q", got)
+	}
+	for i, want := range []byte{41, 42, 43} {
+		if v := m.RAM.Read(uint16(0x0300 + i)); v != want {
+			t.Errorf("RAM[$%04X] = $%02X; want $%02X", 0x0300+i, v, want)
+		}
+	}
+}
+
+func TestCmdMem_HexValues(t *testing.T) {
+	m := newMemCmdModel()
+	m.cmdMem([]string{"$0400", "$FF", "0xAB", "127"})
+	for i, want := range []byte{0xFF, 0xAB, 127} {
+		if v := m.RAM.Read(uint16(0x0400 + i)); v != want {
+			t.Errorf("RAM[$%04X] = $%02X; want $%02X", 0x0400+i, v, want)
+		}
+	}
+}
+
+func TestCmdMem_BadByte(t *testing.T) {
+	m := newMemCmdModel()
+	got := m.cmdMem([]string{"$0500", "$100"}) // exceeds byte range
+	if !strings.Contains(strings.ToLower(got), "byte range") {
+		t.Errorf("expected byte-range error, got %q", got)
+	}
+	if v := m.RAM.Read(0x0500); v != 0x00 {
+		t.Errorf("RAM[$0500] = $%02X; want 0 (no partial write on error)", v)
+	}
+}
+
+func TestCmdMem_Usage(t *testing.T) {
+	m := newMemCmdModel()
+	got := m.cmdMem([]string{"$0600"}) // missing value
+	if !strings.Contains(strings.ToLower(got), "usage") {
+		t.Errorf("expected usage, got %q", got)
+	}
+}
+
+func TestCmdMem_BadAddr(t *testing.T) {
+	m := newMemCmdModel()
+	got := m.cmdMem([]string{"NOSUCH", "$42"})
+	if got == "" || strings.HasPrefix(got, "$") {
+		t.Errorf("expected error string, got %q", got)
+	}
+}

--- a/internal/tui/memedit.go
+++ b/internal/tui/memedit.go
@@ -50,7 +50,7 @@ func (m *Model) handleMemEditKey(s string) memEditResult {
 			m.MemEditBuf = ""
 			return memEditCancelled
 		}
-		m.RAM.Write(m.MemCursor, byte(v))
+		m.memWrite(m.MemCursor, byte(v))
 		m.Status = fmt.Sprintf("$%04X <- $%02X", m.MemCursor, byte(v))
 		m.MemEditing = false
 		m.MemEditBuf = ""

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1357,6 +1357,7 @@ func helpPages() [][]helpSection {
 				{"← →", "move byte cursor ±1"},
 				{"↑ ↓", "move byte cursor ±$10 (auto-scrolls)"},
 				{"e", "edit byte at cursor (hex; enter=commit esc=cancel)"},
+				{":mem $ADDR V [V...]", "write hex bytes via the bus (MMIO + watches fire)"},
 			}},
 			{"Disassembly / Source", [][2]string{
 				{"[ / ]", "scroll one line/instruction up/down (active panel)"},

--- a/internal/tui/prompt.go
+++ b/internal/tui/prompt.go
@@ -394,6 +394,8 @@ func (m *Model) runCommand(line string) string {
 		delete(m.MemBPs, addr)
 		m.saveState()
 		return fmt.Sprintf("mem bp -$%04X", addr)
+	case "mem":
+		return m.cmdMem(args)
 	case "trace":
 		return m.cmdTrace(args)
 	case "textsave":
@@ -415,6 +417,78 @@ func (m *Model) runCommand(line string) string {
 // `off`, or a bare `PATH` (shorthand for `on PATH`). Setting a path opens
 // a fresh file (truncating any existing) and the tracer keeps its
 // enabled/disabled state until Enable/Disable is called.
+// cmdMem implements `:mem ADDR VALUE [VALUE...]` — writes hex bytes
+// starting at ADDR via the CPU's bus so any MMIO peripheral / WBus
+// watch side effects fire (matches the `STA $XXXX` codepath).
+//
+//	:mem $0200 41 42 43        → "ABC" at $0200..$0202
+//	:mem main 00               → zero the byte at symbol `main`
+func (m *Model) cmdMem(args []string) string {
+	if len(args) < 2 {
+		return "usage: :mem $ADDR VALUE [VALUE...]"
+	}
+	addr, err := m.parseAddrSym(args[0])
+	if err != nil {
+		return err.Error()
+	}
+	values := make([]byte, 0, len(args)-1)
+	for _, raw := range args[1:] {
+		v, err := parseByte(raw)
+		if err != nil {
+			return fmt.Sprintf("bad byte %q: %v", raw, err)
+		}
+		values = append(values, v)
+	}
+	for i, v := range values {
+		dst := addr + uint16(i)
+		m.memWrite(dst, v)
+	}
+	m.saveState()
+	if len(values) == 1 {
+		return fmt.Sprintf("$%04X <- $%02X", addr, values[0])
+	}
+	return fmt.Sprintf("$%04X..$%04X <- %d bytes", addr, addr+uint16(len(values)-1), len(values))
+}
+
+// parseByte accepts $XX / 0xXX / decimal 0-255. Returns an error on
+// out-of-range so users can't accidentally write a 16-bit value.
+func parseByte(s string) (byte, error) {
+	var v uint64
+	var err error
+	switch {
+	case strings.HasPrefix(s, "$"):
+		v, err = strconv.ParseUint(s[1:], 16, 16)
+	case strings.HasPrefix(s, "0x"), strings.HasPrefix(s, "0X"):
+		v, err = strconv.ParseUint(s[2:], 16, 16)
+	default:
+		v, err = strconv.ParseUint(s, 10, 16)
+	}
+	if err != nil {
+		return 0, err
+	}
+	if v > 0xFF {
+		return 0, fmt.Errorf("value $%X exceeds byte range", v)
+	}
+	return byte(v), nil
+}
+
+// memWrite is the canonical "TUI wrote one byte" path. Prefer the
+// WBus wrapper (so memory watches fire) over the raw RAM if WBus is
+// wired; otherwise fall through to the CPU's bus (which may be MMIO
+// in chippy-as-library use cases) so peripherals see the write.
+// Direct RAM.Write is the last fallback for the legacy in-process
+// case where no bus is configured.
+func (m *Model) memWrite(addr uint16, v byte) {
+	switch {
+	case m.WBus != nil:
+		m.WBus.Write(addr, v)
+	case m.CPU != nil && m.CPU.Bus != nil:
+		m.CPU.Bus.Write(addr, v)
+	default:
+		m.RAM.Write(addr, v)
+	}
+}
+
 func (m *Model) cmdTrace(args []string) string {
 	if m.Tracer == nil {
 		return "trace unavailable"


### PR DESCRIPTION
Closes #389. The interactive memory-panel cursor + hex edit on `e` / `enter` to commit was already shipped (`memedit.go` + `memedit_test.go`); this PR closes the two real gaps:

## 1. `:mem` command

`:mem $ADDR VALUE [VALUE...]` writes one or more hex bytes starting at `$ADDR`. Values can be `$XX`, `0xXX`, or decimal 0-255. Out-of-range values are rejected before any write happens (no partial writes on bad input).

```
:mem $0200 41 42 43        -> "ABC" at $0200..$0202
:mem main 00                -> zero the byte at symbol main
:mem $0400 $FF 0xAB 127
```

Status:
- single byte → `$0200 <- $42`
- multi → `$0300..$0302 <- 3 bytes`

Tab completion + help modal updated.

## 2. Memory writes go through the bus

Both the interactive editor and the new `:mem` command call `Model.memWrite` which prefers the `WBus` wrapper (so `:bpw` memory watches fire on TUI-driven writes too) over the CPU's raw bus, and falls back to RAM only when neither is wired.

Previously the editor called `m.RAM.Write` directly, bypassing watches + any MMIO peripheral (e.g. a cc65 program with a memory-mapped device).

## Test plan

- New `TestCmdMem_*` table tests cover single, multi, hex / decimal / negative / bad-byte / usage / bad-addr paths.
- Existing `memedit_test.go` still passes (interactive flow uses `memWrite` internally now).
- `go build ./...` clean.
- `go test -race -count=1 ./...` all green.
- `golangci-lint run ./...` 0 issues.

Refs #396 (v1.3.0 epic).