### PR TITLE
docs: ADR records per release + ADR convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ Go-based TUI 6502 emulator + debugger (Bubble Tea, Lipgloss). Targets ca65/cc65 
 ## Release tag scheme
 - chippy ships under bare `vX.Y.Z` tags. Goreleaser via `.goreleaser.chippy.yml` (last released: `v1.5.0` — DAP onramp + complete CPU ROM coverage, epic #402; host debug hooks, epic #419. nessy carved out into [github.com/nkane/nessy](https://github.com/nkane/nessy) post-v1.2.0; VS Code extension removed v1.4.1).
 - Full process in [`docs/RELEASE.md`](docs/RELEASE.md).
+- **Every release gets an ADR.** Cutting a tag includes adding `docs/adr/NNNN-vX.Y.Z.md` (next sequence number) capturing that release's decisions, and a row in `docs/adr/README.md`. The tag does not go out without it.
 
 ## Docs are part of every PR (not a follow-up)
 Every PR ships with the documentation changes its diff implies. Update **in the same PR**, never as a separate cleanup:
@@ -23,6 +24,7 @@ Every PR ships with the documentation changes its diff implies. Update **in the 
 - **`docs/context.md`** — the architecture / progress / decisions handoff doc. When a PR merges, move the issue from "Open issues" to "Merged PRs of note", drop any "in progress" stubs that referred to it, and add an architecture section if the PR introduced a new subsystem (e.g. MMIO, trace).
 - **TUI help modal** (`internal/tui/model.go` `helpModal()`) — when a new `:command`, keybinding, or panel ships.
 - **Code-level doc comments** — when an exported type/function changes shape or contract.
+- **`docs/adr/`** — when the PR embeds an architectural decision (a choice with trade-offs, a new abstraction / extension seam / pattern, a protocol or dependency change, or a reversal). Add or update an ADR (Context / Decision / Consequences) in the same PR; fold per-release decisions into that release's ADR. Mechanical fixes/refactors don't need one. ADRs are numbered `docs/adr/NNNN-*.md` with an index in `docs/adr/README.md`.
 - **This file (`CLAUDE.md`)** — when load-bearing invariants change, or when a convention itself changes.
 
 A PR that adds a feature without updating its docs is incomplete. Reviewers will flag it; pre-empt by updating in the same diff.

--- a/docs/adr/0001-v1.0.0.md
+++ b/docs/adr/0001-v1.0.0.md
@@ -1,0 +1,77 @@
+# ADR 0001 — v1.0.0: Foundation
+
+- **Status:** Accepted
+- **Release:** v1.0.0 (2026-05-13; folds in the v0.0.1–v0.4.0 same-week spikes)
+- **Theme:** A TUI 6502/65C02 emulator + debugger targeting the cc65/ca65 toolchain.
+
+## D1 — Variant-based CPU dispatch via a per-CPU opcode-table pointer
+
+- **Context:** want NMOS 6502 + 65C02 (and later 2A03/65816) without branching on the variant inside every opcode.
+- **Decision:** `CPU.opcodes *[256]Instr` points at a variant table; dispatch is `c.opcodes[op]`. `VariantNMOS` is authoritative; `OpcodesCMOS` is copy-then-override.
+- **Consequences:** new variants are a new table file, zero hot-path cost. Tables share a base.
+
+## D2 — CMOS table init by copy-then-override on Go `init()` lex order
+
+- **Context:** the CMOS table derives from NMOS; illegal opcodes patch NMOS.
+- **Decision:** rely on Go's file-lexical `init()` order: `opcodes.go` < `opcodes_cmos.go` < `opcodes_illegal.go`.
+- **Consequences:** **load-bearing invariant** — renaming these files breaks the init chain. Documented in CLAUDE.md.
+
+## D3 — `Step()` services interrupts at the instruction boundary, then runs one opcode
+
+- **Decision:** NMI (edge) checked first, IRQ (level, gated on `!FlagI`) second; 7-cycle service pushes PC+P (B clear), sets I, jumps to vector, un-halts. Returns total cycles incl. branch extras via an `extraCycles` side channel reset each Step.
+- **Consequences:** simple, deterministic instruction-stepped model. (Per-cycle interleave arrives later for NES — ADR 0004.)
+
+## D4 — Faithful NMOS BCD quirk
+
+- **Decision:** NMOS ADC/SBC: A and C reflect decimal, but N/V/Z reflect the parallel binary path (real-silicon quirk). CMOS: N/V/Z reflect the decimal result, +1 cycle. Dispatched via `c.Variant`.
+- **Consequences:** passes the Bruce Clark exhaustive BCD sweep; matches Klaus.
+
+## D5 — Layered bus chain, loader/reset bypass MMIO
+
+- **Decision:** `CPU → tui.WBus → cpu.MMIO → cpu.RAM`. `MMIO` dispatches registered `Peripheral`s first, falls back to RAM. The loader + reset-vector helpers write `RAM.Data` directly, bypassing MMIO.
+- **Consequences:** peripherals must sit at addresses no ROM occupies; debugger pokes / loads don't trigger peripheral side effects.
+
+## D6 — Peripherals as MMIO registers (Apple-1 style)
+
+- **Decision:** `TextOutput` @ `$F001` (write → buffer, rendered as a panel); `KeyboardInput` @ `$F004/$F005` (data/status pair). `cpu.Peripheral` interface: `Range`/`Read`/`Write`.
+- **Consequences:** generic I/O surface; the TUI pushes keys, the CPU drains them.
+
+## D7 — Execution trace via an optional hook + replay
+
+- **Decision:** `cpu.Tracer` interface (`LogStep`/`LogInterrupt`) called from `Step`; `FileTracer` is a buffered sink. `-trace PATH` / `:trace`. `trace.Replay` parses a log into navigable frames (replay mode).
+- **Consequences:** post-mortem analysis without re-running; foundation for later replay search/diff (ADR 0005).
+
+## D8 — TUI on Bubble Tea + Lipgloss; every key path returns a `tea.Cmd`
+
+- **Decision:** Elm-architecture model in `internal/tui` (private — chippy-specific). Panels read CPU+RAM directly. Keep `Update` responsive.
+- **Consequences:** keeps rendering pure; the later DAP migration (ADR 0008) reshapes this without changing the framework.
+
+## D9 — cc65/ca65 as the first-class toolchain
+
+- **Decision:** parse cc65 `.dbg` for the symbol table + PC→source map (`symbols` package); the loader runs `ld65` for unlinked `.o`.
+- **Consequences:** source-level debugging of ca65/cc65 programs. (Limitation surfaced later: `.dbg` carries no C struct/array layout — ADR 0005 D3.)
+
+## D10 — Reverse-step via page-level copy-on-write RAM shadow + snapshot ring
+
+- **Decision:** `RAM` keeps an optional CoW page shadow; each step pushes a `Snapshot` (page delta + regs) to a fixed `SnapshotRing`. `<` pops/restores.
+- **Consequences:** cheap reverse-step (hundreds of bytes/step). (Depth extended to millions of steps via keyframes in ADR 0005 D5.)
+
+## D11 — GPL test ROMs are downloaded + sha256-verified, never vendored
+
+- **Decision:** MIT license for chippy; Klaus's GPL `6502_65C02_functional_tests` fetched on demand into the user cache, sha256-pinned. Klaus functional + 65C02 + Bruce Clark BCD are the pre-1.0 correctness baseline.
+- **Consequences:** clean license boundary; the pattern scales to AllSuiteA / Tom Harte / Lorenz (ADR 0008).
+
+## D12 — Persistence: frozen state-format v1 contract
+
+- **Decision:** `~/.chippy/state-<rom>.json` carries `schemaVersion: 1`; new fields stay optional within v1.x; semantic changes require a version bump + migration. A golden test pins `state-v1.json`.
+- **Consequences:** save-state stability across releases; new features add `omitempty` fields (watches, deep-rewind budget, …).
+
+## D13 — Single binary, goreleaser, bare `vX.Y.Z` tags
+
+- **Decision:** one `chippy` binary; goreleaser publishes signed binaries + a Homebrew tap on tag push.
+- **Consequences:** simple release story; homebrew-core deferred until ~30 stars.
+
+## D14 — Breakpoint/watch sigils mirror nvim-dap
+
+- **Decision:** 🛑 bp · 👉 PC · 🔶 conditional · 💩 rejected · 📜 logpoint · 👁/✏/🔁 read/write/r+w watch. Wide-emoji column compensation keeps the address column aligned.
+- **Consequences:** familiar to nvim-dap users.

--- a/docs/adr/0002-v1.1.0.md
+++ b/docs/adr/0002-v1.1.0.md
@@ -1,0 +1,34 @@
+# ADR 0002 — v1.1.0: DAP, NES variant, per-cycle bus ticker
+
+- **Status:** Accepted
+- **Release:** v1.1.0 (2026-05-15)
+- **Theme:** Make chippy a debug-adapter server and the reusable core under a NES emulator (nessy).
+
+## D1 — Debug Adapter Protocol server + client library
+
+- **Context:** want editor-driven debugging (VS Code, nvim-dap) and a programmatic client.
+- **Decision:** transport-agnostic `dap.Server` over `io.Reader/Writer` (stdio / TCP); a `dap.Client` library; `-dap-attach` Phase A (handshake) → B/C (live remote TUI).
+- **Consequences:** the protocol becomes chippy's extension seam (custom requests, host hooks, inproc transport all build on it later — ADR 0006, 0008).
+
+## D2 — `Source` interface: local in-process vs remote DAP-backed
+
+- **Context:** the TUI must drive either the in-process CPU or a remote server identically.
+- **Decision:** a `Source` abstraction (`LocalSource` / `RemoteSource`) owns step/reset/continue/breakpoints; display panels read a CPU+RAM **mirror** the source keeps populated.
+- **Consequences:** one TUI, two backends. This is the lever the v1.5.0 TUI-via-DAP migration pulls (ADR 0008 D2).
+
+## D3 — `VariantNES` (Ricoh 2A03 = NMOS minus decimal)
+
+- **Decision:** add a CPU variant whose ADC/SBC ignore the D flag (the 2A03 disables BCD), reusing the NMOS table otherwise.
+- **Consequences:** nessy runs on the chippy core. Caveat that bit later work: the per-cycle path is gated on `VariantNES`, and it disables decimal — so the Tom Harte bus-trace harness keeps `VariantNMOS` and force-enables the per-cycle path (ADR 0008 D4).
+
+## D4 — Bus-ticker hook + cached `Ticker` assertion
+
+- **Context:** peripherals (PPU/APU/cart) must advance per CPU cycle, but the bare debugger CPU must stay single-digit-ns per step.
+- **Decision:** an optional `cpu.Ticker` on the bus; `SetBus` caches the type assertion so `Step` checks a field, not a per-call assertion.
+- **Consequences:** zero cost when no ticker; the hook later carries the full per-cycle interleave (ADR 0004) and the access-tracking heatmap (ADR 0008 D5).
+
+## D5 — Monorepo now, nessy built *on* the core, split later (YAGNI three-way)
+
+- **Context:** nessy (NES emulator) needs the 6502 core; a separate repo adds friction early.
+- **Decision:** keep chippy + nessy in one repo with a monorepo-aware release split; two-process design (emulator + DAP); defer the repo split and reject a speculative three-way split.
+- **Consequences:** fast iteration; the split is executed at v1.2.0 (ADR 0004 D3) once the public API stabilized.

--- a/docs/adr/0003-v1.1.1.md
+++ b/docs/adr/0003-v1.1.1.md
@@ -1,0 +1,27 @@
+# ADR 0003 — v1.1.1: Remote-debug hardening
+
+- **Status:** Accepted
+- **Release:** v1.1.1 (2026-05-16)
+- **Theme:** Make `-dap-attach` against a running emulator (nessy) actually usable.
+
+## D1 — Server owns CPU execution during a session (ownership model)
+
+- **Context:** if both the emulator's game loop and the DAP run loop step the CPU, they race.
+- **Decision:** on DAP attach the host pauses its own loop; the DAP server owns execution (continue/pause/step). A shared `cpuMu` guards CPU-touching dispatch.
+- **Consequences:** the canonical concurrency contract for every later DAP feature — the run loop, host stop-predicate, and live-state streaming all respect `cpuMu` (ADR 0008).
+
+## D2 — `readMemory` routes through `MMIO.Peek` (side-effect-free)
+
+- **Context:** a debugger reading a memory-mapped register must not trigger its read side effect (e.g. clearing a status bit).
+- **Decision:** DAP `readMemory` uses a side-effect-free peek path; the TUI mirrors remote RAM via `readMemory` so disasm/memory panels render real bytes, not zero-byte BRK chains.
+- **Consequences:** safe inspection of cart/peripheral space; the mirror-sync pattern (`RefreshMemory`) is later complemented by event streaming (ADR 0008 D3, and follow-up #440).
+
+## D3 — One-shell launcher + `.dbg` threading
+
+- **Decision:** `chippy -nessy ROM` launches the emulator + attaches in one command; the sibling `.dbg` source map is loaded locally so source view + symbol names work over attach.
+- **Consequences:** turnkey source-level NES debugging.
+
+## D4 — Breakpoints sync to the remote on mutation
+
+- **Decision:** `:bp` / `:run` forward the breakpoint set to the server (later via `setInstructionBreakpoints` with conditions) so the server can short-circuit non-matching hits without a TUI round-trip.
+- **Consequences:** keeps remote and local breakpoint state consistent; conditional-bp forwarding is completed in ADR 0005 D1.

--- a/docs/adr/0004-v1.2.0.md
+++ b/docs/adr/0004-v1.2.0.md
@@ -1,0 +1,28 @@
+# ADR 0004 — v1.2.0: Public 6502 library, per-cycle accuracy, nessy carve-out
+
+- **Status:** Accepted
+- **Release:** v1.2.0 (2026-05-29)
+- **Theme:** Promote the shared core to a public library with a semver contract; reach cycle accuracy for the NES path; split nessy into its own repo.
+
+## D1 — Promote the 6502 core out of `internal/` into public packages
+
+- **Context:** the future standalone nessy repo can't import `internal/`.
+- **Decision:** move `cpu` / `dap` / `symbols` / `peripheral` / `expr` / `loader` / `trace` to public top-level paths; keep `internal/tui` (chippy-only) and `internal/nes` (nessy-only) private. Document a stability/semver contract (`docs/api.md`): `cpu.Bus`/`Peripheral`/`Ticker`/`Variant` are the major-version contract types.
+- **Consequences:** third parties + nessy can pin the library; bare `vX.Y.Z` tags become library semver. The opcode-init lex-order invariant (ADR 0001 D2) is preserved through the move.
+
+## D2 — Per-cycle CPU↔PPU interleave for `VariantNES` (Mesen2 master-clock model)
+
+- **Context:** instruction-stepped timing can't pass the Blargg/nesdev accuracy ROMs (vbl/NMI races, sub-cycle DMA, frame-counter).
+- **Decision:** for `VariantNES`, `Step` runs in lockstep — every bus access ticks the chain one cycle (PPU 3 dots / APU / cart) *before* the access, with the 6502's dummy cycles per addressing template; ported Mesen2's `ProcessPendingDma`, the branch IRQ-poll quirk, and the NTSC frame-counter intervals. NMOS/CMOS keep the instruction-stepped batch tick (byte-identical).
+- **Consequences:** all NES accuracy ROMs pass. Because this path is `VariantNES`-gated and that variant disables decimal, later NMOS per-cycle bus-trace validation force-enables the path on `VariantNMOS` (ADR 0008 D4). The per-cycle path also asserts an exact tick budget — a constraint every later per-cycle change honors.
+
+## D3 — Carve nessy into its own repository
+
+- **Context:** with the public API stable, the monorepo's NES code is dead weight for a 6502-library consumer.
+- **Decision:** carve `internal/nes` + `cmd/nessy*` into [github.com/nkane/nessy](https://github.com/nkane/nessy) (git history preserved via filter-repo, `nessy-v*` tags → `v*`). chippy keeps only the library + TUI debugger.
+- **Consequences:** chippy is a clean general 6502 library; nessy depends on it. v1.2.0 is the last release with nessy in-tree.
+
+## D4 — Accuracy ROM harness with `knownFail` gating
+
+- **Decision:** a rolling accuracy tracker runs Blargg/nesdev ROMs in CI, gating regressions; a ROM is `knownFail` until fixed, then becomes a hard gate.
+- **Consequences:** the model chippy later reuses for its own CPU corpora (Klaus interrupt, AllSuiteA, Lorenz, Tom Harte — ADR 0008 D4).

--- a/docs/adr/0005-v1.3.0.md
+++ b/docs/adr/0005-v1.3.0.md
@@ -1,0 +1,32 @@
+# ADR 0005 — v1.3.0: Debugger UX polish
+
+- **Status:** Accepted
+- **Release:** v1.3.0 (2026-06-04; epic #396)
+- **Theme:** Round out the TUI debugger — conditions, memory editing, watch expansion, trace navigation, deep rewind.
+
+## D1 — Conditional breakpoints over DAP
+
+- **Decision:** forward `condition` / `hitCondition` / `logMessage` on `setInstructionBreakpoints`; `RemoteSource` maps the TUI's `SourceBP{PC,Cond,HitLimit,Log}` to the DAP fields; a BP-modal `c` keybind edits conditions inline.
+- **Consequences:** the server short-circuits non-matching hits without a TUI round-trip; conditions evaluate through the shared `expr` package.
+
+## D2 — `:mem` command + memory writes through the bus
+
+- **Decision:** add `:mem $ADDR V [V…]`; route TUI memory writes through the `WBus`/MMIO chain (not raw RAM) so watchpoints + MMIO side effects fire.
+- **Consequences:** debugger pokes behave like CPU writes where it matters.
+
+## D3 — Watch array expansion + the cc65 `.dbg` finding
+
+- **Context:** wanted struct/array expansion in the watch panel from `.dbg` type info.
+- **Decision (empirical):** verified cc65 V2.18 `.dbg` carries **no** struct member layout or array bounds — every `csym` type collapses to void. So scope to array-only best-effort: `:watch X xN` pins N consecutive byte/word elements; auto-seed from `sym size=` when present. Manual struct overlay + DAP array children deferred (#409/#410).
+- **Consequences:** honest scope; the finding is recorded (`reference-cc65-dbg-no-types`) so it isn't re-litigated. `Watch.Count` is an optional v1 state field (no schema bump).
+
+## D4 — Trace replay: search / jump-to-cycle / side-by-side diff
+
+- **Decision:** `:find EXPR` / `:rfind` evaluate the breakpoint `expr` grammar against a scratch CPU per frame (bare `=`→`==`); `:cycle N` binary-searches the monotonic cycle column; `-diff PATH` loads a second trace and `trace.Diff` marks the first divergence; `d`/`D` toggle a side-by-side overlay.
+- **Consequences:** pure-`trace` logic stays unit-testable apart from the TUI; high-fidelity post-mortem comparison of two runs.
+
+## D5 — Deep rewind via keyframes + `:rewind-budget`
+
+- **Context:** the per-step snapshot ring (ADR 0001 D10) only reaches back its capacity (~256 steps).
+- **Decision:** `cpu.KeyframeRing` keeps periodic full-RAM snapshots (every 4096 steps); `:rewind N` restores the nearest keyframe ≤ target and replays forward to the exact step. `:rewind-budget MB` caps keyframe memory (reach = budget/64KiB × interval); memory is a ceiling, not a reservation.
+- **Consequences:** reach jumps from hundreds to millions of steps; a deep rewind replays ≤4096 instructions (~1 ms). Forward-replay assumes deterministic execution between keyframes (buffered input is snapshotted).

--- a/docs/adr/0006-v1.4.0.md
+++ b/docs/adr/0006-v1.4.0.md
@@ -1,0 +1,15 @@
+# ADR 0006 — v1.4.0: DAP custom-request extension point
+
+- **Status:** Accepted
+- **Release:** v1.4.0 (2026-06-04)
+- **Theme:** A minimal library release cut specifically to give a downstream emulator (nessy) a protocol seam.
+
+## D1 — `AttachConfig.CustomRequestHandler`
+
+- **Context:** `dap.Server.dispatch` was a closed switch — unknown commands returned "not implemented", so a host couldn't serve its own debug requests without forking the protocol. nessy needs a `nessy/debugState` channel (PPU/OAM/mapper/APU state) over the same connection.
+- **Decision:** add an opt-in `CustomRequestHandler func(command string, args json.RawMessage) (body any, handled bool, err error)`, invoked from `dispatch`'s default case **under `cpuMu`** (coherent state reads). `handled=false` defers to the standard not-implemented error.
+- **Consequences:** hosts extend the protocol additively; chippy stays general. This is the first of the host-debug hooks later grouped under epic #419 (ADR 0008 D5). The release carries only this change + a vscode types fix.
+
+## Note
+
+v1.4.0's release pipeline still contained the bundled VS Code extension, whose marketplace publish failed (the extension was blocked — ADR 0007). The binary release shipped fine.

--- a/docs/adr/0007-v1.4.1.md
+++ b/docs/adr/0007-v1.4.1.md
@@ -1,0 +1,16 @@
+# ADR 0007 — v1.4.1: Remove the VS Code extension
+
+- **Status:** Accepted
+- **Release:** v1.4.1 (2026-06-04)
+- **Theme:** Pull the bundled VS Code extension from the repo and the release pipeline.
+
+## D1 — Remove `extension/vscode-chippy/` and its CI/release/dependabot wiring
+
+- **Context:** Microsoft blocked the marketplace listing (publisher `Hidden-Pixel` shows 0 extensions). The v1.3.0/v1.4.0 release `vscode-extension` publish job failed every cut; the trigger was a dependabot bump of `@types/vscode` above `engines.vscode`, which `vsce` rejects.
+- **Decision:** delete the extension package, the `vscode-extension` publish job (`release.yml`), the `vscode-ext` CI job, and the npm dependabot entry. Git history preserves it for revival.
+- **Consequences:** the release pipeline is goreleaser-only and goes fully green for the first time since the breakage. **DAP editor integration is unaffected** — VS Code / Cursor drive chippy via a `chippy -dap stdio` launch config (`examples/dap/launch.json`); the bundled `.vsix` was never required.
+
+## D2 — Patch-release the removal
+
+- **Decision:** removal is a `chore` with no library-API change → patch bump (v1.4.1), cut immediately after the failed v1.4.0 so the next consumer gets a clean pipeline.
+- **Consequences:** first fully-green release post-breakage; revival is a `git revert` of the removal if the marketplace block clears.

--- a/docs/adr/0008-v1.5.0.md
+++ b/docs/adr/0008-v1.5.0.md
@@ -1,0 +1,35 @@
+# ADR 0008 — v1.5.0: DAP onramp, complete CPU ROM coverage, host debug hooks
+
+- **Status:** Accepted
+- **Release:** v1.5.0 (2026-06-11; epics #402 multi-target DAP onramp + complete CPU ROM coverage, #419 host debug hooks)
+- **Theme:** Derisk the v2.0 TUI-via-DAP architecture, fuzz the CPU against every standard corpus, and expose opt-in hooks a downstream emulator builds a Mesen-class debugger on.
+
+## D1 — In-process (zero-marshal) + unix-socket DAP transports
+
+- **Context:** the local TUI-as-DAP-client case (v2.0) needs zero-overhead transport; the server was already `io.Reader/Writer`-based.
+- **Decision:** unix-socket is just another `net.Conn` (`-dap unix:PATH`). The new piece is **inproc**: all server sends funnel through `writeJSON`, which consults an optional `sink func(any)`; when set, Response/Event **structs** go straight to an `InprocClient` instead of being marshalled. `NewInprocServer()` + `InprocClient.Request` dispatch directly. Nil-args requests + all responses round-trip with zero serialization.
+- **Consequences:** inproc `stepIn` ≈ 0.34 µs vs ~30 µs over unix (~90×). The foundation for D2.
+
+## D2 — TUI panels read via DAP (Registers panel PoC)
+
+- **Decision:** the Registers panel renders from `m.Regs` (`RegSnapshot`), sourced by `Source.Registers()` over a single DAP `variables` round-trip — **never direct `cpu.CPU` field access**. `LocalSource` owns an in-process DAP server (D1) attached to the same CPU/RAM, so local mode reads through DAP too; `RemoteSource` reuses its wire client. Pattern written up in `docs/dap-tui-migration.md`.
+- **Consequences:** proves the v2.0 direction one panel at a time. Migrating the remaining panels (stack/flags/memory/disasm) is deferred to v2.0.
+
+## D3 — `chippy-state` custom live-state event (≤60 Hz)
+
+- **Decision:** a server→client custom event pushed during a remote free-run (regs + a reserved `dirtyRanges`), throttled to 60 Hz in the run loop. The TUI updates `m.Regs` from it and **skips polling when remote+running**. Additive per the Mesen/DAP-extension convention — standard clients ignore unknown events.
+- **Consequences:** a remote run is event-driven, not per-frame polling. Streaming changed *memory* (`dirtyRanges`) is the v1.6 follow-up #440.
+
+## D4 — Complete CPU ROM coverage; reframe Visual6502 → Tom Harte bus traces
+
+- **Decision:** wire every standard 6502 corpus on the download-or-vendor pattern (ADR 0001 D11): AllSuiteA (sha-pinned), Wolfgang Lorenz CPU subset (vendored `.prg` + KERNAL-trap harness), Klaus interrupt (ca65 **port** — upstream ships as65 source only, with an active-low/-high feedback-port harness), Tom Harte ProcessorTests (256 opcodes × ~10k cases, state + cycle count). For the Visual6502 "per-cycle bus trace" goal, **reframe** to comparing chippy's per-cycle bus activity against Tom Harte's `cycles` field (~100× the coverage, no manual sourcing) — force-enable the per-cycle path (ADR 0004 D2) on `VariantNMOS` (so decimal stays intact) and record every `Bus.Read/Write`.
+- **Consequences:** 228/238 opcodes match bus-exact. Found + **fixed a real JSR `$20` stack/operand-overlap bug**. Skip-listed: 12 JAM/KIL + 6 unstable illegals (state) + 10 per-cycle branch/JSR/RTS bus quirks (#428) + ARR-decimal (#424) + 65C02 (#426) → v1.6. Each corpus is its own CI job.
+
+## D5 — Opt-in host debug hooks (epic #419), zero-cost when unset
+
+- **Decision:** four hooks let nessy build NES-aware debugging without forking the core, each guarded so the hot path is unaffected when unused:
+  - `AttachConfig.CustomRequestHandler` (ADR 0006) — host DAP requests.
+  - `cpu.SetAccessHook(func(addr, AccessKind))` — per-byte read/write/exec tracking for a memory heatmap (one nil-check per access; perfgate green).
+  - `RAM.Freeze(addr, value)` / `Unfreeze` — write-suppress for a debugger freeze (one `len` check on `Write`).
+  - `expr.HostVarResolver` (`Compile(src, syms, host…)`) + `Server.SetStopPredicate(func() bool)` — host identifiers in conditions (`scanline == 30`) and host step granularity (run-to-NMI / step-scanline) through the server's pause/ownership model.
+- **Consequences:** chippy stays a clean general 6502 library; nessy wires the NES semantics on top. All hooks nil-by-default; perfgate stays green.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,30 @@
+# Architecture Decision Records
+
+One ADR per chippy release, capturing the architectural decisions made in that
+version with their context and consequences. They're a reconstruction from the
+git history, PRs, and `docs/context.md` — the canonical "why we built it this
+way" log.
+
+Each entry uses a compact form: **Context** (the forces), **Decision** (what we
+chose), **Consequences** (what it bought / cost). Decisions that a later release
+reversed or refined are marked *Superseded by* with a link.
+
+## Index
+
+| ADR | Release | Date | Theme |
+|-----|---------|------|-------|
+| [0001](0001-v1.0.0.md) | v1.0.0 | 2026-05-13 | Foundation — 6502/65C02 core, TUI debugger, cc65 toolchain |
+| [0002](0002-v1.1.0.md) | v1.1.0 | 2026-05-15 | DAP server/client + attach; `VariantNES`; per-cycle bus ticker; monorepo |
+| [0003](0003-v1.1.1.md) | v1.1.1 | 2026-05-16 | Remote-debug hardening; server-owns-CPU ownership model |
+| [0004](0004-v1.2.0.md) | v1.2.0 | 2026-05-29 | Public 6502 library + semver; per-cycle CPU↔PPU; nessy carve-out |
+| [0005](0005-v1.3.0.md) | v1.3.0 | 2026-06-04 | Debugger UX polish (epic #396) |
+| [0006](0006-v1.4.0.md) | v1.4.0 | 2026-06-04 | DAP custom-request extension point (for nessy) |
+| [0007](0007-v1.4.1.md) | v1.4.1 | 2026-06-04 | Remove VS Code extension (MS marketplace block) |
+| [0008](0008-v1.5.0.md) | v1.5.0 | 2026-06-11 | DAP onramp + complete CPU ROM coverage + host debug hooks (epics #402, #419) |
+
+## Conventions captured across releases
+
+- **One issue → `feat/<name>` branch → squash-merge `--delete-branch`.** Conventional Commits feed goreleaser changelog grouping.
+- **Quality gate (every PR):** `go build ./...`, `go test -race -count=1 ./...`, `golangci-lint run ./...`, perfgate, docs updated in the same PR.
+- **Releases:** bare `vX.Y.Z` tags → goreleaser (`.goreleaser.chippy.yml`); signed binaries + Homebrew/AUR/deb/rpm/apk + SBOMs.
+- **GPL test ROMs are never vendored** — downloaded on demand + sha256-pinned (or ca65-ported from source).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,6 +60,7 @@ nav:
       - Editor matrix: editors.md
   - Internals:
       - Architecture (context dump): context.md
+      - Decision records (ADRs): adr/README.md
   - Mascot:
       - mascot-prompts.md
   - Playground: https://nkane.dev/chippy/playground/


### PR DESCRIPTION
Adds `docs/adr/` — an Architecture Decision Record per chippy release, plus the convention that future PRs/releases keep them current.

## Summary

Reconstructs chippy's decision history from git, PRs, and `docs/context.md` into one ADR per version (v1.0.0 → v1.5.0), and bakes "write the ADR" into the workflow.

## Changes

- `docs/adr/README.md` — index (8 releases) + the compact Context / Decision / Consequences format.
- `docs/adr/0001-v1.0.0.md` … `0008-v1.5.0.md` — one per release: foundation (variant dispatch, bus chain, reverse-step, trace), DAP + `VariantNES` + bus-ticker, remote-debug ownership model, public library + per-cycle accuracy + nessy carve-out, debugger UX polish, the custom-request seam, the VS Code removal, and the v1.5.0 DAP onramp + CPU ROM coverage + host hooks. Cross-linked where a later release refined a decision.
- `mkdocs.yml` — ADRs under Internals.
- `CLAUDE.md` — ADRs are now part of the doc bar: add/update one in any PR embedding an architectural decision, and always create the release ADR when cutting a tag.

## Testing

- `mkdocs build --strict` exits 0 (the not-in-nav notice for the per-file ADRs is INFO, same as the existing `docs/plans/`).

## Notes

- The `github-pr-issue` skill (user-global) gained a general "ADR where it makes sense + always per release" rule to match.
- `docs:` PR — excluded from the goreleaser changelog by design.
EOF