### PR TITLE
chore: pre-v1.3.0 release prep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@
 # VHS smoke-test renders (generated on demand, never committed).
 test/smoke/out/
 
+# goreleaser build output (snapshot + real releases)
+dist/
+
 # MkDocs build output
 site/
 _site/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Go-based TUI 6502 emulator + debugger (Bubble Tea, Lipgloss). Targets ca65/cc65 
 - Squash-merge with `--delete-branch`. Defer follow-ups by filing new issues.
 
 ## Release tag scheme
-- chippy ships under bare `vX.Y.Z` tags. Goreleaser via `.goreleaser.chippy.yml` (last released: `v1.2.0`; nessy was carved out into [github.com/nkane/nessy](https://github.com/nkane/nessy) post-v1.2.0).
+- chippy ships under bare `vX.Y.Z` tags. Goreleaser via `.goreleaser.chippy.yml` (last released: `v1.3.0` — debugger UX polish, epic #396; nessy was carved out into [github.com/nkane/nessy](https://github.com/nkane/nessy) post-v1.2.0).
 - Full process in [`docs/RELEASE.md`](docs/RELEASE.md).
 
 ## Docs are part of every PR (not a follow-up)


### PR DESCRIPTION
Housekeeping before tagging v1.3.0.

- `.gitignore`: ignore goreleaser `dist/` output so `goreleaser release --snapshot` (the pre-tag verification step in `docs/RELEASE.md`) no longer leaves an untracked tree.
- `CLAUDE.md`: bump the last-released note to v1.3.0 (epic #396).

Pre-tag checklist verified: `go build` / `go test -race` / `golangci-lint` green; `goreleaser --snapshot` builds all 5 platforms + deb/rpm/apk (local SBOM step needs syft, present in CI); changelog config excludes chore/docs/test so v1.3.0 notes = the 5 feature PRs (#388-#392).

Follow-up filed: #413 (migrate deprecated goreleaser `brews:` key).