### PR TITLE
fix(cpu): port Mesen needDummyRead cycle into ProcessPendingDma

### DIFF
--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -177,6 +177,12 @@ type CPU struct {
 	spriteDmaOffset   byte
 	dmcDmaRunning     bool
 	abortDmcDma       bool
+	// needDummyRead — the extra dummy-read cycle a DMC DMA performs
+	//   between the halt cycle and the actual sample read (Mesen
+	//   NesCpu::StartDmcTransfer sets it alongside needHalt). Without it
+	//   the DMC read (and bytesRemaining decrement) lands one cycle too
+	//   early, mis-timing dmc_dma_during_read* (#20-nessy).
+	needDummyRead bool
 
 	// dmcFetcher is the APU-side hook ProcessPendingDma calls to
 	// look up the DMC's current read address + push the fetched
@@ -221,6 +227,7 @@ func (c *CPU) SetNeedSpriteDma(page byte) {
 // APU.SetDmcReadBuffer.
 func (c *CPU) SetNeedDmcDma() {
 	c.dmcDmaRunning = true
+	c.needDummyRead = true
 	c.needHalt = true
 }
 

--- a/cpu/dma.go
+++ b/cpu/dma.go
@@ -55,8 +55,9 @@ func (c *CPU) ProcessPendingDma(readAddress uint16) {
 		getCycle := c.Cycles&1 == 0
 		if getCycle {
 			switch {
-			case c.dmcDmaRunning && !c.needHalt:
-				// DMC sample read.
+			case c.dmcDmaRunning && !c.needHalt && !c.needDummyRead:
+				// DMC sample read — only after BOTH the halt cycle and the
+				// extra dummy-read cycle have run (Mesen ordering).
 				c.dmaProcessCycle()
 				addr := uint16(0)
 				if c.dmcFetcher != nil {
@@ -122,9 +123,12 @@ func (c *CPU) dmaProcessCycle() {
 	case c.abortDmcDma:
 		c.dmcDmaRunning = false
 		c.abortDmcDma = false
+		c.needDummyRead = false
 		c.needHalt = false
 	case c.needHalt:
 		c.needHalt = false
+	case c.needDummyRead:
+		c.needDummyRead = false
 	}
 	c.dmaStartCycle()
 }

--- a/docs/context.md
+++ b/docs/context.md
@@ -15,7 +15,18 @@
   - Theme D (headline): #456 65816 variant (16-bit, emu/native), #462 65816 native-mode completeness + full Tom Harte 65816 (depends on #456), #457 hosted WASM playground (Pages).
   - Theme E (freeze): #463 MMIO/cart-bus freeze beyond RAM (extends #422, RAM-scoped in v1.6).
 - **Suggested opener:** #449 (smallest, unblocks rest of Theme A). Theme A now ends *inside* v1.7 with the #461 default-flip + dead-path delete (no separate v2.0 milestone for it).
-- **0 open issues outside the v1.7 set.** `main` clean at the v1.6.0 prep merge.
+- **DMC-DMA accuracy (nessy #20 spillover):** #480 ported Mesen's missing
+  `needDummyRead` cycle into `ProcessPendingDma` (halt → **dummy read** →
+  DMC read; the read & `bytesRemaining` decrement were landing one cycle
+  early). Non-regressing (cpu_interrupts_v2 5/5 + apu_test 8/8 verified via
+  nessy `go.mod replace`). #481 (epic) tracks the rest of the
+  `dmc_dma_during_read4` fix: the DMA-during-internal-register-read glitch
+  (`ProcessDmaRead`) needs a CPU-side open-bus model + internal/external
+  bus split + `$4016/$4017` bit-deletion that chippy doesn't have yet — an
+  architectural addition, not a port, and convergence needs a MesenCE
+  cycle-by-cycle reference run.
+- **2 open issues outside the v1.7 set** (#480 done-pending-merge, #481 epic).
+  `main` clean at the v1.6.0 prep merge.
 - **ADRs current** through v1.6.0 (0001–0009); v1.7 will be `0010-v1.7.0.md`. Pre-1.0 0.x tags fold into ADR 0001.
 
 ---


### PR DESCRIPTION
## What

Port Mesen's missing `_needDummyRead` cycle into `cpu/dma.go`'s `ProcessPendingDma`.

## Why

The `ProcessPendingDma` port (#377) omitted the extra dummy-read cycle a DMC DMA performs between the halt cycle and the sample read. Mesen's `NesCpu::StartDmcTransfer` sets `dmcDmaRunning + needDummyRead + needHalt`, so a DMC DMA runs **halt → dummy read → align → DMC read**. chippy ran **halt → align → DMC read** (one cycle short), landing the DMC sample read — and the APU's `bytesRemaining` decrement — one CPU cycle too early.

## Change

- New `needDummyRead` flag, set in `SetNeedDmcDma`.
- DMC-read getCycle gated on `!needHalt && !needDummyRead`.
- Cleared after `needHalt` in `dmaProcessCycle`.

Mirrors Mesen `NesCpu.cpp` exactly.

## Verification

- `go test ./cpu/` green.
- Non-regressing against nessy's accuracy suite (via `go.mod replace`): `cpu_interrupts_v2` 5/5, `apu_test` 8/8, `ppu_vbl_nmi`, `instr_timing`, `mmc3_test` all pass.

Prerequisite for the `dmc_dma_during_read*` family (nessy #20). The remaining piece — the DMA-during-internal-register-read glitch (`ProcessDmaRead`) — needs a CPU-side open-bus model and is tracked in #481.

Closes #480
