### PR TITLE
fix(vscode): pin @types/vscode to engines.vscode floor

### DIFF
--- a/extension/vscode-chippy/package-lock.json
+++ b/extension/vscode-chippy/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@types/mocha": "^10.0.6",
         "@types/node": "^25.9.1",
-        "@types/vscode": "^1.120.0",
+        "@types/vscode": "^1.75.0",
         "@vscode/test-electron": "^2.4.0",
         "@vscode/vsce": "^3.9.1",
         "mocha": "^11.7.6",

--- a/extension/vscode-chippy/package.json
+++ b/extension/vscode-chippy/package.json
@@ -175,7 +175,7 @@
   "devDependencies": {
     "@types/mocha": "^10.0.6",
     "@types/node": "^25.9.1",
-    "@types/vscode": "^1.120.0",
+    "@types/vscode": "^1.75.0",
     "@vscode/test-electron": "^2.4.0",
     "@vscode/vsce": "^3.9.1",
     "mocha": "^11.7.6",


### PR DESCRIPTION
The v1.3.0 release goreleaser job succeeded (binaries + packages live), but the **VS Code marketplace publish job failed**:

```
@types/vscode ^1.120.0 greater than engines.vscode ^1.75.0.
Either upgrade engines.vscode or use an older @types/vscode version
```

Root cause: dependabot PR #406 (merged just before the release) bumped `@types/vscode` to ^1.120.0. vsce refuses to publish when the declared `@types/vscode` is newer than `engines.vscode`.

Fix: pin `@types/vscode` back to `^1.75.0` (matching the engine floor) rather than raising `engines.vscode`, which would drop support for VS Code 1.75–1.119. `tsc -p ./` compiles clean — the extension uses no API newer than 1.75.

Extension 0.1.0 is still not on the marketplace; publishing it happens after this merges (manual `vsce publish` or a follow-up tag).

Refs #406.