### PR TITLE
chore: pre-v1.5.0 release prep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Go-based TUI 6502 emulator + debugger (Bubble Tea, Lipgloss). Targets ca65/cc65 
 - Squash-merge with `--delete-branch`. Defer follow-ups by filing new issues.
 
 ## Release tag scheme
-- chippy ships under bare `vX.Y.Z` tags. Goreleaser via `.goreleaser.chippy.yml` (last released: `v1.3.0` — debugger UX polish, epic #396; nessy was carved out into [github.com/nkane/nessy](https://github.com/nkane/nessy) post-v1.2.0).
+- chippy ships under bare `vX.Y.Z` tags. Goreleaser via `.goreleaser.chippy.yml` (last released: `v1.5.0` — DAP onramp + complete CPU ROM coverage, epic #402; host debug hooks, epic #419. nessy carved out into [github.com/nkane/nessy](https://github.com/nkane/nessy) post-v1.2.0; VS Code extension removed v1.4.1).
 - Full process in [`docs/RELEASE.md`](docs/RELEASE.md).
 
 ## Docs are part of every PR (not a follow-up)


### PR DESCRIPTION
Housekeeping before tagging v1.5.0.

- `CLAUDE.md`: bump last-released note to v1.5.0 (was stale at v1.3.0; v1.4.0/v1.4.1 shipped in between).

Pre-tag checklist verified: `go build` / `go test -race` / `golangci-lint` green; `goreleaser --snapshot` builds all 5 platforms + deb/rpm/apk (local SBOM step needs syft, present in CI; no vscode-extension job since v1.4.1). Changelog (feat/fix only) = the DAP onramp + host-hook features + the JSR fix.

v1.5.0 closes epics #402 (DAP onramp + complete CPU ROM coverage) and #419 (host debug hooks).