### PR TITLE
docs: finalize ADR 0010 + release markers for v1.7.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ Go-based TUI 6502 emulator + debugger (Bubble Tea, Lipgloss). Targets ca65/cc65 
 - Squash-merge with `--delete-branch`. Defer follow-ups by filing new issues.
 
 ## Release tag scheme
-- chippy ships under bare `vX.Y.Z` tags. Goreleaser via `.goreleaser.chippy.yml` (last released: `v1.6.0` — accuracy tail + debugger UX cleanup, epic #438: 238/238 6502 bus-exact, 65C02 Tom Harte, struct overlay watch, DAP array children, chippy-state dirtyRanges, goreleaser cask. v1.5.0 — DAP onramp + complete CPU ROM coverage, epic #402; host debug hooks, epic #419. nessy carved out into [github.com/nkane/nessy](https://github.com/nkane/nessy) post-v1.2.0; VS Code extension removed v1.4.1).
+- chippy ships under bare `vX.Y.Z` tags. Goreleaser via `.goreleaser.chippy.yml` (last released: `v1.7.0` — epic #458: full Tom Harte-validated WDC 65C816 core (#456, 256 opcodes, emulation + native), TUI-via-DAP render+control flip (#461/#471), freeze beyond RAM (#463), DAP data breakpoints + setVariable (#453/#454), 65C02 per-cycle bus trace (#455/#475), hosted WASM playground (#457). v1.6.0 — accuracy tail + debugger UX cleanup, epic #438: 238/238 6502 bus-exact, 65C02 Tom Harte, struct overlay watch, DAP array children, chippy-state dirtyRanges, goreleaser cask. v1.5.0 — DAP onramp + complete CPU ROM coverage, epic #402; host debug hooks, epic #419. nessy carved out into [github.com/nkane/nessy](https://github.com/nkane/nessy) post-v1.2.0; VS Code extension removed v1.4.1).
 - Full process in [`docs/RELEASE.md`](docs/RELEASE.md).
 - **Every release gets an ADR.** Cutting a tag includes adding `docs/adr/NNNN-vX.Y.Z.md` (next sequence number) capturing that release's decisions, and a row in `docs/adr/README.md`. The tag does not go out without it.
 

--- a/docs/adr/0010-v1.7.0.md
+++ b/docs/adr/0010-v1.7.0.md
@@ -1,11 +1,12 @@
 # ADR 0010 — v1.7.0: TUI-via-DAP flip, freeze-beyond-RAM, and the full 65816 core
 
-- **Status:** Draft (release pending — finalized when `v1.7.0` is tagged)
-- **Release:** v1.7.0 (epic #458)
+- **Status:** Accepted
+- **Release:** v1.7.0 (2026-06-25; epic #458)
 - **Theme:** Finish the TUI-via-DAP migration, extend the debugger facilities (data breakpoints, freeze beyond RAM), ship the WASM playground, and land the headline feature — a complete, Tom Harte-validated WDC 65C816 core (#456).
 
-This ADR will gather the rest of the v1.7.0 decisions at release; for now it
-captures the 65816 core, whose decisions are the most load-bearing.
+D1–D7 cover the 65816 core (the headline, and the most load-bearing
+decisions); D8–D11 cover the debugger/TUI and packaging work that rounds out
+the release.
 
 ## D1 — A second execution core (`step816`), not an opcode-table variant
 
@@ -48,3 +49,27 @@ captures the 65816 core, whose decisions are the most load-bearing.
 - **Context:** the 65816 immediate length depends on the live M/X state (LDA # is 2 or 3 bytes).
 - **Decision:** a dedicated `Disasm816` with its own 256-entry mnemonic/mode table reads the CPU's current M/X/E to size immediates and renders the new syntaxes (long `$123456`, `[dp]`, `sr,S`, `MVN src,dst`). `DisasmCPU` dispatches to it for the 65816 variant.
 - **Consequences:** the disassembly length matches what `step816` consumes; the TUI disassembly panel renders 65816 programs correctly in bank 0.
+
+## D8 — Complete the TUI-via-DAP flip: panels render and control flow through DAP (#461, #471)
+
+- **Context:** the TUI historically read `cpu.CPU`/`RAM` directly; the migration to source every panel from DAP snapshots (so the local and remote debug paths share one rendering/control surface) was the last v1.7 architecture item.
+- **Decision:** (1) **render path** (#461) — all five panels (registers, flags, stack, memory, disassembly) plus navigation read DAP-sourced snapshots; zero direct `cpu`/`RAM` access remains in render/nav. (2) **control path** (#471) — run/step/breakpoint/watchpoint enforcement is server-owned via a **synchronous** `Server.RunBudget(maxSteps, step, stopAt)` (chosen over an async continue so the local engine stays deterministic and re-entrant from the TUI's `Update` loop). The rich TUI rewind is kept as the documented local-engine exception; single-step and memory-edit stay direct (low value to route through DAP).
+- **Consequences:** the local TUI and a remote DAP client render and drive execution through the same protocol surface; the flip is `internal/`-only, so the public Go API stays additive and v1.7.0 remains a minor bump.
+
+## D9 — Freeze beyond RAM: bus-level write-suppress (#463)
+
+- **Context:** the debugger freeze facility (`RAM.Freeze`, #422) was RAM-only, but a CPU write to a peripheral/cart-mapped address never reaches RAM (MMIO intercepts it), so RAM-level freeze couldn't hold those values.
+- **Decision:** `MMIO.Freeze`/`Unfreeze`/`Frozen`/`FrozenAddrs` move the guard into `MMIO.Write` (a single length check that suppresses frozen addresses); `Freeze` writes the value through once then adds it to the set, so it works for peripheral- and RAM-mapped addresses alike. `RAM.Freeze` stays for direct-RAM contexts.
+- **Consequences:** hosts (nessy) can freeze peripheral/cart values; zero hot-path cost when nothing is frozen (perfgate green).
+
+## D10 — DAP data breakpoints + setVariable parity (#453, #454)
+
+- **Context:** the DAP surface lacked watchpoint and write-back parity with the editor protocol.
+- **Decision:** `setDataBreakpoints`/`dataBreakpointInfo` expose memory watchpoints; `setVariable` writes Globals scalars and array children.
+- **Consequences:** editors get full watchpoint + variable-edit support against the same engine the TUI uses.
+
+## D11 — Hosted WASM playground (#457)
+
+- **Context:** chippy already built a WASM target and a `web/` playground deployed to GitHub Pages.
+- **Decision:** finish the last UX item — drag-and-drop a `.bin`/`.prg`/`.hex` onto the page wired to the existing `loadUserFile` path.
+- **Consequences:** a zero-install in-browser chippy at nkane.dev/chippy; `.dbg` symbol drag-drop deferred (the wasm `load()` API doesn't expose symbol loading yet).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,7 +22,7 @@ reversed or refined are marked *Superseded by* with a link.
 | [0007](0007-v1.4.1.md) | v1.4.1 | 2026-06-04 | Remove VS Code extension (MS marketplace block) |
 | [0008](0008-v1.5.0.md) | v1.5.0 | 2026-06-11 | DAP onramp + complete CPU ROM coverage + host debug hooks (epics #402, #419) |
 | [0009](0009-v1.6.0.md) | v1.6.0 | 2026-06-16 | Accuracy tail (238/238 6502 bus-exact, 65C02 Tom Harte) + debugger UX (struct overlay, DAP array children, dirtyRanges) (epic #438) |
-| [0010](0010-v1.7.0.md) | v1.7.0 | _draft_ | TUI-via-DAP flip + freeze-beyond-RAM + WASM playground + full Tom Harte-validated 65816 core (epic #458) |
+| [0010](0010-v1.7.0.md) | v1.7.0 | 2026-06-25 | TUI-via-DAP flip + freeze-beyond-RAM + WASM playground + full Tom Harte-validated 65816 core (epic #458) |
 
 ## Conventions captured across releases
 

--- a/docs/context.md
+++ b/docs/context.md
@@ -8,7 +8,7 @@
 ## 0. Where we are right now (session handoff)
 
 - **v1.6.0 shipped** 2026-06-16 (tag `v1.6.0`, GitHub release + Homebrew **cask** live, ADR `0009-v1.6.0.md`). Closed epic #438: ARR decimal (#424), 238/238 6502 bus-exact (#428), 65C02 Tom Harte + 5 CMOS fixes (#426), struct overlay watch (#409), DAP array children (#410), chippy-state dirtyRanges (#440), goreleaser cask (#413).
-- **v1.7.0 planned** — epic **#458** + 12 sub-issues filed (all labelled `v1.7`). The former "deferred to v2.0" set was pulled in (2026-06-16): #461 TUI flip, #462 65816 native, #463 freeze beyond RAM. Stays **v1.7.0** (minor) — the TUI flip is `internal/`-only, so the public Go API is additive.
+- **v1.7.0 shipped** 2026-06-25 (tag `v1.7.0`, ADR `0010-v1.7.0.md`). Closed epic #458 + all sub-issues: full Tom Harte-validated WDC 65C816 core (#456, 256 opcodes emulation + native; #462 native folded in), TUI-via-DAP render+control flip (#449–452, #461, #471), freeze beyond RAM (#463), DAP data breakpoints + setVariable (#453, #454), 65C02 per-cycle bus trace (#455, #475), hosted WASM playground drag-drop (#457). Minor bump — TUI flip is `internal/`-only so the public Go API stayed additive.
   - Theme A (TUI-via-DAP migration + default flip, the v2.0 arc): #449 stack→`stackTrace`, #450 flags→`variables`, #451 memory→`readMemory`+dirtyRanges, #452 disasm→`disassemble`, then #461 flip default to DAP-only + delete the dead direct-render path (depends on #449–#452).
   - Theme B (DAP parity): #453 data breakpoints (`setDataBreakpoints`/`dataBreakpointInfo`, expose TUI mem-watch), #454 `setVariable` on memory + Globals array children.
   - Theme C (accuracy): #455 `TestHarte65C02BusTrace` (CMOS per-cycle bus-exactness, mirror #428).


### PR DESCRIPTION
Release-prep for **v1.7.0** (per `docs/RELEASE.md` — the tag doesn't go out without its ADR).

- ADR `0010-v1.7.0.md`: Status → **Accepted** (2026-06-25); completed with D8–D11 (TUI-via-DAP render+control flip, freeze beyond RAM, DAP data breakpoints + setVariable, hosted WASM playground) alongside the 65816 decisions D1–D7.
- ADR index dated; `CLAUDE.md` release marker → v1.7.0; `docs/context.md` handoff records v1.7.0 shipped.

Docs only. Merge, then tag `v1.7.0` on main.