### PR TITLE
fix(release): migrate goreleaser brews → homebrew_casks (#413)

### DIFF
--- a/.goreleaser.chippy.yml
+++ b/.goreleaser.chippy.yml
@@ -159,8 +159,14 @@ aurs:
     commit_msg_template: "aur: bump chippy-bin to {{ .Tag }}"
     skip_upload: auto
 
-brews:
+# Homebrew distribution. goreleaser deprecated `brews:` (formulae) in favour
+# of `homebrew_casks:` (#413) — Homebrew now expects casks for pre-built
+# binaries. The cask carries a post-install hook that clears the macOS
+# quarantine xattr: the binary is cosign-signed but not Apple-notarized, so
+# Gatekeeper would otherwise quarantine it on first launch.
+homebrew_casks:
   - name: chippy
+    binaries: [chippy]
     repository:
       owner: nkane
       name: homebrew-tap
@@ -168,16 +174,17 @@ brews:
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     homepage: "https://github.com/nkane/chippy"
     description: "TUI 6502 emulator + ca65/cc65 source-level debugger"
-    license: "MIT"
     commit_author:
       name: goreleaserbot
       email: bot@goreleaser.com
     commit_msg_template: "brew: bump {{ .ProjectName }} to {{ .Tag }}"
-    directory: Formula
-    test: |
-      system "#{bin}/chippy", "--help"
-    install: |
-      bin.install "chippy"
+    directory: Casks
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/chippy"]
+          end
 
 release:
   github:
@@ -195,7 +202,7 @@ release:
     **Install via Homebrew**
     ```
     brew tap nkane/tap
-    brew install chippy
+    brew install --cask chippy
     ```
 
     **Or download a binary** from the assets below and drop it on your `$PATH`.

--- a/README.md
+++ b/README.md
@@ -59,11 +59,11 @@ Compared to:
 
 ## Install
 
-### Homebrew (macOS / Linux)
+### Homebrew (macOS)
 
 ```sh
 brew tap nkane/tap
-brew install chippy
+brew install --cask chippy
 ```
 
 ### Debian / Ubuntu

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -18,7 +18,7 @@ The release workflow:
 1. Runs goreleaser via `.goreleaser.chippy.yml`.
 2. Builds linux/darwin/windows × amd64/arm64 binaries (CGO off — pure Go chippy core).
 3. Generates SPDX SBOMs via syft + cosign-signs every artifact via keyless OIDC.
-4. Pushes Homebrew formula, AUR PKGBUILD, .deb / .rpm / .apk packages.
+4. Pushes Homebrew cask, AUR PKGBUILD, .deb / .rpm / .apk packages.
 
 Verify a chippy artifact:
 ```sh

--- a/docs/context.md
+++ b/docs/context.md
@@ -423,8 +423,8 @@ chippy -rom <file> [-addr 0x8000] [-reset 0xADDR] [-cfg linker.cfg] [-dbg syms.d
 - `.gitignore` — ignores `*.bin/*.o/*.dbg/*.prg/*.hex/*.lst/*.map`
 - `.github/workflows/ci.yml` — 3-OS test matrix + lint + Codecov + `klaus` job (ubuntu-only)
 - `.github/workflows/release.yml` — goreleaser on tag push
-- `.goreleaser.yml` — multi-arch binaries + brew formula publish
-- `nkane/homebrew-tap` repo — `Formula/chippy.rb` auto-updated by goreleaser
+- `.goreleaser.yml` — multi-arch binaries + brew cask publish
+- `nkane/homebrew-tap` repo — `Casks/chippy.rb` auto-updated by goreleaser (migrated formula→cask in #413; goreleaser deprecated `brews:` for pre-built binaries)
 
 ---
 


### PR DESCRIPTION
## Summary

goreleaser deprecated `brews:` (Homebrew formulae) for pre-built binaries in favour of `homebrew_casks:`. This migrates the chippy tap publish.

## Changes

- `brews:` → `homebrew_casks:` with `binaries: [chippy]`, `directory: Casks`
- Dropped `license:` / `test:` (not cask fields)
- Post-install hook clears the macOS quarantine xattr (`xattr -dr com.apple.quarantine`) — the binary is cosign-signed but not Apple-notarized, so Gatekeeper would quarantine it on first launch otherwise
- Release footer + README install command: `brew install chippy` → `brew install --cask chippy`
- README Homebrew section is now macOS-only — Linuxbrew has no cask support; Linux remains covered by the .deb/.rpm/.apk packages and AUR
- `docs/RELEASE.md` + `docs/context.md` notes updated (Formula → Casks)

## Validation

`goreleaser check -f .goreleaser.chippy.yml` passes clean (no deprecation warnings).

Closes #413