### PR TITLE
docs(adr): 0011 — DmaReadBus seam for 2A03 DMA-read open-bus (#481)

### DIFF
--- a/docs/adr/0011-v1.8.0.md
+++ b/docs/adr/0011-v1.8.0.md
@@ -1,0 +1,43 @@
+# ADR 0011 — v1.8.0 (in progress): accuracy tail — 2A03 DMA-read open-bus seam
+
+- **Status:** Proposed
+- **Release:** v1.8.0 (unreleased; in progress)
+- **Theme:** The post-v1.7.0 accuracy tail. This ADR is opened by the first
+  decision of the cycle and grows as the release lands; per-release decisions
+  fold in here rather than spawning topic ADRs.
+
+## D1 — Tagged DMA reads (`DmaReadBus`) for the 2A03 DMA-read open-bus glitch (#481)
+
+- **Context:** The DMC-DMA-during-internal-register-read glitch
+  (`dmc_dma_during_read4`, nessy #20) only manifests when a DMC sample fetch
+  lands on an internal register `$4000-$401F`. Those reads are invisible to
+  external chips, so the 2A03 latches an open-bus / internal-register **bus
+  conflict** instead of a real value, and `$4016/$4017` fetches delete a
+  controller bit. chippy's DMA loop (`ProcessPendingDma`, #376) issued bare,
+  untagged `Bus.Read(addr)` calls, so the host (nessy) could not tell a DMC
+  sample fetch from an ordinary CPU read and could not apply the DMA-specific
+  semantics. An earlier "minimal `$4015` read" attempt failed for exactly this
+  reason — no DMA context on the read. Open-bus state itself is **host-owned**:
+  nessy already sees every external read/write and can latch the last bus value
+  without any CPU help.
+- **Decision:** Add an optional `DmaReadBus` Bus extension —
+  `ReadDma(addr uint16, kind DmaKind) byte` — with a `DmaKind` tag
+  (`DmaDummyRead` / `DmaSpriteRead` / `DmaDmcRead`). When `c.Bus` implements it,
+  `ProcessPendingDma` routes its reads through `ReadDma`; otherwise it falls
+  back to `Bus.Read`, byte-for-byte identical to today. The assertion is cached
+  at `SetBus` (a `dmaBus` field, mirroring the existing `busTicker` cache) so
+  the 256-read sprite loop pays no per-read type-assert. The CPU contributes
+  **only the tag** — no open-bus latch, mask, or `prevReadValue` moves into
+  `cpu.CPU`; the host owns all of it. The exact conflict formula
+  (`GetOpenBusMask`, controller bit-deletion) is reconstructed and validated in
+  nessy against a MesenCE (`NesCpu::ProcessDmaRead`) cycle-by-cycle reference —
+  chippy cannot validate it, having no NES peripherals.
+- **Consequences:** Additive, minor-bump-safe public API; zero hot-path and
+  zero behavior change for non-NES variants and for hosts that don't implement
+  the interface. chippy ships the seam plus unit tests (a fake `DmaReadBus`
+  asserting each read's tag, and a plain-`Bus` fallback proving identical
+  behavior); full `dmc_dma_during_read4` convergence is a downstream nessy task
+  gated on the MesenCE reference. The seam follows chippy's established
+  host-hook pattern (`DMCFetcher`, `PPURunner`, the per-access hook) — the CPU
+  exposes a typed extension point and the consumer supplies the
+  platform-specific behavior.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -23,6 +23,7 @@ reversed or refined are marked *Superseded by* with a link.
 | [0008](0008-v1.5.0.md) | v1.5.0 | 2026-06-11 | DAP onramp + complete CPU ROM coverage + host debug hooks (epics #402, #419) |
 | [0009](0009-v1.6.0.md) | v1.6.0 | 2026-06-16 | Accuracy tail (238/238 6502 bus-exact, 65C02 Tom Harte) + debugger UX (struct overlay, DAP array children, dirtyRanges) (epic #438) |
 | [0010](0010-v1.7.0.md) | v1.7.0 | 2026-06-25 | TUI-via-DAP flip + freeze-beyond-RAM + WASM playground + full Tom Harte-validated 65816 core (epic #458) |
+| [0011](0011-v1.8.0.md) | v1.8.0 | unreleased | Accuracy tail — 2A03 DMA-read open-bus seam (`DmaReadBus`, #481) |
 
 ## Conventions captured across releases
 


### PR DESCRIPTION
Opens the v1.8.0 ADR with D1: the `DmaReadBus` extension that tags DMA reads so a host (nessy) can model the 2A03 DMA-read open-bus / internal-register conflict (`dmc_dma_during_read4`).

Design summary:
- New optional `DmaReadBus{ ReadDma(addr, DmaKind) }` extension; `ProcessPendingDma` routes through it when implemented, else falls back to `Bus.Read` (identical behavior).
- CPU contributes only the tag — open-bus latch stays host-owned. No new CPU state.
- chippy ships the seam + unit tests; full glitch convergence is a downstream nessy task gated on a MesenCE reference.

ADR-only PR; the seam implementation follows.

Refs #481