### PR TITLE
feat(dap): custom-request extension point for host debug requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ The v1.0 readiness epic at [#121](https://github.com/nkane/chippy/issues/121)
 tracks the remaining gap. Changes since v0.4.0:
 
 ### Added
+- DAP: `AttachConfig.CustomRequestHandler` extension point — hosts can
+  serve their own `vendor/command` requests over the same DAP connection
+  (invoked from dispatch's fallback path under the CPU lock for coherent
+  state reads). Unknown commands without a handler still return "not
+  implemented". Lets nessy expose NES PPU / OAM / mapper debug state to
+  the TUI panels without forking the protocol. (#416)
 - CPU: WAI ($CB) and STP ($DB) now halt the CPU correctly instead of
   acting as NOPs. WAI wakes on any IRQ/NMI (including masked IRQ —
   falls through to the next instruction without dispatching). STP halts

--- a/dap/attach.go
+++ b/dap/attach.go
@@ -46,6 +46,17 @@ type AttachConfig struct {
 	// down: either via a `disconnect` request or wire EOF in Serve().
 	// Hosts resume their autonomous run loop. Optional.
 	OnDisconnected func()
+
+	// CustomRequestHandler handles DAP request commands the built-in
+	// dispatch doesn't recognize — letting a host serve domain-specific
+	// debug data (e.g. nessy's PPU / OAM / mapper state) over its own
+	// `vendor/command` requests without forking the protocol. It runs
+	// from dispatch's fallback path under the CPU lock (so reads of live
+	// debuggee state are coherent). Return handled=false to defer to the
+	// standard "not implemented" error; handled=true with a non-nil err
+	// sends an error response, otherwise body is marshalled as the
+	// response body. Optional; nil means unknown commands always error.
+	CustomRequestHandler func(command string, args json.RawMessage) (body any, handled bool, err error)
 }
 
 // AttachExisting wires an already-constructed debuggee into the server
@@ -71,6 +82,7 @@ func (s *Server) AttachExisting(cfg AttachConfig) error {
 	s.cpuMu = cfg.CPUMu
 	s.onAttached = cfg.OnAttached
 	s.onDisconnected = cfg.OnDisconnected
+	s.customHandler = cfg.CustomRequestHandler
 	return nil
 }
 

--- a/dap/custom_request_test.go
+++ b/dap/custom_request_test.go
@@ -1,0 +1,155 @@
+package dap
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/nkane/chippy/cpu"
+)
+
+// AttachConfig.CustomRequestHandler receives request commands the
+// built-in dispatch doesn't recognize. A handled=true response with no
+// error is sent back as a normal success response carrying the body;
+// handled=false falls through to the standard "not implemented" error;
+// handled=true with an error sends an error response. This is the
+// extension point nessy uses to expose PPU / OAM / mapper debug state
+// over `nessy/*` requests without forking the protocol.
+func TestCustomRequestHandler(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+
+	ram := cpu.NewRAM()
+	c := cpu.New(ram)
+	var cpuMu sync.Mutex
+
+	// lockedDuringHandler records whether the CPU lock was already held
+	// when the handler ran — it must be, so a handler reading live state
+	// observes a coherent snapshot rather than a mid-instruction one.
+	var lockedDuringHandler bool
+
+	srv := NewServer(serverConn, serverConn)
+	cfg := AttachConfig{
+		CPU:   c,
+		RAM:   ram,
+		CPUMu: &cpuMu,
+		CustomRequestHandler: func(command string, args json.RawMessage) (any, bool, error) {
+			switch command {
+			case "nessy/ping":
+				// dispatch holds cpuMu around the fallback path; a
+				// TryLock here must fail, proving the handler runs locked.
+				if cpuMu.TryLock() {
+					cpuMu.Unlock()
+					lockedDuringHandler = false
+				} else {
+					lockedDuringHandler = true
+				}
+				var in struct {
+					Echo string `json:"echo"`
+				}
+				_ = json.Unmarshal(args, &in)
+				return map[string]any{"pong": in.Echo}, true, nil
+			case "nessy/boom":
+				return nil, true, fmt.Errorf("kaboom")
+			default:
+				return nil, false, nil // defer to "not implemented"
+			}
+		},
+	}
+	if err := srv.AttachExisting(cfg); err != nil {
+		t.Fatalf("AttachExisting: %v", err)
+	}
+	go func() {
+		_ = srv.Serve()
+		_ = serverConn.Close()
+	}()
+
+	client := NewClient(clientConn, clientConn)
+	defer func() { _ = client.Close() }()
+
+	if _, err := client.Initialize(InitializeArguments{}); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	if _, err := client.Attach(); err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+
+	// handled=true, no error → success response with body.
+	resp, err := client.Request("nessy/ping", map[string]string{"echo": "hi"})
+	if err != nil {
+		t.Fatalf("nessy/ping: %v", err)
+	}
+	if !resp.Success {
+		t.Fatalf("nessy/ping: Success=false, message=%q", resp.Message)
+	}
+	raw, _ := json.Marshal(resp.Body)
+	var got struct {
+		Pong string `json:"pong"`
+	}
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("unmarshal body: %v", err)
+	}
+	if got.Pong != "hi" {
+		t.Errorf("nessy/ping body pong=%q; want %q", got.Pong, "hi")
+	}
+	if !lockedDuringHandler {
+		t.Error("custom handler ran without the CPU lock held; snapshot would not be coherent")
+	}
+
+	// handled=true with error → error response carrying the message.
+	resp, err = client.Request("nessy/boom", nil)
+	if err != nil {
+		t.Fatalf("nessy/boom transport: %v", err)
+	}
+	if resp.Success {
+		t.Error("nessy/boom: Success=true; want error response")
+	}
+	if resp.Message != "kaboom" {
+		t.Errorf("nessy/boom message=%q; want %q", resp.Message, "kaboom")
+	}
+
+	// handled=false → standard "not implemented" error.
+	resp, err = client.Request("totally/unknown", nil)
+	if err != nil {
+		t.Fatalf("unknown transport: %v", err)
+	}
+	if resp.Success {
+		t.Error("unknown command: Success=true; want not-implemented error")
+	}
+}
+
+// With no CustomRequestHandler set, unknown commands still produce the
+// standard "not implemented" error — the extension point is opt-in.
+func TestCustomRequestHandler_NilDefersToNotImplemented(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	ram := cpu.NewRAM()
+	c := cpu.New(ram)
+
+	srv := NewServer(serverConn, serverConn)
+	if err := srv.AttachExisting(AttachConfig{CPU: c, RAM: ram}); err != nil {
+		t.Fatalf("AttachExisting: %v", err)
+	}
+	go func() {
+		_ = srv.Serve()
+		_ = serverConn.Close()
+	}()
+
+	client := NewClient(clientConn, clientConn)
+	defer func() { _ = client.Close() }()
+
+	if _, err := client.Initialize(InitializeArguments{}); err != nil {
+		t.Fatalf("initialize: %v", err)
+	}
+	if _, err := client.Attach(); err != nil {
+		t.Fatalf("attach: %v", err)
+	}
+
+	resp, err := client.Request("nessy/ping", nil)
+	if err != nil {
+		t.Fatalf("transport: %v", err)
+	}
+	if resp.Success {
+		t.Error("unknown command with nil handler: Success=true; want not-implemented error")
+	}
+}

