### PR TITLE
fix(cpu): idle() polls ProcessPendingDma so a DMA halt drains on dummy-read cycles (#493)

### DIFF
--- a/cpu/cpu.go
+++ b/cpu/cpu.go
@@ -497,6 +497,16 @@ func (c *CPU) write(addr uint16, v byte) {
 // as a real read.
 func (c *CPU) idle(addr uint16) {
 	if c.nesCycle {
+		// A pending DMA halt drains before this cycle's bus access, same
+		// as busRead — Mesen polls ProcessPendingDma on every CPU cycle,
+		// including dummy/idle reads. Without this, a halt armed going
+		// into an idle cycle (e.g. a taken branch's dummy read) is missed
+		// here and only drained at the next real read — landing the DMC
+		// steal one cycle late (wrong get/put parity → 3-cycle steal where
+		// hardware/Mesen take 4). Broke dma_2007_read's phase drift (#493).
+		if c.needHalt {
+			c.ProcessPendingDma(addr)
+		}
 		c.instrCycles++
 		c.masterClock += cpuStartReadShift
 		if c.ppuRunner != nil {

--- a/cpu/dma_test.go
+++ b/cpu/dma_test.go
@@ -169,6 +169,49 @@ func TestProcessPendingDma_StealParityUsesInstrCycles(t *testing.T) {
 	}
 }
 
+// tickerDmaBus is a recDmaBus that also implements Ticker, so NewVariant
+// sets busTicker → nesCycle is true and the per-cycle interleave path
+// (idle / busRead) runs — needed to exercise idle()'s DMA-halt poll.
+type tickerDmaBus struct {
+	recDmaBus
+	ticks int
+}
+
+func (b *tickerDmaBus) Tick(n int) { b.ticks += n }
+
+// idle() must drain a pending DMA halt on its own cycle, exactly like
+// busRead — the 2A03 (and Mesen) poll ProcessPendingDma on every CPU
+// cycle, including dummy/idle reads such as a taken branch's dummy read
+// (branch() → c.idle(c.PC)). Regression for #493: without the poll, a
+// halt armed going into an idle cycle was missed and only drained at the
+// next real read, landing the DMC steal one cycle late (3-cycle steal vs
+// the hardware 4) and freezing dma_2007_read's phase drift so its
+// calibration loop never converged.
+func TestIdle_DrainsPendingDmaHalt(t *testing.T) {
+	bus := &tickerDmaBus{}
+	bus.ram[0x9000] = 0x42
+
+	c := NewVariant(bus, VariantNES)
+	if !c.nesCycle {
+		t.Fatal("nesCycle not set — test bus must implement Ticker")
+	}
+	c.SetDMCFetcher(&fakeDmc{addr: 0x9000})
+	c.SetNeedDmcDma()
+
+	// Drive a single idle (dummy-read) cycle with the halt armed.
+	c.idle(0x8000)
+
+	if c.needHalt {
+		t.Error("idle() left needHalt set — DMA was not drained on the idle cycle")
+	}
+	if c.dmcDmaRunning {
+		t.Error("idle() left dmcDmaRunning set — DMA was not drained")
+	}
+	if bus.count(DmaDmcRead) == 0 {
+		t.Errorf("idle() did not issue the DMC sample read; reads=%+v", bus.reads)
+	}
+}
+
 // A bus that does NOT implement DmaReadBus takes the plain Bus.Read
 // fallback: same routed sample, same cycle count — byte-for-byte the
 // pre-#481 behavior.


### PR DESCRIPTION
## Summary

`busRead` drains a pending DMA halt at its top; `idle()` — used for dummy/internal cycles, including a taken branch's dummy read (`branch()` → `c.idle(c.PC)`) — did not. The 2A03 (and Mesen) poll `ProcessPendingDma` on **every** CPU cycle, so a DMC halt armed going into an idle cycle is missed in chippy and only drained at the next real read. The steal then lands one CPU cycle late, on the wrong get/put parity, taking **3 cycles where hardware takes 4**.

In `dmc_dma_during_read4` / `dma_2007_read` that 1-cycle error pins the calibration loop's period to the DMC sample period (zero phase drift), so the loop never converges (nessy #20).

## Root cause (from-boot diff vs MesenCE)

A per-instruction `(PC, cycle)` trace from boot, chippy vs a headless MesenCE reference, are **bit-identical for 62,741 instructions**, then diverge at exactly one steal:

```
chippy: halt $E062 (branch target)     cyc even  -> steal 3
mesen : halt $E078 (branch dummy read) cyc odd   -> steal 4
```

So this is a **local halt-poll-point bug**, not a cumulative cycle-parity offset.

## Fix

`idle()` polls `ProcessPendingDma` when `needHalt` is set, mirroring `busRead`. Gated by `c.nesCycle` (VariantNES + bus ticker) and `needHalt`.

## Blast radius

Structurally limited to the NES DMA-halt path. Non-NES variants have `nesCycle == false`, so Harte (6502 + bus trace, wdc65c02), Klaus, Klaus-interrupt, and cpu_interrupts are untouched.

## Tests / validation

- New `TestIdle_DrainsPendingDmaHalt` — pins that `idle()` drains a halt on its own cycle (fails without the fix).
- Full `cpu` suite green (`-count=1`): Harte 6502 + bus trace, wdc65c02, Klaus, cpu_interrupts.
- Downstream: `dma_2007_read` escapes the calibration loop and reaches the same terminal state as MesenCE; nessy full unit + accuracy suites green.

Closes #493.