--- a/dap/server.go
+++ b/dap/server.go
@@ -95,6 +95,16 @@ type Server struct {
 	onAttached     func()
 	onDisconnected func()
 
+	// customHandler handles request commands the built-in dispatch
+	// switch doesn't recognize. Set via AttachConfig.CustomRequestHandler.
+	// Invoked from the dispatch `default` case under the CPU lock, so a
+	// handler that reads live debuggee state observes a coherent,
+	// mid-instruction-free snapshot. Returning handled=false falls back
+	// to the standard "not implemented" error. Lets a host (e.g. nessy)
+	// expose domain-specific debug state — PPU / OAM / mapper registers —
+	// over its own `vendor/command` requests without forking the protocol.
+	customHandler func(command string, args json.RawMessage) (body any, handled bool, err error)
+
 	// attachedFired records whether handleAttach completed
 	// successfully. fireDisconnected uses this to guarantee the host
 	// only sees `OnDisconnected` when a paired `OnAttached` actually
@@ -251,6 +261,17 @@ func (s *Server) dispatch(req Request) {
 	case "terminate":
 		s.handleTerminate(req)
 	default:
+		if s.customHandler != nil {
+			body, handled, err := s.customHandler(req.Command, req.Arguments)
+			if handled {
+				if err != nil {
+					s.sendErrorResponse(req, err.Error())
+				} else {
+					s.sendResponse(req, body)
+				}
+				return
+			}
+		}
 		s.sendErrorResponse(req, fmt.Sprintf("not implemented: %s", req.Command))
 	}
 }


### PR DESCRIPTION
## What

Add `AttachConfig.CustomRequestHandler` — an opt-in extension point letting a hosting process serve its own DAP request commands over the same connection.

## Why

`dap.Server.dispatch` is a closed switch; unknown commands return "not implemented" with no host override. nessy needs to expose NES-specific debug state (PPU nametables/CHR/palette, OAM, mapper + APU registers, per-dot events) to the chippy TUI debugger panels (nessy#28) without forking the protocol.

## How

- New `AttachConfig.CustomRequestHandler func(command string, args json.RawMessage) (body any, handled bool, err error)`, copied through `AttachExisting`.
- Invoked from dispatch's `default` case **under the CPU lock** → coherent state reads.
- `handled=false` defers to the standard "not implemented" error; `handled=true,err!=nil` → error response; `handled=true,err==nil` → success response with `body`.

## Tests

`TestCustomRequestHandler` (success+body, asserts the lock is held during the handler, handled-with-error, handled=false → not-implemented) and `TestCustomRequestHandler_NilDefersToNotImplemented`. Full `./dap/` suite + vet + golangci-lint green.

Closes #416
